### PR TITLE
[TYPO] Fix bad plugin hub link

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Visit https://steampipe.io/docs for full documentation on everything Steampipe.
 
 ## Plugins
 
-Looking for plugins? Checkout [The Steampipe Hub](https://hubs.teampipe.io/) to browse available plugins and schema docs.
+Looking for plugins? Checkout [The Steampipe Hub](https://hub.steampipe.io/) to browse available plugins and schema docs.
 
 ## Community
 


### PR DESCRIPTION
Simple typo fix that can affect people's perception of the quality of the project. 