### PR TITLE
Revert changes made for multiline control errors. Closes #706

### DIFF
--- a/control/controldisplay/error.go
+++ b/control/controldisplay/error.go
@@ -3,7 +3,6 @@ package controldisplay
 import (
 	"fmt"
 	"log"
-	"strings"
 
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/control/controlexecute"
@@ -37,11 +36,7 @@ func (r ErrorRenderer) Render() string {
 
 	// figure out how much width we have available for the error message
 	availableWidth := r.width - statusWidth - indentWidth
-	errStrings := strings.Split(r.error.Error(), "\n")
-	for i, str := range errStrings {
-		errStrings[i] = helpers.TruncateString(str, availableWidth)
-	}
-	errorMessage := strings.Join(errStrings, "\n")
+	errorMessage := helpers.TruncateString(r.error.Error(), availableWidth)
 	errorString := fmt.Sprintf("%s", ControlColors.StatusError(errorMessage))
 
 	// now put these all together

--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1
 	github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b
-	github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3
+	github.com/turbot/go-kit v0.2.2-0.20210730122803-1ecb35c27e98
 	github.com/turbot/steampipe-plugin-sdk v1.3.0
 	github.com/ulikunitz/xz v0.5.8
 	github.com/zclconf/go-cty v1.8.2

--- a/go.sum
+++ b/go.sum
@@ -783,6 +783,8 @@ github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1
 github.com/tombuildsstuff/giovanni v0.15.1/go.mod h1:0TZugJPEtqzPlMpuJHYfXY6Dq2uLPrXf98D2XQSxNbA=
 github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3 h1:UAfWYp+K7oESlqomRus4k+h/dSPXU17tEcarbRdtBwQ=
 github.com/turbot/go-kit v0.2.2-0.20210628165333-268ba0a30be3/go.mod h1:SBdPRngbEfYubiR81iAVtO43oPkg1+ASr+XxvgbH7/k=
+github.com/turbot/go-kit v0.2.2-0.20210730122803-1ecb35c27e98 h1:FC2PphWOAmLVxgS4rPUm8OkXOmzl1sgFt8jLrr5AGUc=
+github.com/turbot/go-kit v0.2.2-0.20210730122803-1ecb35c27e98/go.mod h1:SBdPRngbEfYubiR81iAVtO43oPkg1+ASr+XxvgbH7/k=
 github.com/turbot/go-prompt v0.2.6-steampipe.0.20210716071502-aaa801a61636 h1:DoPUBEiDIt+T3S7P2JU0wAHx4MlrT1MZ9opaufOvRd0=
 github.com/turbot/go-prompt v0.2.6-steampipe.0.20210716071502-aaa801a61636/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
 github.com/turbot/steampipe-plugin-sdk v1.3.0 h1:7KMA86Nxpw2dRC1Ri472aSRQgLv3gk9DqPxwFHd3EoE=


### PR DESCRIPTION
Reverting the changes in https://github.com/turbot/steampipe/commit/f9673d5713f578ca16e920d46963e020f9f44db2 since it will be handled in `helpers.truncateString` https://github.com/turbot/go-kit/issues/16

### NOTE:
To be merged only if and when https://github.com/turbot/go-kit/pull/17 is merged into go-kit main.