### PR TITLE
`plugin update` and `plugin install` should not accept no plugins in args. Closes #199

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -206,17 +206,9 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 	installSkipped := []string{}
 
 	if len(plugins) == 0 {
-		utils.ShowError(fmt.Errorf(`you need to provide at least one plugin to install.
-
-# Install a single plugin
-steampipe plugin install <plugin>
-
-# Install multiple plugins
-steampipe plugin install <plugin 1> <plugin 2>
-
-Refer to %s for available plugins`,
-			constants.Bold("https://hub.steampipe.io"),
-		))
+		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to install"))
+		fmt.Println()
+		cmd.Help()
 		return
 	}
 
@@ -289,18 +281,9 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 	plugins := append([]string{}, args...)
 
 	if len(plugins) == 0 && !cmdconfig.Viper().GetBool("all") {
-		utils.ShowError(fmt.Errorf(`you need to provide at least one plugin to update or use the %s flag.
-
-# Update a single plugin
-steampipe plugin update <plugin>
-
-# Update multiple plugins
-steampipe plugin update <plugin 1> <plugin 2>
-
-# Update all plugins
-steampipe plugin update --all
-`,
-			constants.Bold("--all")))
+		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to update or use the %s flag", constants.Bold("--all")))
+		fmt.Println()
+		cmd.Help()
 		return
 	}
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -206,7 +206,17 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 	installSkipped := []string{}
 
 	if len(plugins) == 0 {
-		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to install. Refer to %s for available plugins", constants.Bold("https://hub.steampipe.io")))
+		utils.ShowError(fmt.Errorf(`you need to provide at least one plugin to install.
+
+# Install a single plugin
+steampipe plugin install <plugin>
+
+# Install multiple plugins
+steampipe plugin install <plugin 1> <plugin 2>
+
+Refer to %s for available plugins`,
+			constants.Bold("https://hub.steampipe.io"),
+		))
 		return
 	}
 
@@ -279,7 +289,18 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 	plugins := append([]string{}, args...)
 
 	if len(plugins) == 0 && !cmdconfig.Viper().GetBool("all") {
-		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to update or to update all plugins, use %s", constants.Bold("steampipe plugin update --all")))
+		utils.ShowError(fmt.Errorf(`you need to provide at least one plugin to update or use the %s flag.
+
+# Update a single plugin
+steampipe plugin update <plugin>
+
+# Update multiple plugins
+steampipe plugin update <plugin 1> <plugin 2>
+
+# Update all plugins
+steampipe plugin update --all
+`,
+			constants.Bold("--all")))
 		return
 	}
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -205,6 +205,11 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 	plugins := append([]string{}, args...)
 	installSkipped := []string{}
 
+	if len(plugins) == 0 {
+		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to install. Refer to %s for available plugins", constants.Bold("https://hub.steampipe.io")))
+		return
+	}
+
 	if len(plugins) > 1 {
 		fmt.Println()
 	}
@@ -251,7 +256,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 		fmt.Printf("\nTo update these plugins, please run: %s %s\n", constants.Bold("steampipe plugin update"), constants.Bold(strings.Join(installSkipped, " ")))
 	}
 
-	if len(args) > 1 {
+	if len(plugins) > 1 {
 		fmt.Println("")
 	}
 
@@ -272,6 +277,11 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 	// These can be simple names ('aws') for "standard" plugins, or
 	// full refs to the OCI image (us-docker.pkg.dev/steampipe/plugin/turbot/aws:1.0.0)
 	plugins := append([]string{}, args...)
+
+	if len(plugins) == 0 && !cmdconfig.Viper().GetBool("all") {
+		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to update or to update all plugins, use %s", constants.Bold("steampipe plugin update --all")))
+		return
+	}
 
 	// we can't allow update and install at the same time
 	if cmdconfig.Viper().GetBool("all") {
@@ -345,7 +355,7 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 		}
 		fmt.Printf("\nTo install these plugins, please run: %s %s\n", constants.Bold("steampipe plugin install"), constants.Bold(strings.Join(updateSkipped, " ")))
 	}
-	if len(args) > 1 {
+	if len(plugins) > 1 {
 		fmt.Println("")
 	}
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -209,6 +209,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to install"))
 		fmt.Println()
 		cmd.Help()
+		fmt.Println()
 		return
 	}
 
@@ -284,6 +285,7 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 		utils.ShowError(fmt.Errorf("you need to provide at least one plugin to update or use the %s flag", constants.Bold("--all")))
 		fmt.Println()
 		cmd.Help()
+		fmt.Println()
 		return
 	}
 


### PR DESCRIPTION
![Screenshot 2021-02-22 at 10 53 16 PM](https://user-images.githubusercontent.com/1114038/108827237-5e9c5480-75eb-11eb-8be7-d3b9b7f32b44.png)
![Screenshot 2021-02-22 at 10 56 04 PM](https://user-images.githubusercontent.com/1114038/108827245-61974500-75eb-11eb-9eb8-6ab249d4dfb6.png)

@e-gineer @johnsmyth outputs when no plugins are provided.