### PR TITLE
Add acceptance tests for "search path not being honored by `steampipe check`". Closes #721

### DIFF
--- a/tests/acceptance/test_data/sample_workspace/cis_v130/search_path.sp
+++ b/tests/acceptance/test_data/sample_workspace/cis_v130/search_path.sp
@@ -1,0 +1,57 @@
+benchmark "check_search_path_benchmark" {
+  title         = "Benchmark to test search path and search path prefix functionalities in steampipe check"
+  children = [
+    control.search_path_test_1,
+    control.search_path_test_2,
+    control.search_path_test_3,
+    control.search_path_test_4,
+    control.search_path_test_5,
+    control.search_path_test_6
+  ]
+}
+
+control "search_path_test_1" {
+  title         = "Control to test search path prefix functionality when entered through CLI"
+  description   = "Control to test search path prefix functionality when entered through CLI."
+  sql           = query.search_path_1.sql
+  severity      = "high"
+}
+
+control "search_path_test_2" {
+  title         = "Control to test search path functionality when entered through CLI"
+  description   = "Control to test search path functionality when entered through CLI."
+  sql           = query.search_path_2.sql
+  severity      = "high"
+}
+
+control "search_path_test_3" {
+  title         = "Control to test search path and prefix functionality when entered through CLI"
+  description   = "Control to test search path and prefix functionality when entered through CLI."
+  sql           = query.search_path_1.sql
+  severity      = "high"
+}
+
+control "search_path_test_4" {
+  title         = "Control to test search path prefix functionality when entered through control"
+  description   = "Control to test search path prefix functionality when entered through control."
+  sql           = query.search_path_1.sql
+  search_path_prefix   = "aws"
+  severity      = "high"
+}
+
+control "search_path_test_5" {
+  title         = "Control to test search path functionality when entered through control"
+  description   = "Control to test search path functionality when entered through control."
+  sql           = query.search_path_2.sql
+  search_path   = "a,b,c"
+  severity      = "high"
+}
+
+control "search_path_test_6" {
+  title         = "Control to test search path and prefix functionality when entered through control"
+  description   = "Control to test search path and prefix functionality when entered through control."
+  sql           = query.search_path_1.sql
+  search_path_prefix   = "aws"
+  search_path   = "a,b,c"
+  severity      = "high"
+}

--- a/tests/acceptance/test_data/sample_workspace/query/search_path_1.sql
+++ b/tests/acceptance/test_data/sample_workspace/query/search_path_1.sql
@@ -1,0 +1,7 @@
+WITH s_path AS (select setting from pg_settings where name='search_path') 
+SELECT s_path.setting as resource, 
+CASE 
+    WHEN s_path.setting LIKE 'aws%' THEN 'ok' 
+    ELSE 'alarm' 
+END as status, '' as reason
+FROM s_path

--- a/tests/acceptance/test_data/sample_workspace/query/search_path_2.sql
+++ b/tests/acceptance/test_data/sample_workspace/query/search_path_2.sql
@@ -1,0 +1,7 @@
+WITH s_path AS (select setting from pg_settings where name='search_path') 
+SELECT s_path.setting as resource, 
+CASE 
+    WHEN s_path.setting LIKE 'a, b, c%' THEN 'ok' 
+    ELSE 'alarm' 
+END as status, '' as reason
+FROM s_path

