### PR TITLE
Add support to filter controls with `--tag` argument to `check`. Closes #539

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -9,14 +9,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/turbot/steampipe/control/controldisplay"
-	"github.com/turbot/steampipe/control/execute"
-
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/control/controldisplay"
+	"github.com/turbot/steampipe/control/execute"
 	"github.com/turbot/steampipe/db"
 	"github.com/turbot/steampipe/utils"
 	"github.com/turbot/steampipe/workspace"
@@ -64,7 +63,8 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 		AddStringFlag(constants.ArgTheme, "", "dark", "Set the output theme, which determines the color scheme for the 'text' control output. Possible values are light, dark, plain").
 		AddStringSliceFlag(constants.ArgExport, "", []string{}, "Export output to files").
 		AddBoolFlag(constants.ArgProgress, "", true, "Display control execution progress").
-		AddBoolFlag(constants.ArgDryRun, "", false, "Show which controls will be run without running them")
+		AddBoolFlag(constants.ArgDryRun, "", false, "Show which controls will be run without running them").
+		AddStringFlag(constants.ArgWhere, "", "", "SQL 'where' clause , or named query, used to filter controls ")
 
 	return cmd
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -64,7 +64,8 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 		AddStringSliceFlag(constants.ArgExport, "", []string{}, "Export output to files").
 		AddBoolFlag(constants.ArgProgress, "", true, "Display control execution progress").
 		AddBoolFlag(constants.ArgDryRun, "", false, "Show which controls will be run without running them").
-		AddStringFlag(constants.ArgWhere, "", "", "SQL 'where' clause , or named query, used to filter controls ")
+		AddStringFlag(constants.ArgWhere, "", "", "SQL 'where' clause , or named query, used to filter controls ").
+		AddStringSliceFlag(constants.ArgTag, "", []string{}, "Key value pairs of tags for filter (### needs thought ###)")
 
 	return cmd
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -65,7 +65,7 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 		AddBoolFlag(constants.ArgProgress, "", true, "Display control execution progress").
 		AddBoolFlag(constants.ArgDryRun, "", false, "Show which controls will be run without running them").
 		AddStringFlag(constants.ArgWhere, "", "", "SQL 'where' clause , or named query, used to filter controls ").
-		AddStringSliceFlag(constants.ArgTag, "", []string{}, "Key value pairs of tags for filter (### needs thought ###)")
+		AddStringSliceFlag(constants.ArgFilterTag, "", []string{}, "Key value pairs of tags for filter (### needs thought ###)")
 
 	return cmd
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -65,7 +65,7 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 		AddBoolFlag(constants.ArgProgress, "", true, "Display control execution progress").
 		AddBoolFlag(constants.ArgDryRun, "", false, "Show which controls will be run without running them").
 		AddStringFlag(constants.ArgWhere, "", "", "SQL 'where' clause , or named query, used to filter controls ").
-		AddStringSliceFlag(constants.ArgFilterTag, "", []string{}, "Key value pairs of tags for filter (### needs thought ###)")
+		AddStringSliceFlag(constants.ArgTag, "", []string{}, "Key value pairs of tags for filter (### needs thought ###)")
 
 	return cmd
 }

--- a/constants/args.go
+++ b/constants/args.go
@@ -26,6 +26,7 @@ const (
 	ArgProgress                = "progress"
 	ArgExport                  = "export"
 	ArgDryRun                  = "dry-run"
+	ArgWhere                   = "where"
 )
 
 /// metaquery mode arguments

--- a/constants/args.go
+++ b/constants/args.go
@@ -27,6 +27,7 @@ const (
 	ArgExport                  = "export"
 	ArgDryRun                  = "dry-run"
 	ArgWhere                   = "where"
+	ArgTag                     = "tag"
 )
 
 /// metaquery mode arguments

--- a/constants/args.go
+++ b/constants/args.go
@@ -27,7 +27,7 @@ const (
 	ArgExport                  = "export"
 	ArgDryRun                  = "dry-run"
 	ArgWhere                   = "where"
-	ArgFilterTag               = "filter-tag"
+	ArgTag                     = "tag"
 )
 
 /// metaquery mode arguments

