### PR TITLE
Add support for control dry run with a `--dry-run` flag to check command to show which controls would be run. Closes #468

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -43,7 +43,8 @@ func CheckCmd() *cobra.Command {
 		AddStringFlag(constants.ArgTheme, "", "dark", "Color scheme").
 		AddBoolFlag(constants.ArgProgress, "", true, "Display control execution progress").
 		AddBoolFlag(constants.ArgQuiet, "", false, "Display only failed control results").
-		AddBoolFlag(constants.ArgColor, "", true, "Display control results in color")
+		AddBoolFlag(constants.ArgColor, "", true, "Display control results in color").
+		AddBoolFlag(constants.ArgDryRun, "", false, "Show which controls will be run without running them")
 
 	return cmd
 }

--- a/constants/args.go
+++ b/constants/args.go
@@ -28,6 +28,7 @@ const (
 	ArgProgress                = "progress"
 	ArgQuiet                   = "quiet"
 	ArgColor                   = "color"
+	ArgDryRun                  = "dry-run"
 )
 
 /// metaquery mode arguments

--- a/control/execute/control_run.go
+++ b/control/execute/control_run.go
@@ -53,6 +53,10 @@ func NewControlRun(control *modconfig.Control, group *ResultGroup, executionTree
 	}
 }
 
+func (r *ControlRun) Skip() {
+	r.setRunStatus(ControlRunComplete)
+}
+
 func (r *ControlRun) Start(ctx context.Context, client *db.Client) {
 	log.Printf("[TRACE] begin ControlRun.Start: %s\n", r.Control.Name())
 	defer log.Printf("[TRACE] end ControlRun.Start: %s\n", r.Control.Name())

--- a/control/execute/result_group.go
+++ b/control/execute/result_group.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"log"
 
+	"github.com/spf13/viper"
+	"github.com/turbot/steampipe/constants"
 	"github.com/turbot/steampipe/db"
 	"github.com/turbot/steampipe/steampipeconfig/modconfig"
 )
@@ -116,6 +118,9 @@ func (r *ResultGroup) Execute(ctx context.Context, client *db.Client) int {
 		case <-ctx.Done():
 			controlRun.SetError(ctx.Err())
 		default:
+		if viper.GetBool(constants.ArgDryRun) {
+			controlRun.Skip()
+		} else {
 			controlRun.Start(ctx, client)
 		}
 	}

--- a/control/execute/result_group.go
+++ b/control/execute/result_group.go
@@ -118,14 +118,15 @@ func (r *ResultGroup) Execute(ctx context.Context, client *db.Client) int {
 		case <-ctx.Done():
 			controlRun.SetError(ctx.Err())
 		default:
-		if viper.GetBool(constants.ArgDryRun) {
-			controlRun.Skip()
-		} else {
-			controlRun.Start(ctx, client)
+			if viper.GetBool(constants.ArgDryRun) {
+				controlRun.Skip()
+			} else {
+				controlRun.Start(ctx, client)
+			}
 		}
-	}
-	for _, child := range r.Groups {
-		errors += child.Execute(ctx, client)
+		for _, child := range r.Groups {
+			errors += child.Execute(ctx, client)
+		}
 	}
 	return errors
 }


### PR DESCRIPTION
![Screenshot](https://user-images.githubusercontent.com/1114038/118789757-b973de00-b8b2-11eb-9df3-209e690cccfe.png)
