### PR TITLE
Add support for inspection and autocomplete of Reflection tables. Closes #446

### DIFF
--- a/autocomplete/table.go
+++ b/autocomplete/table.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/c-bata/go-prompt"
 	"github.com/turbot/go-kit/helpers"
-	"github.com/turbot/steampipe/constants"
 	"github.com/turbot/steampipe/schema"
 	"github.com/turbot/steampipe/steampipeconfig"
 )
@@ -20,7 +19,7 @@ func GetTableAutoCompleteSuggestions(schema *schema.Metadata, connectionMap *ste
 	// schema names
 	var schemasToAdd []string
 	// unqualified table names - initialise to the reflection table names
-	unqualifiedTablesToAdd := constants.ReflectionTableNames()
+	unqualifiedTablesToAdd := []string{} // constants.ReflectionTableNames()
 	// fully qualified table names
 	var qualifiedTablesToAdd []string
 
@@ -28,6 +27,8 @@ func GetTableAutoCompleteSuggestions(schema *schema.Metadata, connectionMap *ste
 	pluginSchemaMap := map[string]bool{}
 
 	for schemaName, schemaDetails := range schema.Schemas {
+
+		isTemporarySchema := (schemaName == schema.TemporarySchemaName)
 
 		// when the `schema.Schemas` map is built, it is built from the configured connections and `public`
 		// all other schema are ignored. Refer to Client.loadSchema()
@@ -40,11 +41,16 @@ func GetTableAutoCompleteSuggestions(schema *schema.Metadata, connectionMap *ste
 		}
 
 		// add the schema into the list of schema
-		schemasToAdd = append(schemasToAdd, schemaName)
+
+		if !isTemporarySchema {
+			schemasToAdd = append(schemasToAdd, schemaName)
+		}
 
 		// add qualified names of all tables
 		for tableName := range schemaDetails {
-			qualifiedTablesToAdd = append(qualifiedTablesToAdd, fmt.Sprintf("%s.%s", schemaName, tableName))
+			if !isTemporarySchema {
+				qualifiedTablesToAdd = append(qualifiedTablesToAdd, fmt.Sprintf("%s.%s", schemaName, tableName))
+			}
 		}
 
 		// only add unqualified table name if the schema is in the search_path
@@ -52,10 +58,12 @@ func GetTableAutoCompleteSuggestions(schema *schema.Metadata, connectionMap *ste
 		schemaOfSamePluginIncluded := hasConnectionForSchema && pluginSchemaMap[pluginOfThisSchema]
 		foundInSearchPath := helpers.StringSliceContains(schema.SearchPath, schemaName)
 
-		if foundInSearchPath && !schemaOfSamePluginIncluded {
+		if (foundInSearchPath || isTemporarySchema) && !schemaOfSamePluginIncluded {
 			for tableName := range schemaDetails {
 				unqualifiedTablesToAdd = append(unqualifiedTablesToAdd, tableName)
-				pluginSchemaMap[pluginOfThisSchema] = true
+				if !isTemporarySchema {
+					pluginSchemaMap[pluginOfThisSchema] = true
+				}
 			}
 		}
 	}

--- a/autocomplete/table.go
+++ b/autocomplete/table.go
@@ -19,7 +19,7 @@ func GetTableAutoCompleteSuggestions(schema *schema.Metadata, connectionMap *ste
 	// schema names
 	var schemasToAdd []string
 	// unqualified table names - initialise to the reflection table names
-	unqualifiedTablesToAdd := []string{} // constants.ReflectionTableNames()
+	unqualifiedTablesToAdd := []string{}
 	// fully qualified table names
 	var qualifiedTablesToAdd []string
 

--- a/db/client.go
+++ b/db/client.go
@@ -183,11 +183,11 @@ func (c *Client) loadSchema() {
 
 	defer tablesResult.Close()
 
-	schemas, tempSchemaName, err := buildSchemaMetadata(tablesResult)
+	metadata, err := buildSchemaMetadata(tablesResult)
 	utils.FailOnError(err)
 
-	c.schemaMetadata.Schemas = schemas
-	c.schemaMetadata.TemporarySchemaName = tempSchemaName
+	c.schemaMetadata.Schemas = metadata.Schemas
+	c.schemaMetadata.TemporarySchemaName = metadata.TemporarySchemaName
 }
 
 func (c *Client) getSchemaFromDB() (*sql.Rows, error) {

--- a/db/client.go
+++ b/db/client.go
@@ -36,6 +36,10 @@ func NewClient(autoRefreshConnections bool) (*Client, error) {
 	}
 	client := new(Client)
 	client.dbClient = db
+
+	// setup a blank struct for the schema metadata
+	client.schemaMetadata = schema.NewMetadata()
+
 	client.loadSchema()
 
 	var updatedConnections bool
@@ -179,8 +183,11 @@ func (c *Client) loadSchema() {
 
 	defer tablesResult.Close()
 
-	c.schemaMetadata, err = buildSchemaMetadata(tablesResult)
+	schemas, tempSchemaName, err := buildSchemaMetadata(tablesResult)
 	utils.FailOnError(err)
+
+	c.schemaMetadata.Schemas = schemas
+	c.schemaMetadata.TemporarySchemaName = tempSchemaName
 }
 
 func (c *Client) getSchemaFromDB() (*sql.Rows, error) {
@@ -209,6 +216,8 @@ func (c *Client) getSchemaFromDB() (*sql.Rows, error) {
 			) 
 			OR
 			cols.table_schema = 'public'
+			OR
+			LEFT(cols.table_schema,8) = 'pg_temp_'
 		ORDER BY 
 			cols.table_schema, cols.table_name, cols.column_name;
 `

--- a/db/metadata_tables.go
+++ b/db/metadata_tables.go
@@ -46,6 +46,7 @@ func CreateMetadataTables(workspaceResources *modconfig.WorkspaceResourceMaps, c
 	if err != nil {
 		return fmt.Errorf("failed to create reflection tables: %v", err)
 	}
+	client.loadSchema()
 	return nil
 }
 

--- a/db/schema.go
+++ b/db/schema.go
@@ -20,10 +20,10 @@ type schemaRecord struct {
 	TableDescription  string
 }
 
-func buildSchemaMetadata(rows *sql.Rows) (map[string]map[string]schema.TableSchema, string, error) {
+func buildSchemaMetadata(rows *sql.Rows) (*schema.Metadata, error) {
 	records, err := getSchemaRecordsFromRows(rows)
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 	schemaMetadata := schema.NewMetadata()
 
@@ -55,7 +55,7 @@ func buildSchemaMetadata(rows *sql.Rows) (map[string]map[string]schema.TableSche
 		}
 	}
 
-	return schemaMetadata.Schemas, schemaMetadata.TemporarySchemaName, err
+	return schemaMetadata, err
 }
 
 func getSchemaRecordsFromRows(rows *sql.Rows) ([]schemaRecord, error) {

--- a/query/metaquery/handlers.go
+++ b/query/metaquery/handlers.go
@@ -192,6 +192,9 @@ func listTables(input *HandlerInput) error {
 	if len(input.args()) == 0 {
 		schemas := input.Schema.GetSchemas()
 		for _, schema := range schemas {
+			if schema == input.Schema.TemporarySchemaName {
+				continue
+			}
 			fmt.Printf(" ==> %s\n", schema)
 			inspectConnection(schema, input)
 		}
@@ -251,6 +254,9 @@ func inspect(input *HandlerInput) error {
 		if !schemaFound {
 			searchPath := input.Schema.SearchPath
 
+			// add the temporary schema to the search_path so that it becomes searchable
+			searchPath = append(searchPath, input.Schema.TemporarySchemaName)
+
 			// go through the searchPath one by one and try to find the table by this name
 			for _, schema := range searchPath {
 				tablesInThisSchema := input.Schema.GetTablesInSchema(schema)
@@ -278,6 +284,9 @@ func listConnections(input *HandlerInput) error {
 	rows := [][]string{}
 
 	for _, schema := range input.Schema.GetSchemas() {
+		if schema == input.Schema.TemporarySchemaName {
+			continue
+		}
 		plugin, found := (*input.Connections)[schema]
 		if found {
 			rows = append(rows, []string{schema, plugin.Plugin})

--- a/query/metaquery/handlers.go
+++ b/query/metaquery/handlers.go
@@ -252,9 +252,10 @@ func inspect(input *HandlerInput) error {
 
 		// there was no schema
 		if !schemaFound {
-			searchPath := input.Schema.SearchPath
+			searchPath, _ := input.Executor.GetCurrentSearchPath()
 
 			// add the temporary schema to the search_path so that it becomes searchable
+			// for the next step
 			searchPath = append(searchPath, input.Schema.TemporarySchemaName)
 
 			// go through the searchPath one by one and try to find the table by this name

--- a/schema/schema.go
+++ b/schema/schema.go
@@ -6,12 +6,22 @@ import (
 	"strings"
 )
 
+func NewMetadata() *Metadata {
+	return &Metadata{
+		Schemas:             map[string]map[string]TableSchema{},
+		SearchPath:          []string{},
+		TemporarySchemaName: "", // don't need this, adding for completeness
+	}
+}
+
 // Metadata :: struct to represent the schema of the database
 type Metadata struct {
-	// map {schemaname, {map tablename -> tableschema}}
+	// map {schemaname, {map {tablename -> tableschema}}
 	Schemas map[string]map[string]TableSchema
 	// the search path that is set in the backend
 	SearchPath []string
+	// the name of the temporary schema
+	TemporarySchemaName string
 }
 
 // TableSchema :: contains the details of a single table in the schema


### PR DESCRIPTION
`interactive` autocomplete has reflection tables as `unqualified` tables
![Screenshot 2021-05-20 at 6 01 02 PM](https://user-images.githubusercontent.com/1114038/118978835-69ba1300-b995-11eb-904e-abe94c47f37b.png)

`.inspect <reflection_table_name>` shows the relevant table:
![Screenshot 2021-05-20 at 6 01 56 PM](https://user-images.githubusercontent.com/1114038/118978915-85251e00-b995-11eb-990b-d75a8cc2dedf.png)

`.inspect` without arguments does not show the `temp` schema:
![Screenshot 2021-05-20 at 6 03 29 PM](https://user-images.githubusercontent.com/1114038/118979140-c9b0b980-b995-11eb-9d36-141404e6ffe2.png)
