### PR TITLE
Fix issue where using `--timing` with `check` was not showing duration. Fixes #571

### DIFF
--- a/control/execute/control_run.go
+++ b/control/execute/control_run.go
@@ -42,6 +42,7 @@ type ControlRun struct {
 	Tags        map[string]string `json:"tags"`
 	Title       string            `json:"title"`
 	Rows        []*ResultRow      `json:"results"`
+	Duration    time.Duration     `json:"duration"`
 
 	// the query result stream
 	queryResult *queryresult.Result
@@ -79,6 +80,8 @@ func (r *ControlRun) Skip() {
 func (r *ControlRun) Start(ctx context.Context, client *db.Client) {
 	log.Printf("[TRACE] begin ControlRun.Start: %s\n", r.Control.Name())
 	defer log.Printf("[TRACE] end ControlRun.Start: %s\n", r.Control.Name())
+
+	startTime := time.Now()
 
 	r.runStatus = ControlRunStarted
 
@@ -141,6 +144,7 @@ func (r *ControlRun) Start(ctx context.Context, client *db.Client) {
 			viper.Set(constants.ArgSearchPathPrefix, originalConfiguredSearchPathPrefix)
 			client.SetClientSearchPath()
 		}
+		r.Duration = time.Since(startTime)
 		close(gatherDoneChan)
 	}()
 

--- a/control/execute/control_run.go
+++ b/control/execute/control_run.go
@@ -35,6 +35,9 @@ type ControlRun struct {
 	Control *modconfig.Control `json:"-"`
 	Summary StatusSummary      `json:"-"`
 
+	// execution duration
+	Duration time.Duration `json:"-"`
+
 	// the result
 	ControlId   string            `json:"control_id"`
 	Description string            `json:"description"`
@@ -42,7 +45,6 @@ type ControlRun struct {
 	Tags        map[string]string `json:"tags"`
 	Title       string            `json:"title"`
 	Rows        []*ResultRow      `json:"results"`
-	Duration    time.Duration     `json:"duration"`
 
 	// the query result stream
 	queryResult *queryresult.Result
@@ -144,7 +146,6 @@ func (r *ControlRun) Start(ctx context.Context, client *db.Client) {
 			viper.Set(constants.ArgSearchPathPrefix, originalConfiguredSearchPathPrefix)
 			client.SetClientSearchPath()
 		}
-		r.Duration = time.Since(startTime)
 		close(gatherDoneChan)
 	}()
 
@@ -154,6 +155,7 @@ func (r *ControlRun) Start(ctx context.Context, client *db.Client) {
 	case <-gatherDoneChan:
 		// do nothing
 	}
+	r.Duration = time.Since(startTime)
 }
 
 func (r *ControlRun) gatherResults() {

--- a/control/execute/result_group.go
+++ b/control/execute/result_group.go
@@ -26,7 +26,7 @@ type ResultGroup struct {
 	// the control tree item associated with this group(i.e. a mod/benchmark)
 	GroupItem modconfig.ControlTreeItem `json:"-"`
 	Parent    *ResultGroup              `json:"-"`
-	Duration  time.Duration             `json:"duration"`
+	Duration  time.Duration             `json:"-"`
 }
 
 type GroupSummary struct {


### PR DESCRIPTION
Sample output:
```
binaeksarkar@Binaeks-MacBook-Pro sample_workspace % steampipe check all --timing --output brief          

.
.
.
      
Timing:
+-----+-------------+
|     | Duration    |
+-----+-------------+
| all | 93.834928ms |
+-----+-------------+
binaeksarkar@Binaeks-MacBook-Pro sample_workspace % 
```