--- a/constants/args.go
+++ b/constants/args.go
@@ -27,7 +27,7 @@ const (
 	ArgExport                  = "export"
 	ArgDryRun                  = "dry-run"
 	ArgWhere                   = "where"
-	ArgTag                     = "tag"
+	ArgFilterTag               = "filter-tag"
 )
 
 /// metaquery mode arguments

--- a/control/controldisplay/formatter_csv.go
+++ b/control/controldisplay/formatter_csv.go
@@ -27,5 +27,6 @@ func (j *CSVFormatter) Format(_ context.Context, tree *execute.ExecutionTree) (i
 
 	j.csvWriter.Write(resultColumns.AllColumns)
 	j.csvWriter.WriteAll(data)
-	return strings.NewReader(outBuffer.String()), nil
+	res := strings.NewReader(outBuffer.String())
+	return res, nil
 }

--- a/control/controldisplay/formatter_json.go
+++ b/control/controldisplay/formatter_json.go
@@ -16,5 +16,6 @@ func (j *JSONFormatter) Format(ctx context.Context, tree *execute.ExecutionTree)
 	if err != nil {
 		return nil, err
 	}
-	return strings.NewReader(string(bytes)), nil
+	res := strings.NewReader(string(bytes))
+	return res, nil
 }

--- a/control/controldisplay/formatter_text.go
+++ b/control/controldisplay/formatter_text.go
@@ -10,15 +10,16 @@ import (
 	"github.com/turbot/steampipe/control/execute"
 )
 
