### PR TITLE
Update references from registry.steampipe.io to hub.steampipe.io

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -30,7 +30,7 @@ func PluginCmd() *cobra.Command {
 		Long: `Steampipe plugin management.
 
 Plugins extend Steampipe to work with many different services and providers.
-Find plugins using the public registry at https://registry.steampipe.io.
+Find plugins using the public registry at https://hub.steampipe.io.
 
 Examples:
 

--- a/ociinstaller/imageref.go
+++ b/ociinstaller/imageref.go
@@ -90,7 +90,7 @@ func (r *SteampipeImageRef) GetOrgNameAndStream() (string, string, string) {
 //		turbot/aws@1.0.0
 //      dockerhub.org/myimage@mytag
 //		aws@1.0.0
-//		registry.steampipe.io/plugin/turbot/aws@1.0.0
+//		hub.steampipe.io/plugin/turbot/aws@1.0.0
 
 func getFullImageRef(imagePath string) string {
 

--- a/ociinstaller/versionfile/versionfile.go
+++ b/ociinstaller/versionfile/versionfile.go
@@ -90,7 +90,7 @@ func read(path string) (*VersionFile, error) {
 	return &data, nil
 }
 
-// ex: $CONFIG_DIR/plugins/registry.steampipe.io/turbot/aws/1.1.2/steampipe-plugin-aws
+// ex: $CONFIG_DIR/plugins/hub.steampipe.io/turbot/aws/1.1.2/steampipe-plugin-aws
 func versionFileLocation() string {
 	path := filepath.Join(constants.InternalDir(), versionFileName)
 	return path


### PR DESCRIPTION
I'm new to steampipe, but when I went to try and find plugins via the CLI it told me to go to registry.steampipe.io, which doesn't exist and doesn't redirect to the newer hub.steampipe.io; just fixing that here.