--- a/tests/acceptance/test_data/templates/expected_check_json.json
+++ b/tests/acceptance/test_data/templates/expected_check_json.json
@@ -14,10 +14,15 @@
   },
   "groups": [
     {
-      "group_id": "mod.aws_compliance",
-      "title": "AWS Compliance",
-      "description": "Steampipe Mod for Amazon Web Services (AWS) Compliance",
-      "tags": {},
+      "group_id": "benchmark.cis_v130",
+      "title": "CIS v1.3.0",
+      "description": "The CIS Amazon Web Services Foundations Benchmark provides prescriptive guidance for configuring security options for a subset of Amazon Web Services with an emphasis on foundational, testable, and architecture agnostic settings.",
+      "tags": {
+        "benchmark": "cis",
+        "cis_controls_version": "v7.1",
+        "cis_version": "v1.3.0",
+        "plugin": "aws"
+      },
       "summary": {
         "status": {
           "alarm": 9,
@@ -29,2276 +34,1041 @@
       },
       "groups": [
         {
-          "group_id": "benchmark.cis_v130",
-          "title": "CIS v1.3.0",
-          "description": "The CIS Amazon Web Services Foundations Benchmark provides prescriptive guidance for configuring security options for a subset of Amazon Web Services with an emphasis on foundational, testable, and architecture agnostic settings.",
+          "group_id": "benchmark.cis_v130_1",
+          "title": "1 Identity and Access Management",
+          "description": "",
           "tags": {
             "benchmark": "cis",
             "cis_controls_version": "v7.1",
+            "cis_section_id": "1",
             "cis_version": "v1.3.0",
             "plugin": "aws"
           },
           "summary": {
             "status": {
-              "alarm": 9,
-              "ok": 40,
-              "info": 3,
-              "skip": 2,
+              "alarm": 5,
+              "ok": 16,
+              "info": 0,
+              "skip": 0,
               "error": 1
             }
           },
-          "groups": [
+          "groups": [],
+          "controls": [
             {
-              "group_id": "benchmark.cis_v130_1",
-              "title": "1 Identity and Access Management",
-              "description": "",
+              "control_id": "control.cis_v130_1_1",
+              "description": "Ensure contact email and telephone details for AWS accounts are current and map to more than one individual in your organization.",
+              "severity": "high",
               "tags": {
                 "benchmark": "cis",
+                "cis_controls": "6.3",
                 "cis_controls_version": "v7.1",
+                "cis_item_id": "1.1",
+                "cis_levels": "1",
                 "cis_section_id": "1",
+                "cis_type": "manual",
                 "cis_version": "v1.3.0",
                 "plugin": "aws"
               },
-              "summary": {
-                "status": {
-                  "alarm": 5,
-                  "ok": 16,
-                  "info": 0,
-                  "skip": 0,
-                  "error": 1
-                }
-              },
-              "groups": [],
-              "controls": [
+              "title": "1.1 Maintain current contact details",
+              "results": [
                 {
-                  "control_id": "control.cis_v130_1_1",
-                  "description": "Ensure contact email and telephone details for AWS accounts are current and map to more than one individual in your organization.",
-                  "severity": "high",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.1",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "manual",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.1 Maintain current contact details",
-                  "results": [
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
                     {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_2",
-                  "description": "AWS provides customers with the option of specifying the contact information for accounts security team. It is recommended that this information be provided.",
-                  "severity": "high",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "19,19.2",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.2",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "manual",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.2 Ensure security contact information is registered",
-                  "results": [
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
                     {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_3",
-                  "description": "The AWS support portal allows account owners to establish security questions that can be used to authenticate individuals calling AWS customer service for support. It is recommended that security questions be established.",
-                  "severity": "high",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.3",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "manual",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.3 Ensure security questions are registered in the AWS account",
-                  "results": [
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
                     {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_4",
-                  "description": "The root user account is the most privileged user in an AWS account. AWS Access Keys provide programmatic access to a given AWS account. It is recommended that all access keys associated with the root user account be removed.",
-                  "severity": "high",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.4",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.4 Ensure no root user account access key exists",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_5",
-                  "description": "The root user account is the most privileged user in an AWS account. Multi-factor Authentication (MFA) adds an extra layer of protection on top of a username and password. With MFA enabled, when a user signs in to an AWS website, they will be prompted for their username and password as well as for an authentication code from their AWS MFA device.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4.5",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.5",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.5 Ensure MFA is enabled for the \"root user\" account",
-                  "results": [
-                    {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_6",
-                  "description": "The root user account is the most privileged user in an AWS account. MFA adds an extra layer of protection on top of a user name and password. With MFA enabled, when a user signs in to an AWS website, they will be prompted for their user name and password as well as for an authentication code from their AWS MFA device. For Level 2, it is recommended that the root user account be protected with a hardware MFA.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4.5",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.6",
-                    "cis_levels": "2",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.6 Ensure hardware MFA is enabled for the \"root user\" account",
-                  "results": [
-                    {
-                      "reason": "is in some sort of error state",
-                      "resource": "some messed up resource",
-                      "status": "error",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 20000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_7",
-                  "description": "With the creation of an AWS account, a root user is created that cannot be disabled or deleted. That user has unrestricted access to and control over all resources in the AWS account. It is highly recommended that the use of this account be avoided for everyday tasks.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.7",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.7 Eliminate use of the root user for administrative and daily tasks",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_8",
-                  "description": "Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are at least a given length. It is recommended that the password policy require a minimum password length 14.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.8",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.8 Ensure IAM password policy requires minimum length of 14 or greater",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_9",
-                  "description": "IAM password policies can prevent the reuse of a given password by the same user. It is recommended that the password policy prevent the reuse of passwords.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4.4",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.9",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.9 Ensure IAM password policy prevents password reuse",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_10",
-                  "description": "Multi-Factor Authentication (MFA) adds an extra layer of authentication assurance beyond traditional credentials. With MFA enabled, when a user signs in to the AWS Console, they will be prompted for their user name and password as well as for an authentication code from their physical or virtual MFA token. It is recommended that MFA be enabled for all accounts that have a console password.",
-                  "severity": "critical",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4.5",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.10",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.10 Ensure multi-factor authentication (MFA) is enabled for all IAM users that have a console password",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_11",
-                  "description": "AWS console defaults to no check boxes selected when creating a new IAM user. When cerating the IAM User credentials you have to determine what type of access they require.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.11",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "manual",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.11 Do not setup access keys during initial user setup for all IAM users that have a console password",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_12",
-                  "description": "AWS IAM users can access AWS resources using different types of credentials, such as passwords or access keys. It is recommended that all credentials that have been unused in 90 or greater days be deactivated or removed.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16.9",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.12",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.12 Ensure credentials unused for 90 days or greater are disabled",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_13",
-                  "description": "Access keys are long-term credentials for an IAM user or the AWS account root user. You can use access keys to sign programmatic requests to the AWS CLI or AWS API. One of the best ways to protect your account is to not allow users to have multiple access keys.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.13",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.13 Ensure there is only one active access key available for any single IAM user",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_14",
-                  "description": "Access keys consist of an access key ID and secret access key, which are used to sign programmatic requests that you make to AWS. AWS users need their own access keys to make programmatic calls to AWS from the AWS Command Line Interface (AWS CLI), Tools for Windows PowerShell, the AWS SDKs, or direct HTTP calls using the APIs for individual AWS services. It is recommended that all access keys be regularly rotated.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.14",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.14 Ensure access keys are rotated every 90 days or less",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_15",
-                  "description": "IAM users are granted access to services, functions, and data through IAM policies. There are three ways to define policies for a user: 1) Edit the user policy directly, aka an inline, or user, policy; 2) attach a policy directly to a user; 3) add the user to an IAM group that has an attached policy.  Only the third implementation is recommended.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.15",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.15 Ensure IAM Users Receive Permissions Only Through Groups",
-                  "results": [
-                    {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_16",
-                  "description": "IAM policies are the means by which privileges are granted to users, groups, or roles. It is recommended and considered a standard security advice to grant least privilege -that is, granting only the permissions required to perform a task. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of allowing full administrative privileges.",
-                  "severity": "critical",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.16",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.16 Ensure IAM policies that allow full \"*:*\" administrative privileges are not attached",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_17",
-                  "description": "AWS provides a support center that can be used for incident notification and response, as well as technical support and customer services. Create an IAM Role to allow authorized users to manage incidents with AWS Support.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "14",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.17",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.17 Ensure a support role has been created to manage incidents with AWS Support",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_18",
-                  "description": "AWS access from within AWS instances can be done by either encoding AWS keys into AWS API calls or by assigning the instance to a role which has an appropriate permissions policy for the required access. \"AWS Access\" means accessing the APIs of AWS in order to access AWS resources or manage AWS account resources.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "19",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.18",
-                    "cis_levels": "2",
-                    "cis_section_id": "1",
-                    "cis_type": "manual",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.18 Ensure IAM instance roles are used for AWS resource access from instances",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_19",
-                  "description": "To enable HTTPS connections to your website or application in AWS, you need an SSL/TLS server certificate. You can use ACM or IAM to store and deploy server certificates. Use IAM as a certificate manager only when you must support HTTPS connections in a region that is not supported by ACM. IAM securely encrypts your private keys and stores the encrypted version in IAM SSL certificate storage. IAM supports deploying server certificates in all regions, but you must obtain your certificate from an external provider for use with AWS. You cannot upload an ACM certificate to IAM. Additionally, you cannot manage your certificates from the IAM Console.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "13",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.19",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.19 Ensure that all the expired SSL/TLS certificates stored in AWS IAM are removed",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_20",
-                  "description": "Amazon S3 provides Block public access (bucket settings) and Block public access (account settings) to help you manage public access to Amazon S3 resources. By default, S3 buckets and objects are created with public access disabled. However, an IAM principle with sufficient S3 permissions can enable public access at the bucket and/or object level. While enabled, Block public access (bucket settings) prevents an individual bucket, and its contained objects, from becoming publicly accessible. Similarly, Block public access (account settings) prevents all buckets, and contained objects, from becoming publicly accessible across the entire account.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "14.6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.20",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.20 Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_21",
-                  "description": "Enable IAM Access analyzer for IAM policies about all resources. IAM Access Analyzer is a technology introduced at AWS reinvent 2019. After the Analyzer is enabled in IAM, scan results are displayed on the console showing the accessible resources. Scans show resources that other accounts and federated users can access, such as KMS keys and IAM roles. So the results allow you to determine if an unintended user is allowed, making it easier for administrators to monitor least privileges access.",
-                  "severity": "critical",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "14.6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.21",
-                    "cis_levels": "1",
-                    "cis_section_id": "1",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.21 Ensure that IAM Access analyzer is enabled",
-                  "results": [
-                    {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_1_22",
-                  "description": "In multi-account environments, IAM user centralization facilitates greater user control. User access beyond the initial account is then provide via role assumption. Centralization of users can be accomplished through federation with an external identity provider or through the use of AWS Organizations.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16.2",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "1.22",
-                    "cis_levels": "2",
-                    "cis_section_id": "1",
-                    "cis_type": "manual",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "1.22 Ensure IAM users are managed centrally via identity federation or AWS Organizations for multi-account environments",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
+                      "key": "account",
+                      "value": "3335354343537"
                     }
                   ]
                 }
               ]
             },
             {
-              "group_id": "benchmark.cis_v130_2",
-              "title": "2 Storage",
+              "control_id": "control.cis_v130_1_2",
+              "description": "AWS provides customers with the option of specifying the contact information for accounts security team. It is recommended that this information be provided.",
+              "severity": "high",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "19,19.2",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.2",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "manual",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.2 Ensure security contact information is registered",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_3",
+              "description": "The AWS support portal allows account owners to establish security questions that can be used to authenticate individuals calling AWS customer service for support. It is recommended that security questions be established.",
+              "severity": "high",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.3",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "manual",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.3 Ensure security questions are registered in the AWS account",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_4",
+              "description": "The root user account is the most privileged user in an AWS account. AWS Access Keys provide programmatic access to a given AWS account. It is recommended that all access keys associated with the root user account be removed.",
+              "severity": "high",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4.3",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.4",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.4 Ensure no root user account access key exists",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_5",
+              "description": "The root user account is the most privileged user in an AWS account. Multi-factor Authentication (MFA) adds an extra layer of protection on top of a username and password. With MFA enabled, when a user signs in to an AWS website, they will be prompted for their username and password as well as for an authentication code from their AWS MFA device.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4.5",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.5",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.5 Ensure MFA is enabled for the \"root user\" account",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_6",
+              "description": "The root user account is the most privileged user in an AWS account. MFA adds an extra layer of protection on top of a user name and password. With MFA enabled, when a user signs in to an AWS website, they will be prompted for their user name and password as well as for an authentication code from their AWS MFA device. For Level 2, it is recommended that the root user account be protected with a hardware MFA.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4.5",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.6",
+                "cis_levels": "2",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.6 Ensure hardware MFA is enabled for the \"root user\" account",
+              "results": [
+                {
+                  "reason": "is in some sort of error state",
+                  "resource": "some messed up resource",
+                  "status": "error",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 20000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_7",
+              "description": "With the creation of an AWS account, a root user is created that cannot be disabled or deleted. That user has unrestricted access to and control over all resources in the AWS account. It is highly recommended that the use of this account be avoided for everyday tasks.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4.3",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.7",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.7 Eliminate use of the root user for administrative and daily tasks",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_8",
+              "description": "Password policies are, in part, used to enforce password complexity requirements. IAM password policies can be used to ensure password are at least a given length. It is recommended that the password policy require a minimum password length 14.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.8",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.8 Ensure IAM password policy requires minimum length of 14 or greater",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_9",
+              "description": "IAM password policies can prevent the reuse of a given password by the same user. It is recommended that the password policy prevent the reuse of passwords.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4.4",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.9",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.9 Ensure IAM password policy prevents password reuse",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_10",
+              "description": "Multi-Factor Authentication (MFA) adds an extra layer of authentication assurance beyond traditional credentials. With MFA enabled, when a user signs in to the AWS Console, they will be prompted for their user name and password as well as for an authentication code from their physical or virtual MFA token. It is recommended that MFA be enabled for all accounts that have a console password.",
+              "severity": "critical",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4.5",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.10",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.10 Ensure multi-factor authentication (MFA) is enabled for all IAM users that have a console password",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_11",
+              "description": "AWS console defaults to no check boxes selected when creating a new IAM user. When cerating the IAM User credentials you have to determine what type of access they require.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.11",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "manual",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.11 Do not setup access keys during initial user setup for all IAM users that have a console password",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_12",
+              "description": "AWS IAM users can access AWS resources using different types of credentials, such as passwords or access keys. It is recommended that all credentials that have been unused in 90 or greater days be deactivated or removed.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16.9",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.12",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.12 Ensure credentials unused for 90 days or greater are disabled",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_13",
+              "description": "Access keys are long-term credentials for an IAM user or the AWS account root user. You can use access keys to sign programmatic requests to the AWS CLI or AWS API. One of the best ways to protect your account is to not allow users to have multiple access keys.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.13",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.13 Ensure there is only one active access key available for any single IAM user",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_14",
+              "description": "Access keys consist of an access key ID and secret access key, which are used to sign programmatic requests that you make to AWS. AWS users need their own access keys to make programmatic calls to AWS from the AWS Command Line Interface (AWS CLI), Tools for Windows PowerShell, the AWS SDKs, or direct HTTP calls using the APIs for individual AWS services. It is recommended that all access keys be regularly rotated.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.14",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.14 Ensure access keys are rotated every 90 days or less",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_15",
+              "description": "IAM users are granted access to services, functions, and data through IAM policies. There are three ways to define policies for a user: 1) Edit the user policy directly, aka an inline, or user, policy; 2) attach a policy directly to a user; 3) add the user to an IAM group that has an attached policy.  Only the third implementation is recommended.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.15",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.15 Ensure IAM Users Receive Permissions Only Through Groups",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_16",
+              "description": "IAM policies are the means by which privileges are granted to users, groups, or roles. It is recommended and considered a standard security advice to grant least privilege -that is, granting only the permissions required to perform a task. Determine what users need to do and then craft policies for them that let the users perform only those tasks, instead of allowing full administrative privileges.",
+              "severity": "critical",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.16",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.16 Ensure IAM policies that allow full \"*:*\" administrative privileges are not attached",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_17",
+              "description": "AWS provides a support center that can be used for incident notification and response, as well as technical support and customer services. Create an IAM Role to allow authorized users to manage incidents with AWS Support.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "14",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.17",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.17 Ensure a support role has been created to manage incidents with AWS Support",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_18",
+              "description": "AWS access from within AWS instances can be done by either encoding AWS keys into AWS API calls or by assigning the instance to a role which has an appropriate permissions policy for the required access. \"AWS Access\" means accessing the APIs of AWS in order to access AWS resources or manage AWS account resources.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "19",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.18",
+                "cis_levels": "2",
+                "cis_section_id": "1",
+                "cis_type": "manual",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.18 Ensure IAM instance roles are used for AWS resource access from instances",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_19",
+              "description": "To enable HTTPS connections to your website or application in AWS, you need an SSL/TLS server certificate. You can use ACM or IAM to store and deploy server certificates. Use IAM as a certificate manager only when you must support HTTPS connections in a region that is not supported by ACM. IAM securely encrypts your private keys and stores the encrypted version in IAM SSL certificate storage. IAM supports deploying server certificates in all regions, but you must obtain your certificate from an external provider for use with AWS. You cannot upload an ACM certificate to IAM. Additionally, you cannot manage your certificates from the IAM Console.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "13",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.19",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.19 Ensure that all the expired SSL/TLS certificates stored in AWS IAM are removed",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_20",
+              "description": "Amazon S3 provides Block public access (bucket settings) and Block public access (account settings) to help you manage public access to Amazon S3 resources. By default, S3 buckets and objects are created with public access disabled. However, an IAM principle with sufficient S3 permissions can enable public access at the bucket and/or object level. While enabled, Block public access (bucket settings) prevents an individual bucket, and its contained objects, from becoming publicly accessible. Similarly, Block public access (account settings) prevents all buckets, and contained objects, from becoming publicly accessible across the entire account.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "14.6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.20",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.20 Ensure that S3 Buckets are configured with 'Block public access (bucket settings)'",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_21",
+              "description": "Enable IAM Access analyzer for IAM policies about all resources. IAM Access Analyzer is a technology introduced at AWS reinvent 2019. After the Analyzer is enabled in IAM, scan results are displayed on the console showing the accessible resources. Scans show resources that other accounts and federated users can access, such as KMS keys and IAM roles. So the results allow you to determine if an unintended user is allowed, making it easier for administrators to monitor least privileges access.",
+              "severity": "critical",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "14.6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.21",
+                "cis_levels": "1",
+                "cis_section_id": "1",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.21 Ensure that IAM Access analyzer is enabled",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_1_22",
+              "description": "In multi-account environments, IAM user centralization facilitates greater user control. User access beyond the initial account is then provide via role assumption. Centralization of users can be accomplished through federation with an external identity provider or through the use of AWS Organizations.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16.2",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "1.22",
+                "cis_levels": "2",
+                "cis_section_id": "1",
+                "cis_type": "manual",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "1.22 Ensure IAM users are managed centrally via identity federation or AWS Organizations for multi-account environments",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "group_id": "benchmark.cis_v130_2",
+          "title": "2 Storage",
+          "description": "",
+          "tags": {
+            "benchmark": "cis",
+            "cis_controls_version": "v7.1",
+            "cis_section_id": "2",
+            "cis_version": "v1.3.0",
+            "plugin": "aws"
+          },
+          "summary": {
+            "status": {
+              "alarm": 0,
+              "ok": 2,
+              "info": 1,
+              "skip": 0,
+              "error": 0
+            }
+          },
+          "groups": [
+            {
+              "group_id": "benchmark.cis_v130_2_1",
+              "title": "2.1 Simple Storage Service (S3)",
               "description": "",
               "tags": {
                 "benchmark": "cis",
                 "cis_controls_version": "v7.1",
-                "cis_section_id": "2",
+                "cis_section_id": "2.1",
                 "cis_version": "v1.3.0",
                 "plugin": "aws"
               },
               "summary": {
                 "status": {
                   "alarm": 0,
-                  "ok": 2,
+                  "ok": 1,
                   "info": 1,
                   "skip": 0,
                   "error": 0
                 }
               },
-              "groups": [
+              "groups": [],
+              "controls": [
                 {
-                  "group_id": "benchmark.cis_v130_2_1",
-                  "title": "2.1 Simple Storage Service (S3)",
-                  "description": "",
+                  "control_id": "control.cis_v130_2_1_1",
+                  "description": "Amazon S3 provides a variety of no, or low, cost encryption options to protect data at rest.",
+                  "severity": "",
                   "tags": {
                     "benchmark": "cis",
+                    "cis_controls": "14.8",
                     "cis_controls_version": "v7.1",
+                    "cis_item_id": "2.1.1",
+                    "cis_levels": "1,2",
                     "cis_section_id": "2.1",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "summary": {
-                    "status": {
-                      "alarm": 0,
-                      "ok": 1,
-                      "info": 1,
-                      "skip": 0,
-                      "error": 0
-                    }
-                  },
-                  "groups": [],
-                  "controls": [
-                    {
-                      "control_id": "control.cis_v130_2_1_1",
-                      "description": "Amazon S3 provides a variety of no, or low, cost encryption options to protect data at rest.",
-                      "severity": "",
-                      "tags": {
-                        "benchmark": "cis",
-                        "cis_controls": "14.8",
-                        "cis_controls_version": "v7.1",
-                        "cis_item_id": "2.1.1",
-                        "cis_levels": "1,2",
-                        "cis_section_id": "2.1",
-                        "cis_type": "manual",
-                        "cis_version": "v1.3.0",
-                        "plugin": "aws"
-                      },
-                      "title": "2.1.1 Ensure all S3 buckets employ encryption-at-rest",
-                      "results": [
-                        {
-                          "reason": "is totally secure and this is qa very very very very very long reason",
-                          "resource": "resource name",
-                          "status": "ok",
-                          "dimensions": [
-                            {
-                              "key": "partition",
-                              "value": "partition 30000"
-                            },
-                            {
-                              "key": "region",
-                              "value": "us-east-3"
-                            },
-                            {
-                              "key": "account",
-                              "value": "21323354377537"
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "control_id": "control.cis_v130_2_1_2",
-                      "description": "At the Amazon S3 bucket level, you can configure permissions through a bucket policy making the objects accessible only through HTTPS.",
-                      "severity": "",
-                      "tags": {
-                        "benchmark": "cis",
-                        "cis_controls": "14.8",
-                        "cis_controls_version": "v7.1",
-                        "cis_item_id": "2.1.2",
-                        "cis_levels": "1,2",
-                        "cis_section_id": "2.1",
-                        "cis_type": "manual",
-                        "cis_version": "v1.3.0",
-                        "plugin": "aws"
-                      },
-                      "title": "2.1.2 Ensure S3 Bucket Policy allows HTTPS requests",
-                      "results": [
-                        {
-                          "reason": "just some info, thought you should know",
-                          "resource": "resource name",
-                          "status": "info",
-                          "dimensions": [
-                            {
-                              "key": "partition",
-                              "value": "partition 20000"
-                            },
-                            {
-                              "key": "region",
-                              "value": "us-east-3"
-                            },
-                            {
-                              "key": "account",
-                              "value": "21323354377537"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "group_id": "benchmark.cis_v130_2_2",
-                  "title": "2.2 Elastic Compute Cloud (EC2)",
-                  "description": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls_version": "v7.1",
-                    "cis_section_id": "2.2",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "summary": {
-                    "status": {
-                      "alarm": 0,
-                      "ok": 1,
-                      "info": 0,
-                      "skip": 0,
-                      "error": 0
-                    }
-                  },
-                  "groups": [],
-                  "controls": [
-                    {
-                      "control_id": "control.cis_v130_2_2_1",
-                      "description": "Elastic Compute Cloud (EC2) supports encryption at rest when using the Elastic Block Store (EBS) service. While disabled by default, forcing encryption at EBS volume creation is supported.",
-                      "severity": "",
-                      "tags": {
-                        "benchmark": "cis",
-                        "cis_controls": "14.8",
-                        "cis_controls_version": "v7.1",
-                        "cis_item_id": "2.2.1",
-                        "cis_levels": "1,2",
-                        "cis_section_id": "2.2",
-                        "cis_type": "manual",
-                        "cis_version": "v1.3.0",
-                        "plugin": "aws"
-                      },
-                      "title": "2.2.1 Ensure EBS volume encryption is enabled",
-                      "results": [
-                        {
-                          "reason": "is totally secure and this is qa very very very very very long reason",
-                          "resource": "resource name",
-                          "status": "ok",
-                          "dimensions": [
-                            {
-                              "key": "partition",
-                              "value": "partition 30000"
-                            },
-                            {
-                              "key": "region",
-                              "value": "us-east-3"
-                            },
-                            {
-                              "key": "account",
-                              "value": "21323354377537"
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ],
-              "controls": null
-            },
-            {
-              "group_id": "benchmark.cis_v130_3",
-              "title": "3 Logging",
-              "description": "",
-              "tags": {
-                "benchmark": "cis",
-                "cis_controls_version": "v7.1",
-                "cis_section_id": "3",
-                "cis_version": "v1.3.0",
-                "plugin": "aws"
-              },
-              "summary": {
-                "status": {
-                  "alarm": 0,
-                  "ok": 11,
-                  "info": 0,
-                  "skip": 0,
-                  "error": 0
-                }
-              },
-              "groups": [],
-              "controls": [
-                {
-                  "control_id": "control.cis_v130_3_1",
-                  "description": "AWS CloudTrail is a web service that records AWS API calls for your account and delivers log files to you. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service. CloudTrail provides a history of AWS API calls for an account, including API calls made via the Management Console, SDKs, command line tools, and higher-level AWS services (such as CloudFormation).",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.2",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.1",
-                    "cis_levels": "1",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.1 Ensure CloudTrail is enabled in all regions",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_2",
-                  "description": "CloudTrail log file validation creates a digitally signed digest file containing a hash of each log that CloudTrail writes to S3. These digest files can be used to determine whether a log file was changed, deleted, or unchanged after CloudTrail delivered the log. It is recommended that file validation be enabled on all CloudTrails.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.2",
-                    "cis_levels": "2",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.2 Ensure CloudTrail log file validation is enabled.",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_3",
-                  "description": "CloudTrail logs a record of every API call made in your AWS account. These logs file are stored in an S3 bucket. It is recommended that the bucket policy or access control list (ACL) applied to the S3 bucket that CloudTrail logs to prevent public access to the CloudTrail logs.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "14.6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.3",
-                    "cis_levels": "1",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.3 Ensure the S3 bucket used to store CloudTrail logs is not publicly accessible",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_4",
-                  "description": "AWS CloudTrail is a web service that records AWS API calls made in a given AWS account. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service. CloudTrail uses Amazon S3 for log file storage and delivery, so log files are stored durably. In addition to capturing CloudTrail logs within a specified S3 bucket for long term analysis, realtime analysis can be performed by configuring CloudTrail to send logs to CloudWatch Logs. For a trail that is enabled in all regions in an account, CloudTrail sends log files from all those regions to a CloudWatch Logs log group. It is recommended that CloudTrail logs be sent to CloudWatch Logs.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "6.2",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.4",
-                    "cis_level": "1",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.4 Ensure CloudTrail trails are integrated with CloudWatch Logs",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_5",
-                  "description": "AWS Config is a web service that performs configuration management of supported AWS resources within your account and delivers log files to you. The recorded information includes the configuration item (AWS resource), relationships between configuration items (AWS resources), any configuration changes between resources. It is recommended to enable AWS Config be enabled in all regions.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "1.4,11.2,16.1",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.5",
-                    "cis_level": "1",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.5 Ensure AWS Config is enabled in all regions",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_6",
-                  "description": "S3 Bucket Access Logging generates a log that contains access records for each request made to your S3 bucket. An access log record contains details about the request, such as the request type, the resources specified in the request worked, and the time and date the request was processed. It is recommended that bucket access logging be enabled on the CloudTrail S3 bucket.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "6.2,14.9",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.6",
-                    "cis_level": "1",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.6 Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_7",
-                  "description": "AWS CloudTrail is a web service that records AWS API calls for an account and makes those logs available to users and resources in accordance with IAM policies. AWS Key Management Service (KMS) is a managed service that helps create and control the encryption keys used to encrypt account data, and uses Hardware Security Modules (HSMs) to protect the security of encryption keys. CloudTrail logs can be configured to leverage server side encryption (SSE) and KMS customer created master keys (CMK) to further protect CloudTrail logs. It is recommended that CloudTrail be configured to use SSE-KMS.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.7",
-                    "cis_level": "2",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.7 Ensure CloudTrail logs are encrypted at rest using KMS CMKs",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_8",
-                  "description": "AWS Key Management Service (KMS) allows customers to rotate the backing key which is key material stored within the KMS which is tied to the key ID of the Customer Created customer master key (CMK). It is the backing key that is used to perform cryptographic operations such as encryption and decryption. Automated key rotation currently retains all prior backing keys so that decryption of encrypted data can take place transparently. It is recommended that CMK key rotation be enabled.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.8",
-                    "cis_level": "2",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.8 Ensure rotation for customer created CMKs is enabled",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_9",
-                  "description": "VPC Flow Logs is a feature that enables you to capture information about the IP traffic going to and from network interfaces in your VPC. After you've created a flow log, you can view and retrieve its data in Amazon CloudWatch Logs. It is recommended that VPC Flow Logs be enabled for packet \"Rejects\" for VPCs.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "6.2,12.5",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.9",
-                    "cis_level": "2",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.9 Ensure VPC flow logging is enabled in all VPCs",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_10",
-                  "description": "S3 object-level API operations such as GetObject, DeleteObject, and PutObject are called data events. By default, CloudTrail trails don't log data events and so it is recommended to enable Object-level logging for S3 buckets.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "6.2,6.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.10",
-                    "cis_level": "2",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.10 Ensure that Object-level logging for write events is enabled for S3 bucket",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_3_11",
-                  "description": "S3 object-level API operations such as GetObject, DeleteObject, and PutObject are called data events. By default, CloudTrail trails don't log data events and so it is recommended to enable Object-level logging for S3 buckets.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_control": "6.2,6.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "3.11",
-                    "cis_level": "2",
-                    "cis_section_id": "3",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "3.11 Ensure that Object-level logging for read events is enabled for S3 bucket",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "group_id": "benchmark.cis_v130_4",
-              "title": "4 Monitoring",
-              "description": "",
-              "tags": {
-                "benchmark": "cis",
-                "cis_controls_version": "v7.1",
-                "cis_section_id": "4",
-                "cis_version": "v1.3.0",
-                "plugin": "aws"
-              },
-              "summary": {
-                "status": {
-                  "alarm": 0,
-                  "ok": 11,
-                  "info": 2,
-                  "skip": 2,
-                  "error": 0
-                }
-              },
-              "groups": [],
-              "controls": [
-                {
-                  "control_id": "control.cis_v130_4_1",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for unauthorized API calls.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.5,6.7",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.1",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.1 Ensure a log metric filter and alarm exist for unauthorized API calls",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_2",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for console logins that are not protected by multi-factor authentication (MFA).",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.2",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.2 Ensure a log metric filter and alarm exist for Management Console sign-in without MFA",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_3",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for root login attempts.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "4.9",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.3",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.3 Ensure a log metric filter and alarm exist for usage of \"root\" account",
-                  "results": [
-                    {
-                      "reason": "just some info, thought you should know",
-                      "resource": "resource name",
-                      "status": "info",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 20000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_4",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established changes made to Identity and Access Management (IAM) policies.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.4",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.4 Ensure a log metric filter and alarm exist for IAM policy changes",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_5",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for detecting changes to CloudTrail's configurations.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.5",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.5 Ensure a log metric filter and alarm exist for CloudTrail configuration changes",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_6",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for failed console authentication attempts.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.6",
-                    "cis_levels": "2",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.6 Ensure a log metric filter and alarm exist for AWS Management Console authentication failures",
-                  "results": [
-                    {
-                      "reason": "just some info, thought you should know",
-                      "resource": "resource name",
-                      "status": "info",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 20000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_7",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for customer created CMKs which have changed state to disabled or scheduled deletion.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "16",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.7",
-                    "cis_levels": "2",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.7 Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_8",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for changes to S3 bucket policies.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.2,14",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.8",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.8 Ensure a log metric filter and alarm exist for S3 bucket policy changes",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_9",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for detecting changes to CloudTrail's configurations.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "1.4,11.2,16.1",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.9",
-                    "cis_levels": "2",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.9 Ensure a log metric filter and alarm exist for AWS Config configuration changes",
-                  "results": [
-                    {
-                      "reason": "totally skipping this one",
-                      "resource": "resource name",
-                      "status": "skip",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 40000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-4"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_10",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. Security Groups are a stateful packet filter that controls ingress and egress traffic within a VPC. It is recommended that a metric filter and alarm be established for detecting changes to Security Groups.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.2,14.6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.10",
-                    "cis_levels": "2",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.10 Ensure a log metric filter and alarm exist for security group changes",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_11",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. NACLs are used as a stateless packet filter to control ingress and egress traffic for subnets within a VPC. It is recommended that a metric filter and alarm be established for changes made to NACLs.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "11.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.11",
-                    "cis_levels": "2",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.11 Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL)",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_12",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. Network gateways are required to send/receive traffic to a destination outside of a VPC. It is recommended that a metric filter and alarm be established for changes to network gateways.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.2,11.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.12",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.12 Ensure a log metric filter and alarm exist for changes to network gateways",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_13",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. Routing tables are used to route network traffic between subnets and to network gateways. It is recommended that a metric filter and alarm be established for changes to route tables.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.2,11.3",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.13",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.13 Ensure a log metric filter and alarm exist for route table changes",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_14",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is possible to have more than 1 VPC within an account, in addition it is also possible to create a peer connection between 2 VPCs enabling network traffic to route between VPCs. It is recommended that a metric filter and alarm be established for changes made to VPCs.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "5.5",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.14",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.14 Ensure a log metric filter and alarm exist for VPC changes",
-                  "results": [
-                    {
-                      "reason": "totally skipping this one",
-                      "resource": "resource name",
-                      "status": "skip",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 40000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-4"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_4_15",
-                  "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for AWS Organizations changes made in the master AWS Account.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "6.2,14.6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "4.15",
-                    "cis_levels": "1",
-                    "cis_section_id": "4",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "4.15 Ensure a log metric filter and alarm exists for AWS Organizations changes",
-                  "results": [
-                    {
-                      "reason": "is totally secure and this is qa very very very very very long reason",
-                      "resource": "resource name",
-                      "status": "ok",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 30000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-3"
-                        },
-                        {
-                          "key": "account",
-                          "value": "21323354377537"
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "group_id": "benchmark.cis_v130_5",
-              "title": "5 Networking",
-              "description": "",
-              "tags": {
-                "benchmark": "cis",
-                "cis_controls_version": "v7.1",
-                "cis_section_id": "5",
-                "cis_version": "v1.3.0",
-                "plugin": "aws"
-              },
-              "summary": {
-                "status": {
-                  "alarm": 4,
-                  "ok": 0,
-                  "info": 0,
-                  "skip": 0,
-                  "error": 0
-                }
-              },
-              "groups": [],
-              "controls": [
-                {
-                  "control_id": "control.cis_v130_5_1",
-                  "description": "The Network Access Control List (NACL) function provide stateless filtering of ingress and egress network traffic to AWS resources. It is recommended that no NACL allows unrestricted ingress access to remote server administration ports, such as SSH to port 22 and RDP to port 3389.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "9.2,12.4",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "5.1",
-                    "cis_levels": "1",
-                    "cis_section_id": "5",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "5.1 Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports",
-                  "results": [
-                    {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_5_2",
-                  "description": "Security groups provide stateful filtering of ingress and egress network traffic to AWS resources. It is recommended that no security group allows unrestricted ingress access to remote server administration ports, such as SSH to port 22 and RDP to port 3389.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "9.2,12.4",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "5.2",
-                    "cis_levels": "1",
-                    "cis_section_id": "5",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "5.2 Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration ports",
-                  "results": [
-                    {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_5_3",
-                  "description": "A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group. If you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group. Security groups provide stateful filtering of ingress/egress network traffic to AWS resources. It is recommended that the default security group restrict all traffic.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "14.6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "5.3",
-                    "cis_levels": "1",
-                    "cis_section_id": "5",
-                    "cis_type": "automated",
-                    "cis_version": "v1.3.0",
-                    "plugin": "aws"
-                  },
-                  "title": "5.3 Ensure the default security group of every VPC restricts all traffic",
-                  "results": [
-                    {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
-                      "dimensions": [
-                        {
-                          "key": "partition",
-                          "value": "partition 10000"
-                        },
-                        {
-                          "key": "region",
-                          "value": "us-east-2"
-                        },
-                        {
-                          "key": "account",
-                          "value": "3335354343537"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "control_id": "control.cis_v130_5_4",
-                  "description": "A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group. If you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group. Security groups provide stateful filtering of ingress/egress network traffic to AWS resources. It is recommended that the default security group restrict all traffic.",
-                  "severity": "",
-                  "tags": {
-                    "benchmark": "cis",
-                    "cis_controls": "14.6",
-                    "cis_controls_version": "v7.1",
-                    "cis_item_id": "5.4",
-                    "cis_levels": "1",
-                    "cis_section_id": "5",
                     "cis_type": "manual",
                     "cis_version": "v1.3.0",
                     "plugin": "aws"
                   },
-                  "title": "5.4 Ensure routing tables for VPC peering are 'least access'",
+                  "title": "2.1.1 Ensure all S3 buckets employ encryption-at-rest",
                   "results": [
                     {
-                      "reason": "is pretty insecure",
-                      "resource": "some other resource",
-                      "status": "alarm",
+                      "reason": "is totally secure and this is qa very very very very very long reason",
+                      "resource": "resource name",
+                      "status": "ok",
                       "dimensions": [
                         {
                           "key": "partition",
-                          "value": "partition 10000"
+                          "value": "partition 30000"
                         },
                         {
                           "key": "region",
-                          "value": "us-east-2"
+                          "value": "us-east-3"
                         },
                         {
                           "key": "account",
-                          "value": "3335354343537"
+                          "value": "21323354377537"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "control_id": "control.cis_v130_2_1_2",
+                  "description": "At the Amazon S3 bucket level, you can configure permissions through a bucket policy making the objects accessible only through HTTPS.",
+                  "severity": "",
+                  "tags": {
+                    "benchmark": "cis",
+                    "cis_controls": "14.8",
+                    "cis_controls_version": "v7.1",
+                    "cis_item_id": "2.1.2",
+                    "cis_levels": "1,2",
+                    "cis_section_id": "2.1",
+                    "cis_type": "manual",
+                    "cis_version": "v1.3.0",
+                    "plugin": "aws"
+                  },
+                  "title": "2.1.2 Ensure S3 Bucket Policy allows HTTPS requests",
+                  "results": [
+                    {
+                      "reason": "just some info, thought you should know",
+                      "resource": "resource name",
+                      "status": "info",
+                      "dimensions": [
+                        {
+                          "key": "partition",
+                          "value": "partition 20000"
+                        },
+                        {
+                          "key": "region",
+                          "value": "us-east-3"
+                        },
+                        {
+                          "key": "account",
+                          "value": "21323354377537"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "group_id": "benchmark.cis_v130_2_2",
+              "title": "2.2 Elastic Compute Cloud (EC2)",
+              "description": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls_version": "v7.1",
+                "cis_section_id": "2.2",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "summary": {
+                "status": {
+                  "alarm": 0,
+                  "ok": 1,
+                  "info": 0,
+                  "skip": 0,
+                  "error": 0
+                }
+              },
+              "groups": [],
+              "controls": [
+                {
+                  "control_id": "control.cis_v130_2_2_1",
+                  "description": "Elastic Compute Cloud (EC2) supports encryption at rest when using the Elastic Block Store (EBS) service. While disabled by default, forcing encryption at EBS volume creation is supported.",
+                  "severity": "",
+                  "tags": {
+                    "benchmark": "cis",
+                    "cis_controls": "14.8",
+                    "cis_controls_version": "v7.1",
+                    "cis_item_id": "2.2.1",
+                    "cis_levels": "1,2",
+                    "cis_section_id": "2.2",
+                    "cis_type": "manual",
+                    "cis_version": "v1.3.0",
+                    "plugin": "aws"
+                  },
+                  "title": "2.2.1 Ensure EBS volume encryption is enabled",
+                  "results": [
+                    {
+                      "reason": "is totally secure and this is qa very very very very very long reason",
+                      "resource": "resource name",
+                      "status": "ok",
+                      "dimensions": [
+                        {
+                          "key": "partition",
+                          "value": "partition 30000"
+                        },
+                        {
+                          "key": "region",
+                          "value": "us-east-3"
+                        },
+                        {
+                          "key": "account",
+                          "value": "21323354377537"
                         }
                       ]
                     }
@@ -2308,6 +1078,1218 @@
             }
           ],
           "controls": null
+        },
+        {
+          "group_id": "benchmark.cis_v130_3",
+          "title": "3 Logging",
+          "description": "",
+          "tags": {
+            "benchmark": "cis",
+            "cis_controls_version": "v7.1",
+            "cis_section_id": "3",
+            "cis_version": "v1.3.0",
+            "plugin": "aws"
+          },
+          "summary": {
+            "status": {
+              "alarm": 0,
+              "ok": 11,
+              "info": 0,
+              "skip": 0,
+              "error": 0
+            }
+          },
+          "groups": [],
+          "controls": [
+            {
+              "control_id": "control.cis_v130_3_1",
+              "description": "AWS CloudTrail is a web service that records AWS API calls for your account and delivers log files to you. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service. CloudTrail provides a history of AWS API calls for an account, including API calls made via the Management Console, SDKs, command line tools, and higher-level AWS services (such as CloudFormation).",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6.2",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.1",
+                "cis_levels": "1",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.1 Ensure CloudTrail is enabled in all regions",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_2",
+              "description": "CloudTrail log file validation creates a digitally signed digest file containing a hash of each log that CloudTrail writes to S3. These digest files can be used to determine whether a log file was changed, deleted, or unchanged after CloudTrail delivered the log. It is recommended that file validation be enabled on all CloudTrails.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.2",
+                "cis_levels": "2",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.2 Ensure CloudTrail log file validation is enabled.",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_3",
+              "description": "CloudTrail logs a record of every API call made in your AWS account. These logs file are stored in an S3 bucket. It is recommended that the bucket policy or access control list (ACL) applied to the S3 bucket that CloudTrail logs to prevent public access to the CloudTrail logs.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "14.6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.3",
+                "cis_levels": "1",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.3 Ensure the S3 bucket used to store CloudTrail logs is not publicly accessible",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_4",
+              "description": "AWS CloudTrail is a web service that records AWS API calls made in a given AWS account. The recorded information includes the identity of the API caller, the time of the API call, the source IP address of the API caller, the request parameters, and the response elements returned by the AWS service. CloudTrail uses Amazon S3 for log file storage and delivery, so log files are stored durably. In addition to capturing CloudTrail logs within a specified S3 bucket for long term analysis, realtime analysis can be performed by configuring CloudTrail to send logs to CloudWatch Logs. For a trail that is enabled in all regions in an account, CloudTrail sends log files from all those regions to a CloudWatch Logs log group. It is recommended that CloudTrail logs be sent to CloudWatch Logs.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "6.2",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.4",
+                "cis_level": "1",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.4 Ensure CloudTrail trails are integrated with CloudWatch Logs",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_5",
+              "description": "AWS Config is a web service that performs configuration management of supported AWS resources within your account and delivers log files to you. The recorded information includes the configuration item (AWS resource), relationships between configuration items (AWS resources), any configuration changes between resources. It is recommended to enable AWS Config be enabled in all regions.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "1.4,11.2,16.1",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.5",
+                "cis_level": "1",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.5 Ensure AWS Config is enabled in all regions",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_6",
+              "description": "S3 Bucket Access Logging generates a log that contains access records for each request made to your S3 bucket. An access log record contains details about the request, such as the request type, the resources specified in the request worked, and the time and date the request was processed. It is recommended that bucket access logging be enabled on the CloudTrail S3 bucket.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "6.2,14.9",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.6",
+                "cis_level": "1",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.6 Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_7",
+              "description": "AWS CloudTrail is a web service that records AWS API calls for an account and makes those logs available to users and resources in accordance with IAM policies. AWS Key Management Service (KMS) is a managed service that helps create and control the encryption keys used to encrypt account data, and uses Hardware Security Modules (HSMs) to protect the security of encryption keys. CloudTrail logs can be configured to leverage server side encryption (SSE) and KMS customer created master keys (CMK) to further protect CloudTrail logs. It is recommended that CloudTrail be configured to use SSE-KMS.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.7",
+                "cis_level": "2",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.7 Ensure CloudTrail logs are encrypted at rest using KMS CMKs",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_8",
+              "description": "AWS Key Management Service (KMS) allows customers to rotate the backing key which is key material stored within the KMS which is tied to the key ID of the Customer Created customer master key (CMK). It is the backing key that is used to perform cryptographic operations such as encryption and decryption. Automated key rotation currently retains all prior backing keys so that decryption of encrypted data can take place transparently. It is recommended that CMK key rotation be enabled.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.8",
+                "cis_level": "2",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.8 Ensure rotation for customer created CMKs is enabled",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_9",
+              "description": "VPC Flow Logs is a feature that enables you to capture information about the IP traffic going to and from network interfaces in your VPC. After you've created a flow log, you can view and retrieve its data in Amazon CloudWatch Logs. It is recommended that VPC Flow Logs be enabled for packet \"Rejects\" for VPCs.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "6.2,12.5",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.9",
+                "cis_level": "2",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.9 Ensure VPC flow logging is enabled in all VPCs",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_10",
+              "description": "S3 object-level API operations such as GetObject, DeleteObject, and PutObject are called data events. By default, CloudTrail trails don't log data events and so it is recommended to enable Object-level logging for S3 buckets.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "6.2,6.3",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.10",
+                "cis_level": "2",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.10 Ensure that Object-level logging for write events is enabled for S3 bucket",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_3_11",
+              "description": "S3 object-level API operations such as GetObject, DeleteObject, and PutObject are called data events. By default, CloudTrail trails don't log data events and so it is recommended to enable Object-level logging for S3 buckets.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_control": "6.2,6.3",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "3.11",
+                "cis_level": "2",
+                "cis_section_id": "3",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "3.11 Ensure that Object-level logging for read events is enabled for S3 bucket",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "group_id": "benchmark.cis_v130_4",
+          "title": "4 Monitoring",
+          "description": "",
+          "tags": {
+            "benchmark": "cis",
+            "cis_controls_version": "v7.1",
+            "cis_section_id": "4",
+            "cis_version": "v1.3.0",
+            "plugin": "aws"
+          },
+          "summary": {
+            "status": {
+              "alarm": 0,
+              "ok": 11,
+              "info": 2,
+              "skip": 2,
+              "error": 0
+            }
+          },
+          "groups": [],
+          "controls": [
+            {
+              "control_id": "control.cis_v130_4_1",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for unauthorized API calls.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6.5,6.7",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.1",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.1 Ensure a log metric filter and alarm exist for unauthorized API calls",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_2",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for console logins that are not protected by multi-factor authentication (MFA).",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.2",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.2 Ensure a log metric filter and alarm exist for Management Console sign-in without MFA",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_3",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for root login attempts.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "4.9",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.3",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.3 Ensure a log metric filter and alarm exist for usage of \"root\" account",
+              "results": [
+                {
+                  "reason": "just some info, thought you should know",
+                  "resource": "resource name",
+                  "status": "info",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 20000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_4",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established changes made to Identity and Access Management (IAM) policies.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.4",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.4 Ensure a log metric filter and alarm exist for IAM policy changes",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_5",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for detecting changes to CloudTrail's configurations.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.5",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.5 Ensure a log metric filter and alarm exist for CloudTrail configuration changes",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_6",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for failed console authentication attempts.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.6",
+                "cis_levels": "2",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.6 Ensure a log metric filter and alarm exist for AWS Management Console authentication failures",
+              "results": [
+                {
+                  "reason": "just some info, thought you should know",
+                  "resource": "resource name",
+                  "status": "info",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 20000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_7",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for customer created CMKs which have changed state to disabled or scheduled deletion.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "16",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.7",
+                "cis_levels": "2",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.7 Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_8",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for changes to S3 bucket policies.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6.2,14",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.8",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.8 Ensure a log metric filter and alarm exist for S3 bucket policy changes",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_9",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for detecting changes to CloudTrail's configurations.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "1.4,11.2,16.1",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.9",
+                "cis_levels": "2",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.9 Ensure a log metric filter and alarm exist for AWS Config configuration changes",
+              "results": [
+                {
+                  "reason": "totally skipping this one",
+                  "resource": "resource name",
+                  "status": "skip",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 40000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-4"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_10",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. Security Groups are a stateful packet filter that controls ingress and egress traffic within a VPC. It is recommended that a metric filter and alarm be established for detecting changes to Security Groups.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6.2,14.6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.10",
+                "cis_levels": "2",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.10 Ensure a log metric filter and alarm exist for security group changes",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_11",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. NACLs are used as a stateless packet filter to control ingress and egress traffic for subnets within a VPC. It is recommended that a metric filter and alarm be established for changes made to NACLs.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "11.3",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.11",
+                "cis_levels": "2",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.11 Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL)",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_12",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. Network gateways are required to send/receive traffic to a destination outside of a VPC. It is recommended that a metric filter and alarm be established for changes to network gateways.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6.2,11.3",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.12",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.12 Ensure a log metric filter and alarm exist for changes to network gateways",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_13",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. Routing tables are used to route network traffic between subnets and to network gateways. It is recommended that a metric filter and alarm be established for changes to route tables.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6.2,11.3",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.13",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.13 Ensure a log metric filter and alarm exist for route table changes",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_14",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is possible to have more than 1 VPC within an account, in addition it is also possible to create a peer connection between 2 VPCs enabling network traffic to route between VPCs. It is recommended that a metric filter and alarm be established for changes made to VPCs.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "5.5",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.14",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.14 Ensure a log metric filter and alarm exist for VPC changes",
+              "results": [
+                {
+                  "reason": "totally skipping this one",
+                  "resource": "resource name",
+                  "status": "skip",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 40000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-4"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_4_15",
+              "description": "Real-time monitoring of API calls can be achieved by directing CloudTrail Logs to CloudWatch Logs and establishing corresponding metric filters and alarms. It is recommended that a metric filter and alarm be established for AWS Organizations changes made in the master AWS Account.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "6.2,14.6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "4.15",
+                "cis_levels": "1",
+                "cis_section_id": "4",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "4.15 Ensure a log metric filter and alarm exists for AWS Organizations changes",
+              "results": [
+                {
+                  "reason": "is totally secure and this is qa very very very very very long reason",
+                  "resource": "resource name",
+                  "status": "ok",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 30000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-3"
+                    },
+                    {
+                      "key": "account",
+                      "value": "21323354377537"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "group_id": "benchmark.cis_v130_5",
+          "title": "5 Networking",
+          "description": "",
+          "tags": {
+            "benchmark": "cis",
+            "cis_controls_version": "v7.1",
+            "cis_section_id": "5",
+            "cis_version": "v1.3.0",
+            "plugin": "aws"
+          },
+          "summary": {
+            "status": {
+              "alarm": 4,
+              "ok": 0,
+              "info": 0,
+              "skip": 0,
+              "error": 0
+            }
+          },
+          "groups": [],
+          "controls": [
+            {
+              "control_id": "control.cis_v130_5_1",
+              "description": "The Network Access Control List (NACL) function provide stateless filtering of ingress and egress network traffic to AWS resources. It is recommended that no NACL allows unrestricted ingress access to remote server administration ports, such as SSH to port 22 and RDP to port 3389.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "9.2,12.4",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "5.1",
+                "cis_levels": "1",
+                "cis_section_id": "5",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "5.1 Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote server administration ports",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_5_2",
+              "description": "Security groups provide stateful filtering of ingress and egress network traffic to AWS resources. It is recommended that no security group allows unrestricted ingress access to remote server administration ports, such as SSH to port 22 and RDP to port 3389.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "9.2,12.4",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "5.2",
+                "cis_levels": "1",
+                "cis_section_id": "5",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "5.2 Ensure no security groups allow ingress from 0.0.0.0/0 to remote server administration ports",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_5_3",
+              "description": "A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group. If you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group. Security groups provide stateful filtering of ingress/egress network traffic to AWS resources. It is recommended that the default security group restrict all traffic.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "14.6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "5.3",
+                "cis_levels": "1",
+                "cis_section_id": "5",
+                "cis_type": "automated",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "5.3 Ensure the default security group of every VPC restricts all traffic",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "control_id": "control.cis_v130_5_4",
+              "description": "A VPC comes with a default security group whose initial settings deny all inbound traffic, allow all outbound traffic, and allow all traffic between instances assigned to the security group. If you don't specify a security group when you launch an instance, the instance is automatically assigned to this default security group. Security groups provide stateful filtering of ingress/egress network traffic to AWS resources. It is recommended that the default security group restrict all traffic.",
+              "severity": "",
+              "tags": {
+                "benchmark": "cis",
+                "cis_controls": "14.6",
+                "cis_controls_version": "v7.1",
+                "cis_item_id": "5.4",
+                "cis_levels": "1",
+                "cis_section_id": "5",
+                "cis_type": "manual",
+                "cis_version": "v1.3.0",
+                "plugin": "aws"
+              },
+              "title": "5.4 Ensure routing tables for VPC peering are 'least access'",
+              "results": [
+                {
+                  "reason": "is pretty insecure",
+                  "resource": "some other resource",
+                  "status": "alarm",
+                  "dimensions": [
+                    {
+                      "key": "partition",
+                      "value": "partition 10000"
+                    },
+                    {
+                      "key": "region",
+                      "value": "us-east-2"
+                    },
+                    {
+                      "key": "account",
+                      "value": "3335354343537"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
         }
       ],
       "controls": null

--- a/tests/acceptance/test_files/008.check.bats
+++ b/tests/acceptance/test_files/008.check.bats
@@ -1,52 +1,52 @@
 load "$LIB_BATS_ASSERT/load.bash"
 load "$LIB_BATS_SUPPORT/load.bash"
 
-@test "steampipe check all" {
+@test "steampipe check cis_v130" {
   cd $WORKSPACE_DIR
-  run steampipe check all
+  run steampipe check benchmark.cis_v130
   assert_equal $status 10
   cd -
 }
 
-@test "steampipe check all - output csv" {
+@test "steampipe check cis_v130 - output csv" {
   cd $WORKSPACE_DIR
-  run steampipe check all --output=csv --progress=false
+  run steampipe check benchmark.cis_v130 --output=csv --progress=false
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_check_csv.csv)"
   cd -
 }
 
-@test "steampipe check all - output csv - | separator" {
+@test "steampipe check cis_v130 - output csv - | separator" {
   cd $WORKSPACE_DIR
-  run steampipe check all --output=csv --progress=false "--separator=|"
+  run steampipe check benchmark.cis_v130 --output=csv --progress=false "--separator=|"
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_check_separator_csv.csv)"
   cd -
 }
 
-@test "steampipe check all - output csv - no header" {
+@test "steampipe check cis_v130 - output csv - no header" {
   cd $WORKSPACE_DIR
-  run steampipe check all --output=csv --progress=false --header=false
+  run steampipe check benchmark.cis_v130 --output=csv --progress=false --header=false
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_check_csv_noheader.csv)"
   cd -
 }
 
-@test "steampipe check all - output json" {
+@test "steampipe check cis_v130 - output json" {
   cd $WORKSPACE_DIR
-  run steampipe check all --output=json --progress=false
+  run steampipe check benchmark.cis_v130 --output=json --progress=false
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_check_json.json)"
   cd -
 }
 
-@test "steampipe check all - export csv" {
+@test "steampipe check cis_v130 - export csv" {
   cd $WORKSPACE_DIR
-  run steampipe check all --export=csv:./test.csv --progress=false
+  run steampipe check benchmark.cis_v130 --export=csv:./test.csv --progress=false
   assert_equal "$(cat ./test.csv)" "$(cat $TEST_DATA_DIR/expected_check_csv.csv)"
   rm -f ./test.csv
   cd -
 }
 
-@test "steampipe check all - export json" {
+@test "steampipe check cis_v130 - export json" {
   cd $WORKSPACE_DIR
-  run steampipe check all --export=json:./test.json --progress=false
+  run steampipe check benchmark.cis_v130 --export=json:./test.json --progress=false
   assert_equal "$(cat ./test.json)" "$(cat $TEST_DATA_DIR/expected_check_json.json)"
   rm -f ./test.json
   cd -

--- a/tests/acceptance/test_files/009.check-search-path.bats
+++ b/tests/acceptance/test_files/009.check-search-path.bats
@@ -1,0 +1,48 @@
+load "$LIB_BATS_ASSERT/load.bash"
+load "$LIB_BATS_SUPPORT/load.bash"
+
+@test "steampipe check search_path_prefix when passed through command line" {
+  cd $WORKSPACE_DIR
+  run steampipe check control.search_path_test_1 --output json --search-path-prefix aws --export output.json
+  assert_equal "$(cat output.json | jq '.controls[0].results[0].status')" '"ok"'
+  rm -f output.json
+}
+
+@test "steampipe check search_path when passed through command line" {
+  cd $WORKSPACE_DIR
+  run steampipe check control.search_path_test_2 --output json --search-path a,b,c --export output.json
+  assert_equal "$(cat output.json | jq '.controls[0].results[0].status')" '"ok"'
+  rm -f output.json
+}
+
+@test "steampipe check search_path and search_path_prefix when passed through command line" {
+  cd $WORKSPACE_DIR
+  run steampipe check control.search_path_test_3 --output json --search-path a,b,c --search-path-prefix aws --export output.json
+  assert_equal "$(cat output.json | jq '.controls[0].results[0].status')" '"ok"'
+  rm -f output.json
+}
+
+@test "steampipe check search_path_prefix when passed in the control" {
+  cd $WORKSPACE_DIR
+  run steampipe check control.search_path_test_4 --output json --export output.json
+  assert_equal "$(cat output.json | jq '.controls[0].results[0].status')" '"ok"'
+  rm -f output.json
+}
+
+@test "steampipe check search_path when passed in the control" {
+  cd $WORKSPACE_DIR
+  run steampipe check control.search_path_test_5 --output json --export output.json
+  assert_equal "$(cat output.json | jq '.controls[0].results[0].status')" '"ok"'
+  rm -f output.json
+}
+
+@test "steampipe check search_path and search_path_prefix when passed in the control" {
+  cd $WORKSPACE_DIR
+  run steampipe check control.search_path_test_6 --output json --export output.json
+  assert_equal "$(cat output.json | jq '.controls[0].results[0].status')" '"ok"'
+  rm -f output.json
+}
+
+function teardown() {
+    steampipe service stop --force    
+}


### PR DESCRIPTION
```
pskrbasu@Puskars-MacBook-Pro steampipe (add_tests_for_search_path_721) $ ./tests/acceptance/run-local.sh
 ____  _             _   _               _____         _       
/ ___|| |_ __ _ _ __| |_(_)_ __   __ _  |_   _|__  ___| |_ ___ 
\___ \| __/ _` | '__| __| | '_ \ / _` |   | |/ _ \/ __| __/ __|
 ___) | || (_| | |  | |_| | | | | (_| |   | |  __/\__ \ |_\__ \
|____/ \__\__,_|_|   \__|_|_| |_|\__, |   |_|\___||___/\__|___/
                                 |___/                         
Running with STEAMPIPE_INSTALL_DIR set to /var/folders/50/55rzkdc54sz_08406wysm8l00000gn/T/tmp.nKz0Hp4V
1..69
ok 1 steampipe install
ok 2 steampipe plugin help is displayed when no sub command given
ok 3 steampipe service help is displayed when no sub command given
ok 4 scheduled task run - no update check when disabled in config - TEST DISABLED
ok 5 scheduled task run - no update check when disabled in ENV - TEST DISABLED
ok 6 steampipe install
ok 7 steampipe service start
ok 8 steampipe service restart
ok 9 steampipe service stop
ok 10 steampipe service start --database-port 8765
ok 11 steampipe service start --database-listen local --database-port 8765
ok 12 steampipe plugin install
ok 13 steampipe plugin list
ok 14 steampipe plugin uninstall
ok 15 steampipe query chaos
ok 16 public schema insert select all types
ok 17 query json
ok 18 query csv
ok 19 query line
ok 20 query line long
ok 21 query csv header off
ok 22 query table header off
ok 23 select * from chaos.chaos_high_row_count order by column_0
ok 24 select id, string_column, json_column, boolean_column from chaos.chaos_all_column_types where id='0'
ok 25 select * from chaos.chaos_high_column_count order by column_0
ok 26 select * from chaos.chaos_hydrate_columns_dependency where id='0'
ok 27 select * from chaos.chaos_list_error
ok 28 select panic from chaos.chaos_get_errors where id=0
ok 29 select error from chaos_transform_error
ok 30 select * from chaos.chaos_hydrate_delay
ok 31 select * from chaos.chaos_parallel_hydrate_columns  where id='0'
ok 32 select float32_data, id, int64_data, uint16_data from chaos.chaos_all_numeric_column  where id='31'
ok 33 select transform_method_column from chaos_transforms order by id
ok 34 select parent_should_ignore_error from chaos.chaos_list_parent_child
ok 35 select from_qual_column from chaos_transforms where id=2
ok 36 service start, no config, add connection, query
ok 37 service start, no config, delete connection, query with no restart
ok 38 service start, no config, add connection, query with prefix
ok 39 service start, no config, delete connection, query with prefix
ok 40 service start, no config, query with prefix, add connection, query with prefix
ok 41 service start, no config, query with prefix, delete connection, query with prefix
ok 42 table with header
ok 43 table no header
ok 44 csv header
ok 45 csv no header
ok 46 csv | separator
ok 47 csv | separator no header
ok 48 json
ok 49 line
ok 50 timer on
ok 51 select query install directory
ok 52 named query current folder
ok 53 named query workspace folder
ok 54 sql file
ok 55 sql glob
ok 56 sql glob csv no header
ok 57 steampipe check cis_v130
ok 58 steampipe check cis_v130 - output csv
ok 59 steampipe check cis_v130 - output csv - | separator
ok 60 steampipe check cis_v130 - output csv - no header
ok 61 steampipe check cis_v130 - output json
ok 62 steampipe check cis_v130 - export csv
ok 63 steampipe check cis_v130 - export json
ok 64 steampipe check search_path_prefix when passed through command line
ok 65 steampipe check search_path when passed through command line
ok 66 steampipe check search_path and search_path_prefix when passed through command line
ok 67 steampipe check search_path_prefix when passed in the control
ok 68 steampipe check search_path when passed in the control
ok 69 steampipe check search_path and search_path_prefix when passed in the control
```