### PR TITLE
Support for `--header` flag in `check`. Closes #550

### DIFF
--- a/control/controldisplay/formatter_csv.go
+++ b/control/controldisplay/formatter_csv.go
@@ -25,7 +25,9 @@ func (j *CSVFormatter) Format(_ context.Context, tree *execute.ExecutionTree) (i
 	j.csvWriter = csv.NewWriter(outBuffer)
 	j.csvWriter.Comma = []rune(viper.GetString(constants.ArgSeparator))[0]
 
-	j.csvWriter.Write(resultColumns.AllColumns)
+	if viper.GetBool(constants.ArgHeader) {
+		j.csvWriter.Write(resultColumns.AllColumns)
+	}
 	j.csvWriter.WriteAll(data)
 	res := strings.NewReader(outBuffer.String())
 	return res, nil

--- a/tests/acceptance/test_data/templates/expected_check_csv_noheader.csv
+++ b/tests/acceptance/test_data/templates/expected_check_csv_noheader.csv
@@ -1,0 +1,55 @@
+benchmark.cis_v130_1,1 Identity and Access Management,,is pretty insecure,some other resource,alarm,,,,cis,,6.3,v7.1,1.1,,1,1,manual,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is pretty insecure,some other resource,alarm,,,,cis,,"19,19.2",v7.1,1.2,,1,1,manual,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16,v7.1,1.3,,1,1,manual,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,4.3,v7.1,1.4,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is pretty insecure,some other resource,alarm,,,,cis,,4.5,v7.1,1.5,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is in some sort of error state,some messed up resource,error,,,,cis,,4.5,v7.1,1.6,,2,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,4.3,v7.1,1.7,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16,v7.1,1.8,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,4.4,v7.1,1.9,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,4.5,v7.1,1.10,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16,v7.1,1.11,,1,1,manual,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16.9,v7.1,1.12,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,4,v7.1,1.13,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16,v7.1,1.14,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is pretty insecure,some other resource,alarm,,,,cis,,16,v7.1,1.15,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,4,v7.1,1.16,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,14,v7.1,1.17,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,19,v7.1,1.18,,2,1,manual,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,13,v7.1,1.19,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,14.6,v7.1,1.20,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is pretty insecure,some other resource,alarm,,,,cis,,14.6,v7.1,1.21,,1,1,automated,v1.3.0,aws
+benchmark.cis_v130_1,1 Identity and Access Management,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16.2,v7.1,1.22,,2,1,manual,v1.3.0,aws
+benchmark.cis_v130_2_1,2.1 Simple Storage Service (S3),,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,14.8,v7.1,2.1.1,,"1,2",2.1,manual,v1.3.0,aws
+benchmark.cis_v130_2_1,2.1 Simple Storage Service (S3),,"just some info, thought you should know",resource name,info,,,,cis,,14.8,v7.1,2.1.2,,"1,2",2.1,manual,v1.3.0,aws
+benchmark.cis_v130_2_2,2.2 Elastic Compute Cloud (EC2),,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,14.8,v7.1,2.2.1,,"1,2",2.2,manual,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,6.2,v7.1,3.1,,1,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,6,v7.1,3.2,,2,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,14.6,v7.1,3.3,,1,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,6.2,,v7.1,3.4,1,,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,"1.4,11.2,16.1",,v7.1,3.5,1,,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,"6.2,14.9",,v7.1,3.6,1,,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,6,,v7.1,3.7,2,,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,6,,v7.1,3.8,2,,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,"6.2,12.5",,v7.1,3.9,2,,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,"6.2,6.3",,v7.1,3.10,2,,3,automated,v1.3.0,aws
+benchmark.cis_v130_3,3 Logging,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,"6.2,6.3",,v7.1,3.11,2,,3,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,"6.5,6.7",v7.1,4.1,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16,v7.1,4.2,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,"just some info, thought you should know",resource name,info,,,,cis,,4.9,v7.1,4.3,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16,v7.1,4.4,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,6,v7.1,4.5,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,"just some info, thought you should know",resource name,info,,,,cis,,16,v7.1,4.6,,2,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,16,v7.1,4.7,,2,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,"6.2,14",v7.1,4.8,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,totally skipping this one,resource name,skip,,,,cis,,"1.4,11.2,16.1",v7.1,4.9,,2,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,"6.2,14.6",v7.1,4.10,,2,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,11.3,v7.1,4.11,,2,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,"6.2,11.3",v7.1,4.12,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,"6.2,11.3",v7.1,4.13,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,totally skipping this one,resource name,skip,,,,cis,,5.5,v7.1,4.14,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_4,4 Monitoring,,is totally secure and this is qa very very very very very long reason,resource name,ok,,,,cis,,"6.2,14.6",v7.1,4.15,,1,4,automated,v1.3.0,aws
+benchmark.cis_v130_5,5 Networking,,is pretty insecure,some other resource,alarm,,,,cis,,"9.2,12.4",v7.1,5.1,,1,5,automated,v1.3.0,aws
+benchmark.cis_v130_5,5 Networking,,is pretty insecure,some other resource,alarm,,,,cis,,"9.2,12.4",v7.1,5.2,,1,5,automated,v1.3.0,aws
+benchmark.cis_v130_5,5 Networking,,is pretty insecure,some other resource,alarm,,,,cis,,14.6,v7.1,5.3,,1,5,automated,v1.3.0,aws
+benchmark.cis_v130_5,5 Networking,,is pretty insecure,some other resource,alarm,,,,cis,,14.6,v7.1,5.4,,1,5,manual,v1.3.0,aws

--- a/tests/acceptance/test_files/008.check.bats
+++ b/tests/acceptance/test_files/008.check.bats
@@ -22,6 +22,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cd -
 }
 
+@test "steampipe check all - output csv - no header" {
+  cd $WORKSPACE_DIR
+  run steampipe check all --output=csv --progress=false --header=false
+  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_check_csv_noheader.csv)"
+  cd -
+}
+
 @test "steampipe check all - output json" {
   cd $WORKSPACE_DIR
   run steampipe check all --output=json --progress=false


### PR DESCRIPTION
with `--output=csv` or `--export=csv`, the `--header` is used to decide whether to output the header row to the `csv`