### PR TITLE
fixes spinner new line issue for long texts. Closes #450

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -194,7 +194,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 	// a leading blank line - since we always output multiple lines
 	fmt.Println()
 
-	spinner := utils.ShowSpinner("")
+	spinner := display.ShowSpinner("")
 
 	for _, p := range plugins {
 		isPluginExists, _ := plugin.Exists(p)
@@ -207,7 +207,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 			})
 			continue
 		}
-		utils.UpdateSpinnerMessage(spinner, fmt.Sprintf("Installing plugin: %s", p))
+		display.UpdateSpinnerMessage(spinner, fmt.Sprintf("Installing plugin: %s", p))
 		image, err := plugin.Install(p)
 		if err != nil {
 			msg := ""
@@ -243,7 +243,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 		})
 	}
 
-	utils.StopSpinner(spinner)
+	display.StopSpinner(spinner)
 
 	refreshConnectionsIfNecessary(installReports, false)
 	display.PrintInstallReports(installReports, false)
@@ -340,9 +340,9 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	spinner := utils.ShowSpinner("Checking for available updates")
+	spinner := display.ShowSpinner("Checking for available updates")
 	reports := plugin.GetUpdateReport(state.InstallationID, runUpdatesFor)
-	utils.StopSpinner(spinner)
+	display.StopSpinner(spinner)
 
 	if len(reports) == 0 {
 		// this happens if for some reason the update server could not be contacted,
@@ -362,9 +362,9 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 			continue
 		}
 
-		spinner := utils.ShowSpinner(fmt.Sprintf("Updating plugin %s...", report.CheckResponse.Name))
+		spinner := display.ShowSpinner(fmt.Sprintf("Updating plugin %s...", report.CheckResponse.Name))
 		image, err := plugin.Install(report.Plugin.Name)
-		utils.StopSpinner(spinner)
+		display.StopSpinner(spinner)
 		if err != nil {
 			msg := ""
 			if strings.HasSuffix(err.Error(), "not found") {

--- a/db/client_connections.go
+++ b/db/client_connections.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/steampipeconfig"
 	"github.com/turbot/steampipe/utils"
 )
@@ -51,8 +52,8 @@ func (c *Client) RefreshConnections() (bool, error) {
 		}()
 		// in query, this can only start when in interactive
 		if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
-			spin := utils.ShowSpinner("Refreshing connections...")
-			defer utils.StopSpinner(spin)
+			spin := display.ShowSpinner("Refreshing connections...")
+			defer display.StopSpinner(spin)
 		}
 
 		// first instantiate connection plugins for all updates

--- a/db/client_execute.go
+++ b/db/client_execute.go
@@ -11,6 +11,7 @@ import (
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
 	"github.com/turbot/steampipe/definitions/results"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/utils"
 )
 
