### PR TITLE
Add queries from history on `Ctrl+R`. Closes #146

### DIFF
--- a/autocomplete/reverse_search.go
+++ b/autocomplete/reverse_search.go
@@ -1,0 +1,40 @@
+package autocomplete
+
+import (
+	"fmt"
+	"unicode/utf8"
+)
+
+type ReverseSearch struct {
+	Search       string
+	currentIndex int
+	Inputs       []string
+	Matches      []string
+}
+
+func NewReverseSearch(searchString string, inputStrings []string) ReverseSearch {
+	r := ReverseSearch{
+		Search:       searchString,
+		currentIndex: 0,
+		Inputs:       inputStrings,
+	}
+	r.updateMatches()
+	return r
+}
+
+func (r *ReverseSearch) updateMatches()    {}
+func (r *ReverseSearch) Current() string   { return "" }
+func (r *ReverseSearch) GoToPrevious()     {}
+func (r *ReverseSearch) GoToNext()         {}
+func (r *ReverseSearch) GetPrompt() string { return "" }
+
+func (r *ReverseSearch) PushCharacters(chars string) {
+	r.SetSearch(fmt.Sprintf("%s%s", r.Search, chars))
+}
+func (r *ReverseSearch) PopLastCharacter() {
+	if len(r.Search) > 0 {
+		_, size := utf8.DecodeLastRuneInString(r.Search)
+		r.SetSearch(r.Search[:len(r.Search)-size])
+	}
+}
+func (r *ReverseSearch) SetSearch(search string) { r.Search = search; r.updateMatches() }

