### PR TITLE
Add link to online help docs from the CLI. Closes #92

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,10 +41,11 @@ Getting started:
   steampipe plugin install azure
 
   # Get help for a command
-  steampipe help query`,
-}
+  steampipe help query
 
-//var viper *v.Viper
+For more information, refer to https://www.steampipe.io
+ `,
+}
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,7 +43,7 @@ Getting started:
   # Get help for a command
   steampipe help query
 
-For more information, refer to https://www.steampipe.io
+  Documentation available at https://steampipe.io/docs
  `,
 }
 

--- a/metaquery/handlers.go
+++ b/metaquery/handlers.go
@@ -101,10 +101,10 @@ func doHelp(input *HandlerInput) error {
 	}
 	advanceCmdRows := getMetaQueryHelpRows(advanceCmds, true)
 	// print out
-	fmt.Printf("Welcome to Steampipe shell.\n\nTo start, simply enter your SQL query at the prompt:\n\n  select * from aws_iam_user\n\nCommon commands:\n\n%s\n\nAdvanced commands:\n\n%s\n\nFor more information, refer to %s\n",
+	fmt.Printf("Welcome to Steampipe shell.\n\nTo start, simply enter your SQL query at the prompt:\n\n  select * from aws_iam_user\n\nCommon commands:\n\n%s\n\nAdvanced commands:\n\n%s\n\nDocumentation available at %s\n",
 		buildTable(commonCmdRows, true),
 		buildTable(advanceCmdRows, true),
-		constants.Bold("https://www.steampipe.io"))
+		constants.Bold("https://steampipe.io/docs"))
 	fmt.Println()
 	return nil
 }

--- a/metaquery/handlers.go
+++ b/metaquery/handlers.go
@@ -101,9 +101,11 @@ func doHelp(input *HandlerInput) error {
 	}
 	advanceCmdRows := getMetaQueryHelpRows(advanceCmds, true)
 	// print out
-	fmt.Printf("Welcome to Steampipe shell.\n\nTo start, simply enter your SQL query at the prompt:\n\n  select * from aws_iam_user\n\nCommon commands:\n\n%s\n\nAdvanced commands:\n\n%s\n",
+	fmt.Printf("Welcome to Steampipe shell.\n\nTo start, simply enter your SQL query at the prompt:\n\n  select * from aws_iam_user\n\nCommon commands:\n\n%s\n\nAdvanced commands:\n\n%s\n\nFor more information, refer to %s\n",
 		buildTable(commonCmdRows, true),
-		buildTable(advanceCmdRows, true))
+		buildTable(advanceCmdRows, true),
+		constants.Bold("https://www.steampipe.io"))
+	fmt.Println()
 	return nil
 }
 


### PR DESCRIPTION
`steampipe help`

![Screenshot 2021-02-02 at 2 21 40 PM](https://user-images.githubusercontent.com/1114038/106575613-498b5300-6562-11eb-8dff-90b09c4f4ee5.png)

`.help`

![Screenshot 2021-02-02 at 2 21 13 PM](https://user-images.githubusercontent.com/1114038/106575649-5314bb00-6562-11eb-8803-5e96f493b1e2.png)