@@ -44,7 +45,7 @@ func (c *Client) executeQuery(query string, countStream bool) (*results.QueryRes
 	if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
 		// if showspinner is false, the spinner gets created, but is never shown
 		// so the s.Active() will always come back false . . .
-		spinner = utils.StartSpinnerAfterDelay("Loading results...", constants.SpinnerShowTimeout, queryDone)
+		spinner = display.StartSpinnerAfterDelay("Loading results...", constants.SpinnerShowTimeout, queryDone)
 	} else {
 		// no point in showing count if we don't have the spinner
 		countStream = false
@@ -55,7 +56,7 @@ func (c *Client) executeQuery(query string, countStream bool) (*results.QueryRes
 
 	if err != nil {
 		// in case the query takes a long time to fail
-		utils.StopSpinner(spinner)
+		display.StopSpinner(spinner)
 		return nil, err
 	}
 
@@ -97,19 +98,19 @@ func (c *Client) executeQuery(query string, countStream bool) (*results.QueryRes
 
 			if !countStream {
 				// stop the spinner if we don't want to show load count
-				utils.StopSpinner(spinner)
+				display.StopSpinner(spinner)
 			}
 
 			// we have started populating results
 			result.StreamRow(rowResult)
 
 			// update the spinner message with the count of rows that have already been fetched
-			utils.UpdateSpinnerMessage(spinner, fmt.Sprintf("Loading results: %3s", humanizeRowCount(rowCount)))
+			display.UpdateSpinnerMessage(spinner, fmt.Sprintf("Loading results: %3s", humanizeRowCount(rowCount)))
 			rowCount++
 		}
 
 		// we are done fetching results. time for display. remove the spinner
-		utils.StopSpinner(spinner)
+		display.StopSpinner(spinner)
 
 		// set the time that it took for this one to execute
 		result.Duration <- time.Since(start)

--- a/db/install.go
+++ b/db/install.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/turbot/steampipe-plugin-sdk/logging"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/ociinstaller"
 	"github.com/turbot/steampipe/ociinstaller/versionfile"
 	"github.com/turbot/steampipe/utils"
@@ -48,32 +49,32 @@ func EnsureDBInstalled() {
 	}
 
 	log.Println("[TRACE] calling killPreviousInstanceIfAny")
-	killPreviousSpinner := utils.ShowSpinner(fmt.Sprintf("Cleanup any Steampipe processes..."))
+	killPreviousSpinner := display.ShowSpinner(fmt.Sprintf("Cleanup any Steampipe processes..."))
 	killPreviousInstanceIfAny()
 	log.Println("[TRACE] calling removeRunningInstanceInfo")
 	err := removeRunningInstanceInfo()
-	utils.StopSpinner(killPreviousSpinner)
+	display.StopSpinner(killPreviousSpinner)
 	if err != nil && !os.IsNotExist(err) {
 		utils.FailOnErrorWithMessage(err, "x Cleanup any Steampipe processes... FAILED!")
 	}
 
 	log.Println("[TRACE] removing previous installation")
-	dbCleanupSpinner := utils.ShowSpinner(fmt.Sprintf("Prepare database install location..."))
+	dbCleanupSpinner := display.ShowSpinner(fmt.Sprintf("Prepare database install location..."))
 	err = os.RemoveAll(getDatabaseLocation())
 	if err != nil {
-		utils.StopSpinner(dbCleanupSpinner)
+		display.StopSpinner(dbCleanupSpinner)
 		utils.FailOnErrorWithMessage(err, "x Prepare database install location... FAILED!")
 	}
 	err = os.RemoveAll(getDataLocation())
 	if err != nil {
-		utils.StopSpinner(dbCleanupSpinner)
+		display.StopSpinner(dbCleanupSpinner)
 		utils.FailOnErrorWithMessage(err, "x Prepare database install location... FAILED!")
 	}
-	utils.StopSpinner(dbCleanupSpinner)
+	display.StopSpinner(dbCleanupSpinner)
 
-	dbInstallSpinner := utils.ShowSpinner(fmt.Sprintf("Download & install embedded PostgreSQL database..."))
+	dbInstallSpinner := display.ShowSpinner(fmt.Sprintf("Download & install embedded PostgreSQL database..."))
 	_, err = ociinstaller.InstallDB(constants.DefaultEmbeddedPostgresImage, getDatabaseLocation())
-	utils.StopSpinner(dbInstallSpinner)
+	display.StopSpinner(dbInstallSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Download & install embedded PostgreSQL database... FAILED!")
 	}
@@ -81,35 +82,35 @@ func EnsureDBInstalled() {
 	// installFDW takes care of the spinner, since it may need to run independently
 	_, err = installFDW(true)
 
-	dbInitSpinner := utils.ShowSpinner(fmt.Sprintf("Initializing database..."))
+	dbInitSpinner := display.ShowSpinner(fmt.Sprintf("Initializing database..."))
 	err = initDatabase()
-	utils.StopSpinner(dbInitSpinner)
+	display.StopSpinner(dbInitSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Initializing database... FAILED!")
 	}
 
-	pwSpinner := utils.ShowSpinner(fmt.Sprintf("Generating database passwords..."))
+	pwSpinner := display.ShowSpinner(fmt.Sprintf("Generating database passwords..."))
 	// Try for passwords of the form dbC-3Ji-d04d
 	steampipePassword := generatePassword()
 	rootPassword := generatePassword()
 	// write the passwords that were generated
 	err = writePasswordFile(steampipePassword, rootPassword)
-	utils.StopSpinner(pwSpinner)
+	display.StopSpinner(pwSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Generating database passwords... FAILED!")
 	}
 
-	startServiceSpinner := utils.ShowSpinner(fmt.Sprintf("Configuring database..."))
+	startServiceSpinner := display.ShowSpinner(fmt.Sprintf("Configuring database..."))
 	StartService(InvokerInstaller)
 	err = installSteampipeDatabase(steampipePassword, rootPassword)
-	utils.StopSpinner(startServiceSpinner)
+	display.StopSpinner(startServiceSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Configuring database... FAILED!")
 	}
 
-	installSteampipeSpinner := utils.ShowSpinner(fmt.Sprintf("Configuring Steampipe..."))
+	installSteampipeSpinner := display.ShowSpinner(fmt.Sprintf("Configuring Steampipe..."))
 	err = installSteampipeHub()
-	utils.StopSpinner(installSteampipeSpinner)
+	display.StopSpinner(installSteampipeSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Configuring Steampipe... FAILED!")
 	}
@@ -118,9 +119,9 @@ func EnsureDBInstalled() {
 
 	// write a signature after everything gets done!
 	// so that we can check for this later on
-	writeSignaturesSpinner := utils.ShowSpinner(fmt.Sprintf("Updating install records..."))
+	writeSignaturesSpinner := display.ShowSpinner(fmt.Sprintf("Updating install records..."))
 	err = updateDownloadedBinarySignature()
-	utils.StopSpinner(writeSignaturesSpinner)
+	display.StopSpinner(writeSignaturesSpinner)
 	if err != nil {
 		utils.FailOnErrorWithMessage(err, "x Updating install records... FAILED!")
 	}
@@ -250,9 +251,9 @@ func installFDW(firstSetup bool) (string, error) {
 			}
 		}()
 	}
-	fdwInstallSpinner := utils.ShowSpinner(fmt.Sprintf("Download & install %s...", constants.Bold("steampipe-postgres-fdw")))
+	fdwInstallSpinner := display.ShowSpinner(fmt.Sprintf("Download & install %s...", constants.Bold("steampipe-postgres-fdw")))
 	newDigest, err := ociinstaller.InstallFdw(constants.DefaultFdwImage, getDatabaseLocation())
-	utils.StopSpinner(fdwInstallSpinner)
+	display.StopSpinner(fdwInstallSpinner)
 	if err != nil {
 		if firstSetup {
 			utils.FailOnErrorWithMessage(err, "x Download & install steampipe-postgres-fdw... FAILED!")

--- a/db/start_database.go
+++ b/db/start_database.go
@@ -13,7 +13,7 @@ import (
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
-	"github.com/turbot/steampipe/utils"
+	"github.com/turbot/steampipe/display"
 )
 
 // StartResult :: pseudoEnum for outcomes of Start
@@ -247,10 +247,10 @@ func handleStartFailure(err error) error {
 	// starting up the process. this may be because of a stray
 	// steampipe postgres running or another one from a different installation.
 	checkedPreviousInstances := make(chan bool, 1)
-	s := utils.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
+	s := display.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
 	otherProcess := findSteampipePostgresInstance()
 	checkedPreviousInstances <- true
-	utils.StopSpinner(s)
+	display.StopSpinner(s)
 	if otherProcess != nil {
 		return fmt.Errorf("Another Steampipe service is already running. Use %s to kill all running instances before continuing.", constants.Bold("steampipe service stop --force"))
 	}

--- a/db/start_service.go
+++ b/db/start_service.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/utils"
 )
 
@@ -44,8 +45,8 @@ func StartService(invoker Invoker) {
 			}
 			if time.Since(startedAt) > constants.SpinnerShowTimeout && !spinnerShown {
 				if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
-					s := utils.ShowSpinner("Waiting for database to start...")
-					defer utils.StopSpinner(s)
+					s := display.ShowSpinner("Waiting for database to start...")
+					defer display.StopSpinner(s)
 				}
 				// set this anyway, so that next time it doesn't come in
 				spinnerShown = true

--- a/db/stop_database.go
+++ b/db/stop_database.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 
 	"github.com/turbot/steampipe/utils"
 )
@@ -69,7 +70,7 @@ func StopDB(force bool, invoker Invoker) (StopStatus, error) {
 	if force {
 		// check if we have a process from another install-dir
 		checkedPreviousInstances := make(chan bool, 1)
-		s := utils.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
+		s := display.StartSpinnerAfterDelay("Checking for running instances...", constants.SpinnerShowTimeout, checkedPreviousInstances)
 		for {
 			previousProcess := findSteampipePostgresInstance()
 			if previousProcess != nil {
@@ -80,7 +81,7 @@ func StopDB(force bool, invoker Invoker) (StopStatus, error) {
 			checkedPreviousInstances <- true
 			break
 		}
-		utils.StopSpinner(s)
+		display.StopSpinner(s)
 		os.Remove(runningInfoFilePath())
 		return ServiceStopped, nil
 	}
@@ -144,8 +145,8 @@ func StopDB(force bool, invoker Invoker) (StopStatus, error) {
 			}
 			if time.Since(signalSentAt) > constants.SpinnerShowTimeout && !spinnerShown {
 				if cmdconfig.Viper().GetBool(constants.ConfigKeyShowInteractiveOutput) {
-					s := utils.ShowSpinner("Shutting down...")
-					defer utils.StopSpinner(s)
+					s := display.ShowSpinner("Shutting down...")
+					defer display.StopSpinner(s)
 					spinnerShown = true
 				}
 			}

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -1,4 +1,4 @@
-package utils
+package display
 
 import (
 	"fmt"

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -3,6 +3,7 @@ package display
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -10,6 +11,10 @@ import (
 )
 
 func truncateSpinnerMessageToScreen(msg string) string {
+	if len(strings.TrimSpace(msg)) == 0 {
+		// if this is a blank message, return it as is
+		return msg
+	}
 	maxCols, _, _ := gows.GetWinSize()
 	availableColumns := maxCols - 7
 	if len(msg) > availableColumns {

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -6,13 +6,26 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/karrick/gows"
 )
+
+func truncateSpinnerMessageToScreen(msg string) string {
+	maxCols, _, _ := gows.GetWinSize()
+	availableColumns := maxCols - 7
+	if len(msg) > availableColumns {
+		msg = msg[:availableColumns]
+		msg = fmt.Sprintf("%s ...", msg)
+	}
+	return msg
+}
 
 // StartSpinnerAfterDelay :: create a spinner with a given message and start
 func StartSpinnerAfterDelay(msg string, delay time.Duration, cancelStartIf chan bool) *spinner.Spinner {
+	msg = truncateSpinnerMessageToScreen(msg)
 	spinner := spinner.New(
 		spinner.CharSets[14],
 		100*time.Millisecond,
+		spinner.WithHiddenCursor(true),
 		spinner.WithWriter(os.Stdout),
 		spinner.WithSuffix(fmt.Sprintf(" %s", msg)),
 	)
@@ -33,9 +46,11 @@ func StartSpinnerAfterDelay(msg string, delay time.Duration, cancelStartIf chan 
 
 // ShowSpinner :: create a spinner with a given message and start
 func ShowSpinner(msg string) *spinner.Spinner {
+	msg = truncateSpinnerMessageToScreen(msg)
 	s := spinner.New(
 		spinner.CharSets[14],
 		100*time.Millisecond,
+		spinner.WithHiddenCursor(true),
 		spinner.WithWriter(os.Stdout),
 		spinner.WithSuffix(fmt.Sprintf(" %s", msg)),
 	)
@@ -61,6 +76,7 @@ func StopSpinner(spinner *spinner.Spinner) {
 // UpdateSpinnerMessage :: updates the message on the right of the given spinner
 func UpdateSpinnerMessage(spinner *spinner.Spinner, newMessage string) {
 	if spinner != nil && spinner.Active() {
+		newMessage = truncateSpinnerMessageToScreen(newMessage)
 		spinner.Suffix = fmt.Sprintf(" %s", newMessage)
 	}
 }

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -18,7 +18,7 @@ import (
 //
 // Not using the (…) character, since it is too small
 //
-const mustHaveCharLengthForSpinner = 7
+const minSpinnerWidth = 7
 
 func truncateSpinnerMessageToScreen(msg string) string {
 	if len(strings.TrimSpace(msg)) == 0 {
@@ -27,10 +27,11 @@ func truncateSpinnerMessageToScreen(msg string) string {
 	}
 
 	maxCols, _, _ := gows.GetWinSize()
-	if maxCols < mustHaveCharLengthForSpinner {
+	// if the screen is smaller than the minimum spinner width, we cannot truncate
+	if maxCols < minSpinnerWidth {
 		return msg
 	}
-	availableColumns := maxCols - mustHaveCharLengthForSpinner
+	availableColumns := maxCols - minSpinnerWidth
 	if len(msg) > availableColumns {
 		msg = msg[:availableColumns]
 		msg = fmt.Sprintf("%s ...", msg)

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -19,7 +19,13 @@ func truncateSpinnerMessageToScreen(msg string) string {
 	return msg
 }
 
-// StartSpinnerAfterDelay :: create a spinner with a given message and start
+// StartSpinnerAfterDelay shows the spinner with the given `msg` if and only if `cancelStartIf` resolves
+// after `delay`.
+//
+// Example: if delay is 2 seconds and `cancelStartIf` resolves after 2.5 seconds, the spinner
+// will show for 0.5 seconds. If `cancelStartIf` resolves after 1.5 seconds, the spinner will
+// NOT be shown at all
+//
 func StartSpinnerAfterDelay(msg string, delay time.Duration, cancelStartIf chan bool) *spinner.Spinner {
 	msg = truncateSpinnerMessageToScreen(msg)
 	spinner := spinner.New(
@@ -44,7 +50,7 @@ func StartSpinnerAfterDelay(msg string, delay time.Duration, cancelStartIf chan 
 	return spinner
 }
 
-// ShowSpinner :: create a spinner with a given message and start
+// ShowSpinner shows a spinner with the given message
 func ShowSpinner(msg string) *spinner.Spinner {
 	msg = truncateSpinnerMessageToScreen(msg)
 	s := spinner.New(
@@ -58,7 +64,7 @@ func ShowSpinner(msg string) *spinner.Spinner {
 	return s
 }
 
-// StopSpinnerWithMessage :: stops a spinner instance and clears it, after writing `finalMsg`
+// StopSpinnerWithMessage stops a spinner instance and clears it, after writing `finalMsg`
 func StopSpinnerWithMessage(spinner *spinner.Spinner, finalMsg string) {
 	if spinner != nil && spinner.Active() {
 		spinner.FinalMSG = finalMsg
@@ -66,14 +72,14 @@ func StopSpinnerWithMessage(spinner *spinner.Spinner, finalMsg string) {
 	}
 }
 
-// StopSpinner :: stops a spinner instance and clears it
+// StopSpinner stops a spinner instance and clears it
 func StopSpinner(spinner *spinner.Spinner) {
 	if spinner != nil && spinner.Active() {
 		spinner.Stop()
 	}
 }
 
-// UpdateSpinnerMessage :: updates the message on the right of the given spinner
+// UpdateSpinnerMessage updates the message of the given spinner
 func UpdateSpinnerMessage(spinner *spinner.Spinner, newMessage string) {
 	if spinner != nil && spinner.Active() {
 		newMessage = truncateSpinnerMessageToScreen(newMessage)

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -16,6 +16,9 @@ func truncateSpinnerMessageToScreen(msg string) string {
 		return msg
 	}
 	maxCols, _, _ := gows.GetWinSize()
+	if maxCols < 7 {
+		return msg
+	}
 	availableColumns := maxCols - 7
 	if len(msg) > availableColumns {
 		msg = msg[:availableColumns]

--- a/display/spinner.go
+++ b/display/spinner.go
@@ -10,16 +10,27 @@ import (
 	"github.com/karrick/gows"
 )
 
+//
+// spinner format:
+// <spinner><space><message><space><dot><dot><dot><cursor>
+// 		1	   1   [.......]   1     1    1    1     1
+// We need at least seven characters to show the spinner properly
+//
+// Not using the (…) character, since it is too small
+//
+const mustHaveCharLengthForSpinner = 7
+
 func truncateSpinnerMessageToScreen(msg string) string {
 	if len(strings.TrimSpace(msg)) == 0 {
 		// if this is a blank message, return it as is
 		return msg
 	}
+
 	maxCols, _, _ := gows.GetWinSize()
-	if maxCols < 7 {
+	if maxCols < mustHaveCharLengthForSpinner {
 		return msg
 	}
-	availableColumns := maxCols - 7
+	availableColumns := maxCols - mustHaveCharLengthForSpinner
 	if len(msg) > availableColumns {
 		msg = msg[:availableColumns]
 		msg = fmt.Sprintf("%s ...", msg)

--- a/plugin/actions.go
+++ b/plugin/actions.go
@@ -6,9 +6,8 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/turbot/steampipe/utils"
-
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/display"
 	"github.com/turbot/steampipe/ociinstaller"
 	"github.com/turbot/steampipe/ociinstaller/versionfile"
 )
@@ -21,8 +20,8 @@ const (
 
 // Remove :: removes an installed plugin
 func Remove(image string, pluginConnections map[string][]string) error {
-	spinner := utils.ShowSpinner(fmt.Sprintf("Removing plugin %s", image))
-	defer utils.StopSpinner(spinner)
+	spinner := display.ShowSpinner(fmt.Sprintf("Removing plugin %s", image))
+	defer display.StopSpinner(spinner)
 
 	fullPluginName := ociinstaller.NewSteampipeImageRef(image).DisplayImageRef()
 


### PR DESCRIPTION
spinner displays a new line on every refresh if the text given as suffix to the spinner exceeds the current terminal width.

this fix truncates the suffix to the maximum available width and appends ellipsis at the end