### PR TITLE
Use custom postgres escape token to avoid chance of clash with the escaped text. Closes #554

### DIFF
--- a/db/postgres.go
+++ b/db/postgres.go
@@ -6,6 +6,9 @@ func PgEscapeName(name string) string {
 	return fmt.Sprintf(`"%s"`, name)
 }
 
+// PgEscapeString escapes strings which are to be inserted
+// use a custom escape tag to avoid chance of clash with the escaped text
+// https://medium.com/@lnishada/postgres-dollar-quoting-6d23e4f186ec
 func PgEscapeString(str string) string {
-	return fmt.Sprintf(`$$%s$$`, str)
+	return fmt.Sprintf(`$steampipe_escape$%s$steampipe_escape$`, str)
 }


### PR DESCRIPTION
…