### PR TITLE
New Feature :: `CI` mode for steampipe commands. Closes #233

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -194,7 +194,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 	// a leading blank line - since we always output multiple lines
 	fmt.Println()
 
-	spinner := utils.ShowSpinner("")
+	spinner := display.ShowSpinner("")
 
 	for _, p := range plugins {
 		isPluginExists, _ := plugin.Exists(p)
@@ -207,7 +207,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 			})
 			continue
 		}
-		utils.UpdateSpinnerMessage(spinner, fmt.Sprintf("Installing plugin: %s", p))
+		display.UpdateSpinnerMessage(spinner, fmt.Sprintf("Installing plugin: %s", p))
 		image, err := plugin.Install(p)
 		if err != nil {
 			msg := ""
@@ -243,7 +243,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 		})
 	}
 
-	utils.StopSpinner(spinner)
+	display.StopSpinner(spinner)
 
 	refreshConnectionsIfNecessary(installReports, false)
 	display.PrintInstallReports(installReports, false)
@@ -340,9 +340,9 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	spinner := utils.ShowSpinner("Checking for available updates")
+	spinner := display.ShowSpinner("Checking for available updates")
 	reports := plugin.GetUpdateReport(state.InstallationID, runUpdatesFor)
-	utils.StopSpinner(spinner)
+	display.StopSpinner(spinner)
 
 	if len(reports) == 0 {
 		// this happens if for some reason the update server could not be contacted,
@@ -362,9 +362,9 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		spinner := utils.ShowSpinner(fmt.Sprintf("Updating plugin %s...", report.CheckResponse.Name))
+		spinner := display.ShowSpinner(fmt.Sprintf("Updating plugin %s...", report.CheckResponse.Name))
 		image, err := plugin.Install(report.Plugin.Name)
-		utils.StopSpinner(spinner)
+		display.StopSpinner(spinner)
 		if err != nil {
 			msg := ""
 			if strings.HasSuffix(err.Error(), "not found") {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,9 +60,11 @@ func InitCmd() {
 
 	rootCmd.PersistentFlags().String(constants.ArgInstallDir, constants.DefaultInstallDir, "Path to the Config Directory")
 	rootCmd.PersistentFlags().String(constants.ArgWorkspace, "", "Path to the workspace (default to current working directory) ")
+	rootCmd.PersistentFlags().Bool(constants.ArgCI, false, fmt.Sprintf("Set %s to run in CI mode", constants.Bold("steampipe")))
 
 	viper.BindPFlag(constants.ArgInstallDir, rootCmd.PersistentFlags().Lookup(constants.ArgInstallDir))
 	viper.BindPFlag(constants.ArgWorkspace, rootCmd.PersistentFlags().Lookup(constants.ArgWorkspace))
+	viper.BindPFlag(constants.ArgCI, rootCmd.PersistentFlags().Lookup(constants.ArgCI))
 
 	AddCommands()
 

--- a/constants/args.go
+++ b/constants/args.go
@@ -23,6 +23,7 @@ const (
 	ArgSearchPath              = "search-path"
 	ArgSearchPathPrefix        = "search-path-prefix"
 	ArgWatch                   = "watch"
+	ArgCI                      = "ci"
 )
 
 /// metaquery mode arguments

--- a/db/client_connections.go
+++ b/db/client_connections.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/steampipeconfig"
 	"github.com/turbot/steampipe/utils"
 )
@@ -51,8 +52,8 @@ func (c *Client) RefreshConnections() (bool, error) {
 		}()
 		// in query, this can only start when in interactive
 		if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
-			spin := utils.ShowSpinner("Refreshing connections...")
-			defer utils.StopSpinner(spin)
+			spin := display.ShowSpinner("Refreshing connections...")
+			defer display.StopSpinner(spin)
 		}
 
 		// first instantiate connection plugins for all updates

--- a/db/client_execute.go
+++ b/db/client_execute.go
@@ -11,6 +11,7 @@ import (
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
 	"github.com/turbot/steampipe/definitions/results"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/utils"
 )
 
@@ -44,7 +45,7 @@ func (c *Client) executeQuery(query string, countStream bool) (*results.QueryRes
 	if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
 		// if showspinner is false, the spinner gets created, but is never shown
 		// so the s.Active() will always come back false . . .
-		spinner = utils.StartSpinnerAfterDelay("Loading results...", constants.SpinnerShowTimeout, queryDone)
+		spinner = display.StartSpinnerAfterDelay("Loading results...", constants.SpinnerShowTimeout, queryDone)
 	} else {
 		// no point in showing count if we don't have the spinner
 		countStream = false
@@ -55,7 +56,7 @@ func (c *Client) executeQuery(query string, countStream bool) (*results.QueryRes
 
 	if err != nil {
 		// in case the query takes a long time to fail
-		utils.StopSpinner(spinner)
+		display.StopSpinner(spinner)
 		return nil, err
 	}
 
@@ -97,19 +98,19 @@ func (c *Client) executeQuery(query string, countStream bool) (*results.QueryRes
 
 			if !countStream {
 				// stop the spinner if we don't want to show load count
-				utils.StopSpinner(spinner)
+				display.StopSpinner(spinner)
 			}
 
 			// we have started populating results
 			result.StreamRow(rowResult)
 
 			// update the spinner message with the count of rows that have already been fetched
-			utils.UpdateSpinnerMessage(spinner, fmt.Sprintf("Loading results: %3s", humanizeRowCount(rowCount)))
+			display.UpdateSpinnerMessage(spinner, fmt.Sprintf("Loading results: %3s", humanizeRowCount(rowCount)))
 			rowCount++
 		}
 
 		// we are done fetching results. time for display. remove the spinner
-		utils.StopSpinner(spinner)
+		display.StopSpinner(spinner)
 
 		// set the time that it took for this one to execute
 		result.Duration <- time.Since(start)

--- a/db/install.go
+++ b/db/install.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/turbot/steampipe-plugin-sdk/logging"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/ociinstaller"
 	"github.com/turbot/steampipe/ociinstaller/versionfile"
 	"github.com/turbot/steampipe/utils"
@@ -48,32 +49,32 @@ func EnsureDBInstalled() {
 	}
 
 	log.Println("[TRACE] calling killPreviousInstanceIfAny")
-	killPreviousSpinner := utils.ShowSpinner(fmt.Sprintf("Cleanup any Steampipe processes..."))
+	killPreviousSpinner := display.ShowSpinner(fmt.Sprintf("Cleanup any Steampipe processes..."))
 	killPreviousInstanceIfAny()
 	log.Println("[TRACE] calling removeRunningInstanceInfo")
 	err := removeRunningInstanceInfo()
-	utils.StopSpinner(killPreviousSpinner)
+	display.StopSpinner(killPreviousSpinner)
 	if err != nil && !os.IsNotExist(err) {
 		utils.FailOnErrorWithMessage(err, "x Cleanup any Steampipe processes... FAILED!")
 	}
 
 	log.Println("[TRACE] removing previous installation")
-	dbCleanupSpinner := utils.ShowSpinner(fmt.Sprintf("Prepare database install location..."))
+	dbCleanupSpinner := display.ShowSpinner(fmt.Sprintf("Prepare database install location..."))
 	err = os.RemoveAll(getDatabaseLocation())
 	if err != nil {
-		utils.StopSpinner(dbCleanupSpinner)
+		display.StopSpinner(dbCleanupSpinner)
 		utils.FailOnErrorWithMessage(err, "x Prepare database install location... FAILED!")
 	}
 	err = os.RemoveAll(getDataLocation())
 	if err != nil {
-		utils.StopSpinner(dbCleanupSpinner)
+		display.StopSpinner(dbCleanupSpinner)
 		utils.FailOnErrorWithMessage(err, "x Prepare database install location... FAILED!")
 	}
-	utils.StopSpinner(dbCleanupSpinner)
+	display.StopSpinner(dbCleanupSpinner)
 
-	dbInstallSpinner := utils.ShowSpinner(fmt.Sprintf("Download & install embedded PostgreSQL database..."))
+	dbInstallSpinner := display.ShowSpinner(fmt.Sprintf("Download & install embedded PostgreSQL database..."))
 	_, err = ociinstaller.InstallDB(constants.DefaultEmbeddedPostgresImage, getDatabaseLocation())
-	utils.StopSpinner(dbInstallSpinner)
+	display.StopSpinner(dbInstallSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Download & install embedded PostgreSQL database... FAILED!")
 	}
@@ -81,35 +82,35 @@ func EnsureDBInstalled() {
 	// installFDW takes care of the spinner, since it may need to run independently
 	_, err = installFDW(true)
 
-	dbInitSpinner := utils.ShowSpinner(fmt.Sprintf("Initializing database..."))
+	dbInitSpinner := display.ShowSpinner(fmt.Sprintf("Initializing database..."))
 	err = initDatabase()
-	utils.StopSpinner(dbInitSpinner)
+	display.StopSpinner(dbInitSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Initializing database... FAILED!")
 	}
 
-	pwSpinner := utils.ShowSpinner(fmt.Sprintf("Generating database passwords..."))
+	pwSpinner := display.ShowSpinner(fmt.Sprintf("Generating database passwords..."))
 	// Try for passwords of the form dbC-3Ji-d04d
 	steampipePassword := generatePassword()
 	rootPassword := generatePassword()
 	// write the passwords that were generated
 	err = writePasswordFile(steampipePassword, rootPassword)
-	utils.StopSpinner(pwSpinner)
+	display.StopSpinner(pwSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Generating database passwords... FAILED!")
 	}
 
-	startServiceSpinner := utils.ShowSpinner(fmt.Sprintf("Configuring database..."))
+	startServiceSpinner := display.ShowSpinner(fmt.Sprintf("Configuring database..."))
 	StartService(InvokerInstaller)
 	err = installSteampipeDatabase(steampipePassword, rootPassword)
-	utils.StopSpinner(startServiceSpinner)
+	display.StopSpinner(startServiceSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Configuring database... FAILED!")
 	}
 
-	installSteampipeSpinner := utils.ShowSpinner(fmt.Sprintf("Configuring Steampipe..."))
+	installSteampipeSpinner := display.ShowSpinner(fmt.Sprintf("Configuring Steampipe..."))
 	err = installSteampipeHub()
-	utils.StopSpinner(installSteampipeSpinner)
+	display.StopSpinner(installSteampipeSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Configuring Steampipe... FAILED!")
 	}
@@ -118,9 +119,9 @@ func EnsureDBInstalled() {
 
 	// write a signature after everything gets done!
 	// so that we can check for this later on
-	writeSignaturesSpinner := utils.ShowSpinner(fmt.Sprintf("Updating install records..."))
+	writeSignaturesSpinner := display.ShowSpinner(fmt.Sprintf("Updating install records..."))
 	err = updateDownloadedBinarySignature()
-	utils.StopSpinner(writeSignaturesSpinner)
+	display.StopSpinner(writeSignaturesSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Updating install records... FAILED!")
 	}
@@ -250,9 +251,9 @@ func installFDW(firstSetup bool) (string, error) {
 			}
 		}()
 	}
-	fdwInstallSpinner := utils.ShowSpinner(fmt.Sprintf("Download & install %s...", constants.Bold("steampipe-postgres-fdw")))
+	fdwInstallSpinner := display.ShowSpinner(fmt.Sprintf("Download & install %s...", constants.Bold("steampipe-postgres-fdw")))
 	newDigest, err := ociinstaller.InstallFdw(constants.DefaultFdwImage, getDatabaseLocation())
-	utils.StopSpinner(fdwInstallSpinner)
+	display.StopSpinner(fdwInstallSpinner)
 	if err != nil {
 		if firstSetup {
 			utils.FailOnErrorWithMessage(err, "x Download & install steampipe-postgres-fdw... FAILED!")

--- a/db/start_database.go
+++ b/db/start_database.go
@@ -13,7 +13,7 @@ import (
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
-	"github.com/turbot/steampipe/utils"
+	"github.com/turbot/steampipe/display"
 )
 
 // StartResult :: pseudoEnum for outcomes of Start
@@ -247,10 +247,10 @@ func handleStartFailure(err error) error {
 	// starting up the process. this may be because of a stray
 	// steampipe postgres running or another one from a different installation.
 	checkedPreviousInstances := make(chan bool, 1)
-	s := utils.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
+	s := display.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
 	otherProcess := findSteampipePostgresInstance()
 	checkedPreviousInstances <- true
-	utils.StopSpinner(s)
+	display.StopSpinner(s)
 	if otherProcess != nil {
 		return fmt.Errorf("Another Steampipe service is already running. Use %s to kill all running instances before continuing.", constants.Bold("steampipe service stop --force"))
 	}

--- a/db/start_service.go
+++ b/db/start_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/utils"
 )
 
@@ -44,8 +45,8 @@ func StartService(invoker Invoker) {
 			}
 			if time.Since(startedAt) > constants.SpinnerShowTimeout && !spinnerShown {
 				if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
-					s := utils.ShowSpinner("Waiting for database to start...")
-					defer utils.StopSpinner(s)
+					s := display.ShowSpinner("Waiting for database to start...")
+					defer display.StopSpinner(s)
 				}
 				// set this anyway, so that next time it doesn't come in
 				spinnerShown = true

--- a/db/stop_database.go
+++ b/db/stop_database.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 
 	"github.com/turbot/steampipe/utils"
 )
@@ -69,7 +70,7 @@ func StopDB(force bool, invoker Invoker) (StopStatus, error) {
 	if force {
 		// check if we have a process from another install-dir
 		checkedPreviousInstances := make(chan bool, 1)
-		s := utils.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
+		s := display.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
 		for {
 			previousProcess := findSteampipePostgresInstance()
 			if previousProcess != nil {
@@ -80,7 +81,7 @@ func StopDB(force bool, invoker Invoker) (StopStatus, error) {
 			checkedPreviousInstances <- true
 			break
 		}
-		utils.StopSpinner(s)
+		display.StopSpinner(s)
 		os.Remove(runningInfoFilePath())
 		return ServiceStopped, nil
 	}
@@ -144,8 +145,8 @@ func StopDB(force bool, invoker Invoker) (StopStatus, error) {
 			}
 			if time.Since(signalSentAt) > constants.SpinnerShowTimeout && !spinnerShown {
 				if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
-					s := utils.ShowSpinner("Shutting down...")
-					defer utils.StopSpinner(s)
+					s := display.ShowSpinner("Shutting down...")
+					defer display.StopSpinner(s)
 					spinnerShown = true
 				}
 			}

--- a/display/pager.go
+++ b/display/pager.go
@@ -35,6 +35,11 @@ func isPagerNeeded(content string) bool {
 		return false
 	}
 
+	// do not show pager if in CI mode (even for interactive)
+	if viper.GetBool(constants.ArgCI) {
+		return false
+	}
+
 	maxCols, maxRow, _ := gows.GetWinSize()
 
 	// let's scan through it instead of iterating over it fully

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -1,4 +1,4 @@
-package utils
+package display
 
 import (
 	"fmt"

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/spf13/viper"
+	"github.com/turbot/steampipe/constants"
 )
 
 // StartSpinnerAfterDelay :: create a spinner with a given message and start
@@ -21,7 +23,7 @@ func StartSpinnerAfterDelay(msg string, delay time.Duration, cancelStartIf chan 
 		select {
 		case <-cancelStartIf:
 		case <-time.After(delay):
-			if spinner != nil && !spinner.Active() {
+			if spinner != nil && !spinner.Active() && !viper.GetBool(constants.ArgCI) {
 				spinner.Start()
 			}
 		}
@@ -39,7 +41,9 @@ func ShowSpinner(msg string) *spinner.Spinner {
 		spinner.WithWriter(os.Stdout),
 		spinner.WithSuffix(fmt.Sprintf(" %s", msg)),
 	)
-	s.Start()
+	if !viper.GetBool(constants.ArgCI) {
+		s.Start()
+	}
 	return s
 }
 

--- a/plugin/actions.go
+++ b/plugin/actions.go
@@ -6,9 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/turbot/steampipe/utils"
-
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/ociinstaller"
 	"github.com/turbot/steampipe/ociinstaller/versionfile"
 )
@@ -21,8 +20,8 @@ const (
 
 // Remove :: removes an installed plugin
 func Remove(image string, pluginConnections map[string][]string) error {
-	spinner := utils.ShowSpinner(fmt.Sprintf("Removing plugin %s", image))
-	defer utils.StopSpinner(spinner)
+	spinner := display.ShowSpinner(fmt.Sprintf("Removing plugin %s", image))
+	defer display.StopSpinner(spinner)
 
 	fullPluginName := ociinstaller.NewSteampipeImageRef(image).DisplayImageRef()
 

--- a/task/runner.go
+++ b/task/runner.go
@@ -57,7 +57,7 @@ func (r *Runner) runAsyncJob(job func(), wg *sync.WaitGroup) {
 
 // determines whether the task runner should run at all
 // tasks are to be run at most once every 24 hours
-// also, this is not to run in batch query mode
+// also, this is not to run in batch query mode and in CI mode (`--ci`)
 func (r *Runner) shouldRun() bool {
 	cmd := viper.Get(constants.ConfigKeyActiveCommand).(*cobra.Command)
 	cmdArgs := viper.GetStringSlice(constants.ConfigKeyActiveCommandArgs)
@@ -67,6 +67,9 @@ func (r *Runner) shouldRun() bool {
 		return false
 	}
 
+	if viper.GetBool(constants.ArgCI) {
+		return false
+	}
 	now := time.Now()
 	if r.currentState.LastCheck == "" {
 		return true


### PR DESCRIPTION
`CI` mode in the steampipe CLI is meant to be useful when the user wants to disable all extraneous activities.

We have taken design queues from `terraform` which has `-input=false` and `-auto-approve` flags for running in automated environments. `terraform` also support a `TF_IN_AUTOMATION` environment variable.

This PR adds a new `--ci` flag for all commands.

When the `--ci` flag is passed in any command, the CLI will:
* disable `scheduled tasks` (`cli update check`, `plugin update check`, `log trimming`)
* disable `spinner` display
* disable `paging` of output