### PR TITLE
Fixes `nil pointer exception` in `steampipe plugin`. Closes #678

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -33,8 +33,11 @@ Find plugins using the public registry at https://hub.steampipe.io.
 
 Examples:
 
-  # Install or update a plugin
+  # Install a plugin
   steampipe plugin install aws
+
+  # Update a plugin
+  steampipe plugin update aws
 
   # List installed plugins
   steampipe plugin list
@@ -47,8 +50,6 @@ Examples:
 	cmd.AddCommand(pluginListCmd())
 	cmd.AddCommand(pluginUninstallCmd())
 	cmd.AddCommand(pluginUpdateCmd())
-
-	cmdconfig.OnCmd(cmd)
 
 	return cmd
 }

--- a/cmdconfig/builder.go
+++ b/cmdconfig/builder.go
@@ -22,9 +22,9 @@ func OnCmd(cmd *cobra.Command) *CmdBuilder {
 
 	// we will wrap over these two function - need references to call them
 	originalPreRun := cfg.cmd.PreRun
-	originalRun := cfg.cmd.Run
-
 	cfg.cmd.PreRun = func(cmd *cobra.Command, args []string) {
+		utils.LogTime(fmt.Sprintf("cmd.%s.PreRun start", cmd.CommandPath()))
+		defer utils.LogTime(fmt.Sprintf("cmd.%s.PreRun end", cmd.CommandPath()))
 		// bind flags
 		for flagName, flag := range cfg.bindings {
 			viper.GetViper().BindPFlag(flagName, flag)
@@ -35,11 +35,16 @@ func OnCmd(cmd *cobra.Command) *CmdBuilder {
 		}
 	}
 
+	// wrap over the original Run function
+	originalRun := cfg.cmd.Run
 	cfg.cmd.Run = func(cmd *cobra.Command, args []string) {
 		utils.LogTime(fmt.Sprintf("cmd.%s.Run start", cmd.CommandPath()))
 		defer utils.LogTime(fmt.Sprintf("cmd.%s.Run end", cmd.CommandPath()))
 
-		originalRun(cmd, args)
+		// run the original Run
+		if originalRun != nil {
+			originalRun(cmd, args)
+		}
 	}
 
 	return cfg


### PR DESCRIPTION
Output:
```
binaeksarkar@Binaeks-MacBook-Pro steampipe % steampipe plugin
Steampipe plugin management.

Plugins extend Steampipe to work with many different services and providers.
Find plugins using the public registry at https://hub.steampipe.io.

Examples:

  # Install a plugin
  steampipe plugin install aws

  # Update a plugin
  steampipe plugin update aws

  # List installed plugins
  steampipe plugin list

  # Uninstall a plugin
  steampipe plugin uninstall aws

Usage:
  steampipe plugin [command]

Available Commands:
  install     Install one or more plugins
  list        List currently installed plugins
  uninstall   Uninstall a plugin
  update      Update one or more plugins

Flags:
  -h, --help   help for plugin

Global Flags:
      --install-dir string   Path to the Config Directory (defaults to ~/.steampipe) (default "~/.steampipe")
      --workspace string     Path to the workspace (defaults to current working directory)

Use "steampipe plugin [command] --help" for more information about a command.
binaeksarkar@Binaeks-MacBook-Pro steampipe % 
```