### PR TITLE
Fix typo in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,5 +73,5 @@ echo "Steampipe was installed successfully to $exe"
 if command -v steampipe >/dev/null; then
 	echo "Run 'steampipe --help' to get started"
 else
-    echo "Steampipe was installed, but could not be located. Are you sure `/use/local/bin` is exported?"
+    echo "Steampipe was installed, but could not be located. Are you sure `/usr/local/bin` is exported?"
 fi


### PR DESCRIPTION
There is a typo in a help message at the very end of install.sh