### PR TITLE
Ensure we report error and do not start DB service if `port` is already in use. Closes #399

### DIFF
--- a/db/start_database.go
+++ b/db/start_database.go
@@ -103,7 +103,7 @@ func StartDB(port int, listen StartListenType, invoker Invoker) (StartResult, er
 	}
 
 	if !isPortBindable(port) {
-		return ServiceFailedToStart, handleStartFailure(fmt.Errorf("Cannot listen on %d. Are you sure that the interface is free?", port))
+		return ServiceFailedToStart, fmt.Errorf("Cannot listen on port %d. Are you sure that the interface is free?", constants.Bold(port))
 	}
 
 	postgresCmd := exec.Command(
@@ -261,14 +261,7 @@ func handleStartFailure(err error) error {
 }
 
 func isPortBindable(port int) bool {
-	// resolve an address to 127.0.0.1 for the given port
-	addrString := fmt.Sprintf("127.0.0.1:%d", port)
-	addr, err := net.ResolveTCPAddr("tcp", addrString)
-	if err != nil {
-		return false
-	}
-	// check that the given port can be used
-	l, err := net.ListenTCP("tcp", addr)
+	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return false
 	}

--- a/db/start_database.go
+++ b/db/start_database.go
@@ -103,7 +103,7 @@ func StartDB(port int, listen StartListenType, invoker Invoker) (StartResult, er
 	}
 
 	if !isPortBindable(port) {
-		return ServiceFailedToStart, fmt.Errorf("Cannot listen on port %d. Are you sure that the interface is free?", constants.Bold(port))
+		return ServiceFailedToStart, fmt.Errorf("Cannot listen on port %s. To start the service with a different port, use %s", constants.Bold(port), constants.Bold("--database-port <number>"))
 	}
 
 	postgresCmd := exec.Command(


### PR DESCRIPTION
fixing issue with service start where if another service is running in a different `install-dir`, the second service on the same `port` fails silently