### PR TITLE
Fixes issue where `initdb` fails because of missing permissions and users. Closes #634

### DIFF
--- a/db/client.go
+++ b/db/client.go
@@ -33,7 +33,7 @@ func NewClient() (*Client, error) {
 	utils.LogTime("db.NewClient start")
 	defer utils.LogTime("db.NewClient end")
 
-	db, err := createSteampipeUserClient()
+	db, err := createSteampipeSteampipeClient()
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *Client) RefreshConnectionAndSearchPaths() *RefreshConnectionResult {
 	return res
 }
 
-func createSteampipeUserClient() (*sql.DB, error) {
+func createSteampipeSteampipeClient() (*sql.DB, error) {
 	utils.LogTime("db.createSteampipeDbClient start")
 	defer utils.LogTime("db.createSteampipeDbClient end")
 
@@ -88,7 +88,7 @@ func createSteampipeUserClient() (*sql.DB, error) {
 // close and reopen db client
 func (c *Client) refreshDbClient() error {
 	c.dbClient.Close()
-	db, err := createSteampipeUserClient()
+	db, err := createSteampipeSteampipeClient()
 	if err != nil {
 		return err
 	}
@@ -96,7 +96,7 @@ func (c *Client) refreshDbClient() error {
 	return nil
 }
 
-func createSteampipeRootDbClient() (*sql.DB, error) {
+func createSteampipeRootClient() (*sql.DB, error) {
 	utils.LogTime("db.createSteampipeRootDbClient start")
 	defer utils.LogTime("db.createSteampipeRootDbClient end")
 
@@ -151,7 +151,7 @@ func createDbClient(dbname string, username string) (*sql.DB, error) {
 
 func executeSqlAsRoot(statements []string) ([]sql.Result, error) {
 	var results []sql.Result
-	rootClient, err := createSteampipeRootDbClient()
+	rootClient, err := createSteampipeRootClient()
 	if err != nil {
 		return nil, err
 	}

--- a/db/client.go
+++ b/db/client.go
@@ -33,7 +33,7 @@ func NewClient() (*Client, error) {
 	utils.LogTime("db.NewClient start")
 	defer utils.LogTime("db.NewClient end")
 
-	db, err := createSteampipeSteampipeClient()
+	db, err := createSteampipeDbClient()
 	if err != nil {
 		return nil, err
 	}
@@ -78,17 +78,10 @@ func (c *Client) RefreshConnectionAndSearchPaths() *RefreshConnectionResult {
 	return res
 }
 
-func createSteampipeSteampipeClient() (*sql.DB, error) {
-	utils.LogTime("db.createSteampipeDbClient start")
-	defer utils.LogTime("db.createSteampipeDbClient end")
-
-	return createDbClient(constants.DatabaseName, constants.DatabaseUser)
-}
-
 // close and reopen db client
 func (c *Client) refreshDbClient() error {
 	c.dbClient.Close()
-	db, err := createSteampipeSteampipeClient()
+	db, err := createSteampipeDbClient()
 	if err != nil {
 		return err
 	}
@@ -96,18 +89,18 @@ func (c *Client) refreshDbClient() error {
 	return nil
 }
 
-func createSteampipeRootClient() (*sql.DB, error) {
+func createSteampipeDbClient() (*sql.DB, error) {
+	utils.LogTime("db.createSteampipeDbClient start")
+	defer utils.LogTime("db.createSteampipeDbClient end")
+
+	return createDbClient(constants.DatabaseName, constants.DatabaseUser)
+}
+
+func createRootDbClient() (*sql.DB, error) {
 	utils.LogTime("db.createSteampipeRootDbClient start")
 	defer utils.LogTime("db.createSteampipeRootDbClient end")
 
 	return createDbClient(constants.DatabaseName, constants.DatabaseSuperUser)
-}
-
-func createPostgresRootClient() (*sql.DB, error) {
-	utils.LogTime("db.createPostgresDbClient start")
-	defer utils.LogTime("db.createPostgresDbClient end")
-
-	return createDbClient("postgres", constants.DatabaseSuperUser)
 }
 
 func createDbClient(dbname string, username string) (*sql.DB, error) {
@@ -151,7 +144,7 @@ func createDbClient(dbname string, username string) (*sql.DB, error) {
 
 func executeSqlAsRoot(statements []string) ([]sql.Result, error) {
 	var results []sql.Result
-	rootClient, err := createSteampipeRootClient()
+	rootClient, err := createRootDbClient()
 	if err != nil {
 		return nil, err
 	}

--- a/db/client.go
+++ b/db/client.go
@@ -33,7 +33,7 @@ func NewClient() (*Client, error) {
 	utils.LogTime("db.NewClient start")
 	defer utils.LogTime("db.NewClient end")
 
-	db, err := createSteampipeDbClient()
+	db, err := createSteampipeUserClient()
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func (c *Client) RefreshConnectionAndSearchPaths() *RefreshConnectionResult {
 	return res
 }
 
-func createSteampipeDbClient() (*sql.DB, error) {
+func createSteampipeUserClient() (*sql.DB, error) {
 	utils.LogTime("db.createSteampipeDbClient start")
 	defer utils.LogTime("db.createSteampipeDbClient end")
 
@@ -88,7 +88,7 @@ func createSteampipeDbClient() (*sql.DB, error) {
 // close and reopen db client
 func (c *Client) refreshDbClient() error {
 	c.dbClient.Close()
-	db, err := createSteampipeDbClient()
+	db, err := createSteampipeUserClient()
 	if err != nil {
 		return err
 	}
@@ -97,15 +97,22 @@ func (c *Client) refreshDbClient() error {
 }
 
 func createSteampipeRootDbClient() (*sql.DB, error) {
+	utils.LogTime("db.createSteampipeRootDbClient start")
+	defer utils.LogTime("db.createSteampipeRootDbClient end")
+
 	return createDbClient(constants.DatabaseName, constants.DatabaseSuperUser)
 }
 
-func createPostgresDbClient() (*sql.DB, error) {
+func createPostgresRootClient() (*sql.DB, error) {
+	utils.LogTime("db.createPostgresDbClient start")
+	defer utils.LogTime("db.createPostgresDbClient end")
+
 	return createDbClient("postgres", constants.DatabaseSuperUser)
 }
 
 func createDbClient(dbname string, username string) (*sql.DB, error) {
 	utils.LogTime("db.createDbClient start")
+	utils.LogTime(fmt.Sprintf("to %s with %s", dbname, username))
 	defer utils.LogTime("db.createDbClient end")
 
 	log.Println("[TRACE] createDbClient")

--- a/db/install.go
+++ b/db/install.go
@@ -196,20 +196,11 @@ func doInit(firstInstall bool, spinner *spinner.Spinner) error {
 	}
 
 	display.UpdateSpinnerMessage(spinner, "Starting database...")
-
-	// start service, but do not refresh connections as there is no need
-	//
-	// We cannot check for errors when starting Implicit service here
-	// since Start will error out when trying to connect with the `steampipe` user
-	// and ensuring the `steampipe_hub` server
-	//
-	// These do not exist yet and the service is being started to create these
-	// in the first place
-	//
-	// Ideally, this should just start the postgres process and not run the checks
-	// when starting it
-	//
-	StartImplicitService(InvokerInstaller, false)
+	err = startPostgresProcess(constants.DatabaseDefaultPort, ListenTypeLocal, InvokerInstaller)
+	if err != nil {
+		display.StopSpinner(spinner)
+		utils.FailOnErrorWithMessage(err, "x Starting database... FAILED!")
+	}
 
 	display.UpdateSpinnerMessage(spinner, "Configuring database...")
 	err = installSteampipeDatabaseAndUser(steampipePassword, rootPassword)

--- a/db/install.go
+++ b/db/install.go
@@ -260,7 +260,7 @@ func installSteampipeDatabaseAndUser(steampipePassword string, rootPassword stri
 	utils.LogTime("db.installSteampipeDatabase start")
 	defer utils.LogTime("db.installSteampipeDatabase end")
 
-	rawClient, err := createPostgresRootClient()
+	rawClient, err := createDbClient("postgres", constants.DatabaseSuperUser)
 	if err != nil {
 		return err
 	}

--- a/db/start_database.go
+++ b/db/start_database.go
@@ -279,7 +279,7 @@ func StartDB(port int, listen StartListenType, invoker Invoker, refreshConnectio
 // ensures that the `steampipe` fdw server exists
 // checks for it - (re)install FDW and creates server if it doesn't
 func ensureSteampipeServer() error {
-	rootClient, err := createSteampipeRootClient()
+	rootClient, err := createRootDbClient()
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func ensureSteampipeServer() error {
 // ensures that the `steampipe_users` role has permissions to work with temporary tables
 // this is done during database installation, but we need to migrate current installations
 func ensureTempTablePermissions() error {
-	rootClient, err := createSteampipeRootClient()
+	rootClient, err := createRootDbClient()
 	if err != nil {
 		return err
 	}

--- a/db/start_database.go
+++ b/db/start_database.go
@@ -279,7 +279,7 @@ func StartDB(port int, listen StartListenType, invoker Invoker, refreshConnectio
 // ensures that the `steampipe` fdw server exists
 // checks for it - (re)install FDW and creates server if it doesn't
 func ensureSteampipeServer() error {
-	rootClient, err := createSteampipeRootDbClient()
+	rootClient, err := createSteampipeRootClient()
 	if err != nil {
 		return err
 	}
@@ -297,7 +297,7 @@ func ensureSteampipeServer() error {
 // ensures that the `steampipe_users` role has permissions to work with temporary tables
 // this is done during database installation, but we need to migrate current installations
 func ensureTempTablePermissions() error {
-	rootClient, err := createSteampipeRootDbClient()
+	rootClient, err := createSteampipeRootClient()
 	if err != nil {
 		return err
 	}

--- a/db/start_database.go
+++ b/db/start_database.go
@@ -2,7 +2,6 @@ package db
 
 import (
 	"fmt"
-	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -127,17 +126,59 @@ func StartDB(port int, listen StartListenType, invoker Invoker, refreshConnectio
 		utils.ShowWarning("self signed certificate creation failed, connecting to the database without SSL")
 	}
 
+	if err := isPortBindable(port); err != nil {
+		return ServiceFailedToStart, fmt.Errorf("cannot listen on port %d", constants.Bold(port))
+	}
+
+	utils.LogTime("postgresCmd start")
+	err = startPostgresProcess(port, listen, invoker)
+	if err != nil {
+		return ServiceFailedToStart, err
+	}
+	utils.LogTime("postgresCmd end")
+
+	// create a client
+	// pass 'false' to disable auto refreshing connections
+	//- we will explicitly refresh connections after ensuring the steampipe server exists
+	if refreshConnections {
+		client, err = NewClient()
+		if err != nil {
+			return ServiceFailedToStart, handleStartFailure(err)
+		}
+		refreshResult := client.RefreshConnectionAndSearchPaths()
+		if refreshResult.Error != nil {
+			return ServiceFailedToStart, handleStartFailure(refreshResult.Error)
+		}
+		// display any initialisation warnings
+		refreshResult.ShowWarnings()
+	}
+	err = ensureSteampipeServer()
+	if err != nil {
+		// there was a problem with the installation
+		return ServiceFailedToStart, err
+	}
+
+	err = ensureTempTablePermissions()
+	if err != nil {
+		// there was a problem with the installation
+		return ServiceFailedToStart, err
+	}
+
+	return ServiceStarted, err
+}
+
+// startPostgresProcess starts the postgres process and writes out the state file
+// after it is convinced that the process is started and is accepting connections
+func startPostgresProcess(port int, listen StartListenType, invoker Invoker) error {
+	utils.LogTime("startPostgresProcess start")
+	defer utils.LogTime("startPostgresProcess end")
+
 	listenAddresses := "localhost"
 
 	if listen == ListenTypeNetwork {
 		listenAddresses = "*"
 	}
 
-	if err := isPortBindable(port); err != nil {
-		return ServiceFailedToStart, fmt.Errorf("cannot listen on port %d", constants.Bold(port))
-	}
-
-	utils.LogTime("postgresCmd start")
 	postgresCmd := exec.Command(
 		getPostgresBinaryExecutablePath(),
 		// by this time, we are sure that the port if free to listen to
@@ -205,21 +246,18 @@ func StartDB(port int, listen StartListenType, invoker Invoker, refreshConnectio
 		postgresCmd.Env = append(os.Environ(), fmt.Sprintf("OPENSSL_CONF=%s", constants.SslConfDir))
 	}
 
-	log.Println("[TRACE] postgres start command: ", postgresCmd.String())
-
 	postgresCmd.SysProcAttr = &syscall.SysProcAttr{
 		Setpgid:    true,
 		Foreground: false,
 	}
 
-	err = postgresCmd.Start()
-
+	err := postgresCmd.Start()
 	if err != nil {
-		return ServiceFailedToStart, err
+		return err
 	}
 
 	// get the password file
-	passwords, err := getPasswords()
+	passwords, _ := getPasswords()
 
 	runningInfo := new(RunningDBInstanceInfo)
 	runningInfo.Pid = postgresCmd.Process.Pid
@@ -235,45 +273,26 @@ func StartDB(port int, listen StartListenType, invoker Invoker, refreshConnectio
 		addrs, _ := localAddresses()
 		runningInfo.Listen = append(runningInfo.Listen, addrs...)
 	}
-
-	if err := postgresCmd.Process.Release(); err != nil {
-		return ServiceStarted, err
-	}
-
-	if err := saveRunningInstanceInfo(runningInfo); err != nil {
-		return ServiceStarted, err
-	}
-	utils.LogTime("postgresCmd end")
-
-	// create a client
-	// pass 'false' to disable auto refreshing connections
-	//- we will explicitly refresh connections after ensuring the steampipe server exists
-	var res *RefreshConnectionResult
-	client, err = NewClient()
+	err = runningInfo.Save()
 	if err != nil {
-		return ServiceFailedToStart, handleStartFailure(err)
-	}
-	if refreshConnections {
-		res = client.RefreshConnectionAndSearchPaths()
-		if res.Error != nil {
-			return ServiceFailedToStart, handleStartFailure(res.Error)
-		}
-		// display any initialisation warnings
-		res.ShowWarnings()
-	}
-	err = ensureSteampipeServer()
-	if err != nil {
-		// there was a problem with the installation
-		return ServiceFailedToStart, err
+		postgresCmd.Process.Kill()
+		return err
 	}
 
-	err = ensureTempTablePermissions()
+	err = postgresCmd.Process.Release()
 	if err != nil {
-		// there was a problem with the installation
-		return ServiceFailedToStart, err
+		postgresCmd.Process.Kill()
+		return err
 	}
 
-	return ServiceStarted, err
+	connection, err := createDbClient("postgres", constants.DatabaseSuperUser)
+	if err != nil {
+		postgresCmd.Process.Kill()
+		return err
+	}
+	connection.Close()
+
+	return nil
 }
 
 // ensures that the `steampipe` fdw server exists

--- a/db/stop_database.go
+++ b/db/stop_database.go
@@ -68,7 +68,7 @@ func Shutdown(client *Client, invoker Invoker) {
 }
 
 func GetCountOfConnectedClients() (int, error) {
-	rootClient, err := createSteampipeRootClient()
+	rootClient, err := createRootDbClient()
 	if err != nil {
 		return -1, err
 	}

--- a/db/stop_database.go
+++ b/db/stop_database.go
@@ -68,7 +68,7 @@ func Shutdown(client *Client, invoker Invoker) {
 }
 
 func GetCountOfConnectedClients() (int, error) {
-	rootClient, err := createSteampipeRootDbClient()
+	rootClient, err := createSteampipeRootClient()
 	if err != nil {
 		return -1, err
 	}

--- a/query/execute/execute.go
+++ b/query/execute/execute.go
@@ -12,6 +12,9 @@ import (
 )
 
 func RunInteractiveSession(initChan *chan *db.QueryInitData) {
+	utils.LogTime("execute.RunInteractiveSession start")
+	defer utils.LogTime("execute.RunInteractiveSession end")
+
 	// the db executor sends result data over resultsStreamer
 	resultsStreamer, err := db.RunInteractivePrompt(initChan)
 	utils.FailOnError(err)


### PR DESCRIPTION
Outputs:
_Batch mode_:
```
binaeksarkar@Binaeks-MacBook-Pro sample_workspace % rm -rf ~/.steampipe/db/12.1.0/data/pg_hba.conf && steampipe query "select 1 one"
+-----+
| one |
+-----+
| 1   |
+-----+

binaeksarkar@Binaeks-MacBook-Pro sample_workspace % 
```

_Interactive Mode_:
```
binaeksarkar@Binaeks-MacBook-Pro sample_workspace % rm -rf ~/.steampipe/db/12.1.0/data/pg_hba.conf && steampipe query                  
Welcome to Steampipe v0.7.0-rc.0
For more information, type .help
> .exit
binaeksarkar@Binaeks-MacBook-Pro sample_workspace % 
```