-const UsableMaxCols = 200
+// limit text width
+const maxCols = 200
 
 type TextFormatter struct{}
 
 func (j *TextFormatter) Format(ctx context.Context, tree *execute.ExecutionTree) (io.Reader, error) {
-	// limit to 200
-	maxCols := j.getMaxCols(UsableMaxCols)
-	renderer := NewTableRenderer(tree, maxCols)
-	return (strings.NewReader(fmt.Sprintf("\n%s\n", renderer.Render()))), nil
+	maxCols := j.getMaxCols(maxCols)
+	renderedText := NewTableRenderer(tree, maxCols).Render()
+	res := strings.NewReader(fmt.Sprintf("\n%s\n", renderedText))
+	return res, nil
 }
 
 func (j *TextFormatter) getMaxCols(limitCol int) int {

--- a/control/controldisplay/group.go
+++ b/control/controldisplay/group.go
@@ -46,14 +46,15 @@ func (r GroupRenderer) isLastChild(group *execute.ResultGroup) bool {
 		if b, ok := s.(*modconfig.Benchmark); ok {
 			// find the result group for this benchmark and see if it has controls
 			resultGroup := r.resultTree.Root.GetChildGroupByName(b.Name())
-			if resultGroup != nil && resultGroup.ControlRunCount() == 0 {
+			// if the result group has not controls, we will not find it in the result tree
+			if resultGroup == nil || resultGroup.ControlRunCount() == 0 {
 				continue
 			}
 		}
-		// sibling is a control - add
+		// store the name of this sibling
 		finalSiblingName = s.Name()
-
 	}
+
 	res := group.GroupItem.Name() == finalSiblingName
 
 	return res

--- a/control/execute/execution_tree.go
+++ b/control/execute/execution_tree.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"net/url"
+	"os"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -118,12 +119,19 @@ func (e *ExecutionTree) populateControlFilterMap(ctx context.Context) error {
 		for key, values := range whereMap {
 			thisComponent := []string{}
 			for _, x := range values {
+				if len(x) == 0 {
+					// ignore
+					continue
+				}
 				thisComponent = append(thisComponent, fmt.Sprintf("tags->>'%s'='%s'", key, x))
 			}
 			whereComponents = append(whereComponents, fmt.Sprintf("(%s)", strings.Join(thisComponent, " OR ")))
 		}
 
 		controlFilterWhereClause = strings.Join(whereComponents, " AND ")
+
+		fmt.Println(controlFilterWhereClause)
+		os.Exit(0)
 
 	} else if viper.IsSet(constants.ArgWhere) {
 		// if a 'where' arg was used, execute this sql to get a list of  control names

--- a/control/execute/execution_tree.go
+++ b/control/execute/execution_tree.go
@@ -91,7 +91,7 @@ func (e *ExecutionTree) Execute(ctx context.Context, client *db.Client) int {
 
 func (e *ExecutionTree) populateControlFilterMap(ctx context.Context) error {
 
-	// if both '--where' and '--tag' have been used, then it's an error
+	// if both '--where' and '--filter-tag' have been used, then it's an error
 	if viper.IsSet(constants.ArgWhere) && viper.IsSet(constants.ArgFilterTag) {
 		return fmt.Errorf("'--%s' and '--%s' cannot be used together", constants.ArgWhere, constants.ArgFilterTag)
 	}
@@ -99,7 +99,7 @@ func (e *ExecutionTree) populateControlFilterMap(ctx context.Context) error {
 	controlFilterWhereClause := ""
 
 	if viper.IsSet(constants.ArgFilterTag) {
-		// if '--tags' were used, derive the whereClause from ut
+		// if '--filter-tag' were used, derive the whereClause from ut
 		tags := viper.GetStringSlice(constants.ArgFilterTag)
 		controlFilterWhereClause = e.generateWhereClauseFromTags(tags)
 	} else if viper.IsSet(constants.ArgWhere) {

--- a/control/execute/execution_tree.go
+++ b/control/execute/execution_tree.go
@@ -90,17 +90,16 @@ func (e *ExecutionTree) Execute(ctx context.Context, client *db.Client) int {
 }
 
 func (e *ExecutionTree) populateControlFilterMap(ctx context.Context) error {
-
-	// if both '--where' and '--filter-tag' have been used, then it's an error
-	if viper.IsSet(constants.ArgWhere) && viper.IsSet(constants.ArgFilterTag) {
-		return fmt.Errorf("'--%s' and '--%s' cannot be used together", constants.ArgWhere, constants.ArgFilterTag)
+	// if both '--where' and '--tag' have been used, then it's an error
+	if viper.IsSet(constants.ArgWhere) && viper.IsSet(constants.ArgTag) {
+		return fmt.Errorf("'--%s' and '--%s' cannot be used together", constants.ArgWhere, constants.ArgTag)
 	}
 
 	controlFilterWhereClause := ""
 
-	if viper.IsSet(constants.ArgFilterTag) {
-		// if '--filter-tag' were used, derive the whereClause from ut
-		tags := viper.GetStringSlice(constants.ArgFilterTag)
+	if viper.IsSet(constants.ArgTag) {
+		// if '--tag' args were used, derive the whereClause from them
+		tags := viper.GetStringSlice(constants.ArgTag)
 		controlFilterWhereClause = e.generateWhereClauseFromTags(tags)
 	} else if viper.IsSet(constants.ArgWhere) {
 		// if a 'where' arg was used, execute this sql to get a list of  control names

--- a/control/execute/execution_tree.go
+++ b/control/execute/execution_tree.go
@@ -2,7 +2,6 @@ package execute
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"net/url"
@@ -93,15 +92,15 @@ func (e *ExecutionTree) Execute(ctx context.Context, client *db.Client) int {
 func (e *ExecutionTree) populateControlFilterMap(ctx context.Context) error {
 
 	// if both `--where` and `--tag` have been used, then it's an error
-	if viper.IsSet(constants.ArgWhere) && viper.IsSet(constants.ArgTag) {
-		return errors.New("`--where` and `--tag` cannot be used together")
+	if viper.IsSet(constants.ArgWhere) && viper.IsSet(constants.ArgFilterTag) {
+		return fmt.Errorf("`--%s` and `--%s` cannot be used together", constants.ArgWhere, constants.ArgFilterTag)
 	}
 
 	controlFilterWhereClause := ""
 
-	if viper.IsSet(constants.ArgTag) {
+	if viper.IsSet(constants.ArgFilterTag) {
 		// if `--tags` were used, derive the whereClause from ut
-		tags := viper.GetStringSlice(constants.ArgTag)
+		tags := viper.GetStringSlice(constants.ArgFilterTag)
 		controlFilterWhereClause = e.generateWhereClauseFromTags(tags)
 	} else if viper.IsSet(constants.ArgWhere) {
 		// if a 'where' arg was used, execute this sql to get a list of  control names

--- a/control/execute/execution_tree.go
+++ b/control/execute/execution_tree.go
@@ -91,15 +91,15 @@ func (e *ExecutionTree) Execute(ctx context.Context, client *db.Client) int {
 
 func (e *ExecutionTree) populateControlFilterMap(ctx context.Context) error {
 
-	// if both `--where` and `--tag` have been used, then it's an error
+	// if both '--where' and '--tag' have been used, then it's an error
 	if viper.IsSet(constants.ArgWhere) && viper.IsSet(constants.ArgFilterTag) {
-		return fmt.Errorf("`--%s` and `--%s` cannot be used together", constants.ArgWhere, constants.ArgFilterTag)
+		return fmt.Errorf("'--%s' and '--%s' cannot be used together", constants.ArgWhere, constants.ArgFilterTag)
 	}
 
 	controlFilterWhereClause := ""
 
 	if viper.IsSet(constants.ArgFilterTag) {
-		// if `--tags` were used, derive the whereClause from ut
+		// if '--tags' were used, derive the whereClause from ut
 		tags := viper.GetStringSlice(constants.ArgFilterTag)
 		controlFilterWhereClause = e.generateWhereClauseFromTags(tags)
 	} else if viper.IsSet(constants.ArgWhere) {
@@ -124,7 +124,7 @@ func (e *ExecutionTree) populateControlFilterMap(ctx context.Context) error {
 func (e *ExecutionTree) generateWhereClauseFromTags(tags []string) string {
 	whereMap := map[string][]string{}
 
-	// `tags` should be KV Pairs of the form: `benchmark=pic` or `cis_level=1`
+	// 'tags' should be KV Pairs of the form: 'benchmark=pic' or 'cis_level=1'
 	for _, tag := range tags {
 		value, _ := url.ParseQuery(tag)
 		for k, v := range value {
@@ -203,7 +203,7 @@ func (e *ExecutionTree) getExecutionRootFromArg(arg string) ([]modconfig.Control
 }
 
 // Get a map of control names from the reflection table steampipe_control
-// This is used to implement the `where` control filtering
+// This is used to implement the 'where' control filtering
 func (e *ExecutionTree) getControlMapFromMetadataQuery(ctx context.Context, whereClause string) (map[string]bool, error) {
 	// query may either be a 'where' clause, or a named query
 	query, isNamedQuery := execute.GetQueryFromArg(whereClause, e.workspace)


### PR DESCRIPTION
The feature `AND`s between different tag keys and `OR` between same tag keys

Example:
`--tag key1=1 --tag key2=2 --tag key3=5 --tag key1=4` 
will generate the clause 
`(tags->>'key1'='1' OR tags->>'key1'='4') AND (tags->>'key2'='2') AND (tags->>'key3'='5')`

`--tag key1=1 --tag key2=2 --tag key3=5 --tag "key1=4;key5=6"` and ` --tag key1=1 --tag key2=2 --tag key3=5 --tag "key1=4&key5=6"`
will generate:
(tags->>'key2'='2') AND (tags->>'key3'='5') AND (tags->>'key5'='6') AND (tags->>'key1'='1' OR tags->>'key1'='4')



Each `--tag` value is expected to be a list of `key=value` settings separated by `ampersands` or `semicolons`. A setting without an equals sign is interpreted as a key set to an empty value and is ignored.