### PR TITLE
utility sql functions. Closes #134

### DIFF
--- a/constants/db.go
+++ b/constants/db.go
@@ -31,7 +31,7 @@ const (
 )
 
 // FunctionSchema :: schema container for all steampipe helper functions
-const FunctionSchema = "functions"
+const FunctionSchema = "internal"
 
 // Functions is a map of `SQLFunc`s that are synced to the db service during startup
 var Functions = []schema.SQLFunc{

--- a/constants/db.go
+++ b/constants/db.go
@@ -33,7 +33,7 @@ const (
 // FunctionSchema :: schema container for all steampipe helper functions
 const FunctionSchema = "internal"
 
-// Functions is a map of `SQLFunc`s that are synced to the db service during startup
+// Functions :: a list of SQLFunc objects that are installed in the db 'internal' schema startup
 var Functions = []schema.SQLFunc{
 	{
 		Name:     "glob",

--- a/constants/db.go
+++ b/constants/db.go
@@ -1,5 +1,7 @@
 package constants
 
+import "github.com/turbot/steampipe/schema"
+
 // dbClient constants
 // TODO these should be configuration settings
 
@@ -27,3 +29,25 @@ const (
 	DefaultEmbeddedPostgresImage = "us-docker.pkg.dev/steampipe/steampipe/db:12.1.0-v2"
 	DefaultFdwImage              = "us-docker.pkg.dev/steampipe/steampipe/fdw:" + FdwVersion
 )
+
+// FunctionSchema :: schema container for all steampipe helper functions
+const FunctionSchema = "functions"
+
+// Functions is a map of `SQLFunc`s that are synced to the db service during startup
+var Functions = []schema.SQLFunc{
+	{
+		Name:     "glob",
+		Params:   map[string]string{"input_glob": "text"},
+		Returns:  "text",
+		Language: "plpgsql",
+		Body: `
+declare
+	output_pattern text;
+begin
+	output_pattern = replace(input_glob, '*', '%');
+	output_pattern = replace(output_pattern, '?', '_');
+	return output_pattern;
+end;
+`,
+	},
+}

--- a/db/client.go
+++ b/db/client.go
@@ -160,13 +160,16 @@ func (c *Client) setSearchPath() {
 		sort.Strings(schemas)
 		// set this before the `public` schema gets added
 		c.schemaMetadata.SearchPath = schemas
-		// Add the public schema as the first schema in the search_path. This makes it
+		// add the public schema as the first schema in the search_path. This makes it
 		// easier for users to build and work with their own tables, and since it's normally
 		// empty, doesn't make using steampipe tables any more difficult.
 		schemas = append([]string{"public"}, schemas...)
+		// add 'internal' schema as last schema in the search path
+		schemas = append(schemas, constants.FunctionSchema)
+
 		log.Println("[TRACE] setting search path to", schemas)
-		sql := fmt.Sprintf("SET search_path TO %s;", strings.Join(schemas, ","))
-		c.ExecuteSync(sql)
+		query := fmt.Sprintf("SET search_path TO %s;", strings.Join(schemas, ","))
+		c.ExecuteSync(query)
 	}
 }
 

--- a/db/client.go
+++ b/db/client.go
@@ -52,6 +52,7 @@ func GetClient(autoRefreshConnections bool) (*Client, error) {
 
 		if autoRefreshConnections {
 			refreshConnections(clientSingleton)
+			refreshFunctions(clientSingleton)
 		}
 
 		// load the connection state and cache it!

--- a/db/functions.go
+++ b/db/functions.go
@@ -1,0 +1,98 @@
+package db
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/schema"
+)
+
+/**
+
+Query to get functions:
+SELECT
+    p.proname AS function_name
+FROM
+    pg_proc p
+    LEFT JOIN pg_namespace n ON p.pronamespace = n.oid
+WHERE
+    n.nspname = 'functionSchema'
+ORDER BY
+    function_name;
+
+**/
+
+func refreshFunctions(client *Client) error {
+	sql := []string{
+		fmt.Sprintf(`create schema if not exists %s;`, constants.FunctionSchema),
+		fmt.Sprintf(`grant usage on schema %s to steampipe_users;`, constants.FunctionSchema),
+	}
+	sql = append(sql, getFunctionAddStrings(constants.Functions)...)
+	if err := executeAddFunctionQuery(strings.Join(sql, ";")); err != nil {
+		// panic - this should never happen,
+		// since the function definitions are
+		// tightly bound to development
+		panic(err)
+	}
+	return nil
+}
+
+func getFunctionAddStrings(functions []schema.SQLFunc) []string {
+	addStrings := []string{}
+	for _, function := range functions {
+		addStrings = append(addStrings, getFunctionAddString(function))
+	}
+	return addStrings
+}
+
+func getFunctionAddString(function schema.SQLFunc) string {
+	if err := validateFunction(function); err != nil {
+		// panic - this should never happen,
+		// since the function definitions are
+		// tightly bound to development
+		panic(err)
+	}
+
+	inputParams := []string{}
+
+	for argName, argType := range function.Params {
+		inputParams = append(inputParams, fmt.Sprintf("%s %s", argName, argType))
+	}
+
+	return strings.TrimSpace(fmt.Sprintf(
+		`
+;create or replace function %s.%s (%s) returns %s language %s as
+$$
+%s
+$$;
+`,
+		constants.FunctionSchema,
+		function.Name,
+		strings.Join(inputParams, ","),
+		function.Returns,
+		function.Language,
+		strings.TrimSpace(function.Body),
+	))
+}
+
+func validateFunction(f schema.SQLFunc) error {
+	return nil
+}
+
+func executeAddFunctionQuery(functionQueryString string) error {
+	log.Println("[TRACE]", "executeAddFunctionQuery", "executing", functionQueryString)
+	client, err := createSteampipeRootDbClient()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		client.Close()
+	}()
+	_, err = client.Exec(functionQueryString)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/db/query.go
+++ b/db/query.go
@@ -42,6 +42,11 @@ func ExecuteQuery(queryString string) (*ResultStreamer, error) {
 		shutdown(client)
 		return nil, fmt.Errorf("failed to refresh connections: %v", err)
 	}
+	if err = refreshFunctions(client); err != nil {
+		// shutdown the service if something went wrong!!!
+		shutdown(client)
+		return nil, fmt.Errorf("failed to add functions: %v", err)
+	}
 
 	resultsStreamer := newQueryResults()
 

--- a/db/start.go
+++ b/db/start.go
@@ -209,6 +209,9 @@ func StartDB(port int, listen StartListenType, invoker Invoker) (StartResult, er
 		if err = refreshConnections(client); err != nil {
 			return ServiceStarted, err
 		}
+		if err = refreshFunctions(client); err != nil {
+			return ServiceStarted, err
+		}
 	}
 
 	return ServiceStarted, nil

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -10,7 +10,7 @@ import (
 type Metadata struct {
 	// map {schemaname, {map tablename -> tableschema}}
 	Schemas map[string]map[string]TableSchema
-	// the search path that is set in the backend - except `public`
+	// the search path that is set in the backend
 	SearchPath []string
 }
 

--- a/schema/sqlfunc.go
+++ b/schema/sqlfunc.go
@@ -1,0 +1,10 @@
+package schema
+
+// SQLFunc :: struct for an sqlFunc
+type SQLFunc struct {
+	Name     string
+	Params   map[string]string
+	Returns  string
+	Body     string
+	Language string
+}


### PR DESCRIPTION
creates `steampipe` functions in a `schema` called `functions`.

permissions are given to the `steampipe` user.

can be called using `select functions.glob('***')`

```
binaeksarkar@Binaeks-MacBook-Pro ~ % steampipe query                    
Welcome to Steampipe v0.1.1
For more information, type .help
> select functions.glob('%%%')
+------+
| glob |
+------+
| %%%  |
+------+
> select functions.glob('***')
+------+
| glob |
+------+
| %%%  |
+------+
> 
```