### PR TITLE
Fix: generated file names in `check` `export`s should not have colons. Closes #542

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -259,5 +259,5 @@ func getExportFormats(executing string) []controldisplay.CheckExportFormat {
 }
 
 func generateDefaultExportFileName(format string, executing string) string {
-	return fmt.Sprintf("%s-%s.%s", executing, time.Now().UTC().Format(time.RFC3339), format)
+	return fmt.Sprintf("%s-%s.%s", executing, time.Now().UTC().Format("20060102150405Z"), format)
 }


### PR DESCRIPTION
New file name format for `steampipe check all --export csv --output=none` is `all-20210616095005Z.csv`