--- a/cmd/readline.go
+++ b/cmd/readline.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/chzyer/readline"
+	"github.com/spf13/cobra"
+	"github.com/turbot/steampipe/cmdconfig"
+)
+
+// queryCmd :: represents the query command
+func readlineCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:              "readline",
+		TraverseChildren: true,
+		Args:             cobra.ArbitraryArgs,
+		Run:              runReadlineCmd,
+		Short:            "Readline",
+		Long:             ``,
+	}
+
+	// Notes:
+	// * In the future we may add --csv and --json flags as shortcuts for --output
+	cmdconfig.
+		OnCmd(cmd)
+
+	return cmd
+}
+
+func filterInput(r rune) (rune, bool) {
+	switch r {
+	// block CtrlZ feature
+	case readline.CharCtrlZ:
+		return r, false
+	}
+	return r, true
+}
+func listFiles(path string) func(string) []string {
+	return func(line string) []string {
+		names := make([]string, 0)
+		files, _ := ioutil.ReadDir(path)
+		for _, f := range files {
+			names = append(names, f.Name())
+		}
+		return names
+	}
+}
+
+var completer = readline.NewPrefixCompleter(
+	readline.PcItem("mode",
+		readline.PcItem("vi"),
+		readline.PcItem("emacs"),
+	),
+	readline.PcItem("login"),
+	readline.PcItem("say",
+		readline.PcItemDynamic(listFiles("./"),
+			readline.PcItem("with",
+				readline.PcItem("following"),
+				readline.PcItem("items"),
+			),
+		),
+		readline.PcItem("hello"),
+		readline.PcItem("bye"),
+	),
+	readline.PcItem("setprompt"),
+	readline.PcItem("setpassword"),
+	readline.PcItem("bye"),
+	readline.PcItem("help"),
+	readline.PcItem("go",
+		readline.PcItem("build", readline.PcItem("-o"), readline.PcItem("-v")),
+		readline.PcItem("install",
+			readline.PcItem("-v"),
+			readline.PcItem("-vv"),
+			readline.PcItem("-vvv"),
+		),
+		readline.PcItem("test"),
+	),
+	readline.PcItem("sleep"),
+)
+
+func runReadlineCmd(cmd *cobra.Command, args []string) {
+	l, err := readline.NewEx(&readline.Config{
+		Prompt:          "\033[31m»\033[0m ",
+		HistoryFile:     "/tmp/readline.tmp",
+		AutoComplete:    completer,
+		InterruptPrompt: "^C",
+		EOFPrompt:       "exit",
+
+		HistorySearchFold:   true,
+		FuncFilterInputRune: filterInput,
+	})
+	if err != nil {
+		panic(err)
+	}
+	defer l.Close()
+
+	setPasswordCfg := l.GenPasswordConfig()
+	setPasswordCfg.SetListener(func(line []rune, pos int, key rune) (newLine []rune, newPos int, ok bool) {
+		l.SetPrompt(fmt.Sprintf("Enter password(%v): ", len(line)))
+		l.Refresh()
+		return nil, 0, false
+	})
+
+	log.SetOutput(l.Stderr())
+	for {
+		line, err := l.Readline()
+		if err == readline.ErrInterrupt {
+			if len(line) == 0 {
+				break
+			} else {
+				continue
+			}
+		} else if err == io.EOF {
+			break
+		}
+
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "mode "):
+			switch line[5:] {
+			case "vi":
+				l.SetVimMode(true)
+			case "emacs":
+				l.SetVimMode(false)
+			default:
+				println("invalid mode:", line[5:])
+			}
+		case line == "mode":
+			if l.IsVimMode() {
+				println("current mode: vim")
+			} else {
+				println("current mode: emacs")
+			}
+		case line == "login":
+			pswd, err := l.ReadPassword("please enter your password: ")
+			if err != nil {
+				break
+			}
+			println("you enter:", strconv.Quote(string(pswd)))
+		case line == "help":
+			fmt.Println()
+		case line == "setpassword":
+			pswd, err := l.ReadPasswordWithConfig(setPasswordCfg)
+			if err == nil {
+				println("you set:", strconv.Quote(string(pswd)))
+			}
+		case strings.HasPrefix(line, "setprompt"):
+			if len(line) <= 10 {
+				log.Println("setprompt <prompt>")
+				break
+			}
+			l.SetPrompt(line[10:])
+		case strings.HasPrefix(line, "say"):
+			line := strings.TrimSpace(line[3:])
+			if len(line) == 0 {
+				log.Println("say what?")
+				break
+			}
+			go func() {
+				for range time.Tick(time.Second) {
+					log.Println(line)
+				}
+			}()
+		case line == "bye":
+			return
+		case line == "sleep":
+			log.Println("sleep 4 second")
+			time.Sleep(4 * time.Second)
+		case line == "":
+		default:
+			log.Println("you said:", strconv.Quote(line))
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/bmatcuk/doublestar v1.3.4 // indirect
 	github.com/briandowns/spinner v1.11.1
 	github.com/c-bata/go-prompt v0.2.5
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
 	github.com/containerd/cgroups v1.0.1 // indirect
 	github.com/containerd/containerd v1.4.8
 	github.com/containerd/continuity v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheggaaa/pb v1.0.27/go.mod h1:pQciLPpbU0oxA0h+VJYYLxO+XeDQb5pZijXscXHm81s=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e h1:fY5BOSpyZCqRo5OhCuC+XN+r/bBCmeuuJtjz+bCNIf8=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=

--- a/interactive/interactive_client.go
+++ b/interactive/interactive_client.go
@@ -472,8 +472,12 @@ func (c *InteractiveClient) queryCompleter(d prompt.Document) []prompt.Suggest {
 	}
 
 	if c.addHistoryToAutoComplete {
+		added := []string{}
 		for _, historyElement := range c.interactiveQueryHistory.Get() {
-			s = append(s, prompt.Suggest{Text: historyElement})
+			if !helpers.StringSliceContains(added, historyElement) {
+				s = append(s, prompt.Suggest{Text: historyElement})
+				added = append(added, historyElement)
+			}
 		}
 	}
 

--- a/interactive/interactive_client.go
+++ b/interactive/interactive_client.go
@@ -475,7 +475,7 @@ func (c *InteractiveClient) queryCompleter(d prompt.Document) []prompt.Suggest {
 		added := []string{}
 		for _, historyElement := range c.interactiveQueryHistory.Get() {
 			if !helpers.StringSliceContains(added, historyElement) {
-				s = append(s, prompt.Suggest{Text: historyElement})
+				s = append(s, prompt.Suggest{Text: historyElement, Description: "History"})
 				added = append(added, historyElement)
 			}
 		}


### PR DESCRIPTION
History elements are prepended to the autocomplete suggestions on `Ctrl+C`:

Normally, this is turned off:
![Normal](https://user-images.githubusercontent.com/1114038/127301252-325b9e9d-53f9-4577-90ca-7f69648a8416.png)


When `Ctrl+R` is pressed:
![After Ctrl+R](https://user-images.githubusercontent.com/1114038/127301267-a8b07fcc-9fac-4c56-b81a-4e22fe0c331f.png)


The history entries are de-duplicated before adding to the suggestions.
