### PR TITLE
Add acceptance test for "When an aggregator connection is evaluating a wildcard, only include connections with compatible type". Closes #720

### DIFF
--- a/tests/acceptance/test_data/source_files/aggregator.spc
+++ b/tests/acceptance/test_data/source_files/aggregator.spc
@@ -1,18 +1,3 @@
-connection "chaos_01" {
-  plugin      = "chaos" 
-  profile     = "chaos_01"
-}
-
-connection "chaos_02" {
-  plugin      = "chaos" 
-  profile     = "chaos_02"
-}
-
-connection "steampipe_01" {
-  plugin      = "steampipe" 
-  profile     = "steampipe_02"
-}
-
 connection "chaos_group" {
   type        = "aggregator"
   plugin      = "chaos"

--- a/tests/acceptance/test_data/source_files/aggregator.spc
+++ b/tests/acceptance/test_data/source_files/aggregator.spc
@@ -1,3 +1,11 @@
+connection "chaos" {
+    plugin = "chaos"
+}
+
+connection "chaos2" {
+  plugin = "chaos"
+}
+
 connection "chaos_group" {
   type        = "aggregator"
   plugin      = "chaos"

--- a/tests/acceptance/test_data/source_files/aggregator.spc
+++ b/tests/acceptance/test_data/source_files/aggregator.spc
@@ -1,0 +1,20 @@
+connection "chaos_01" {
+  plugin      = "chaos" 
+  profile     = "chaos_01"
+}
+
+connection "chaos_02" {
+  plugin      = "chaos" 
+  profile     = "chaos_02"
+}
+
+connection "steampipe_01" {
+  plugin      = "steampipe" 
+  profile     = "steampipe_02"
+}
+
+connection "chaos_group" {
+  type        = "aggregator"
+  plugin      = "chaos"
+  connections = ["*"]
+}

--- a/tests/acceptance/test_files/003.plugin.bats
+++ b/tests/acceptance/test_files/003.plugin.bats
@@ -6,14 +6,6 @@ load "$LIB_BATS_SUPPORT/load.bash"
     assert_success
 }
 
-@test "steampipe aggregator connection wildcard check" {
-    run steampipe plugin install chaos
-    run steampipe plugin install aws
-    cp $SRC_DATA_DIR/aggregator.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
-    run steampipe query "select * from chaos_group.chaos_all_column_types"
-    assert_success
-}
-
 @test "steampipe plugin list" {
     run steampipe plugin list
     assert_success

--- a/tests/acceptance/test_files/003.plugin.bats
+++ b/tests/acceptance/test_files/003.plugin.bats
@@ -8,10 +8,9 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "steampipe aggregator connection wildcard check" {
     run steampipe plugin install chaos
-    run steampipe plugin install steampipe
+    run steampipe plugin install aws
     cp $SRC_DATA_DIR/aggregator.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
-    cat $STEAMPIPE_INSTALL_DIR/config/chaos.spc
-    run steampipe query "select * from chaos_all_column_types"
+    run steampipe query "select * from chaos_group.chaos_all_column_types"
     assert_success
 }
 

--- a/tests/acceptance/test_files/003.plugin.bats
+++ b/tests/acceptance/test_files/003.plugin.bats
@@ -6,6 +6,15 @@ load "$LIB_BATS_SUPPORT/load.bash"
     assert_success
 }
 
+@test "steampipe aggregator connection wildcard check" {
+    run steampipe plugin install chaos
+    run steampipe plugin install steampipe
+    cp $SRC_DATA_DIR/aggregator.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
+    cat $STEAMPIPE_INSTALL_DIR/config/chaos.spc
+    run steampipe query "select * from chaos_all_column_types"
+    assert_success
+}
+
 @test "steampipe plugin list" {
     run steampipe plugin list
     assert_success

--- a/tests/acceptance/test_files/010.connection.bats
+++ b/tests/acceptance/test_files/010.connection.bats
@@ -1,0 +1,16 @@
+load "$LIB_BATS_ASSERT/load.bash"
+load "$LIB_BATS_SUPPORT/load.bash"
+
+@test "steampipe aggregator connection wildcard check" {
+    run steampipe plugin install chaos
+    run steampipe plugin install aws
+    cp $SRC_DATA_DIR/aggregator.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
+    run steampipe query "select * from chaos_group.chaos_all_column_types"
+    assert_success
+}
+
+# To add more connection and aggregator connection tests
+
+function teardown() {
+    steampipe service stop --force    
+}


### PR DESCRIPTION
```
pskrbasu@Puskars-MacBook-Pro steampipe (test_for_aggregator_evaluating_wildcard_720) $ ./tests/acceptance/run-local.sh
 ____  _             _   _               _____         _       
/ ___|| |_ __ _ _ __| |_(_)_ __   __ _  |_   _|__  ___| |_ ___ 
\___ \| __/ _` | '__| __| | '_ \ / _` |   | |/ _ \/ __| __/ __|
 ___) | || (_| | |  | |_| | | | | (_| |   | |  __/\__ \ |_\__ \
|____/ \__\__,_|_|   \__|_|_| |_|\__, |   |_|\___||___/\__|___/
                                 |___/                         
Running with STEAMPIPE_INSTALL_DIR set to /var/folders/50/55rzkdc54sz_08406wysm8l00000gn/T/tmp.8EYNcgys
1..70
ok 1 steampipe install
ok 2 steampipe plugin help is displayed when no sub command given
ok 3 steampipe service help is displayed when no sub command given
ok 4 scheduled task run - no update check when disabled in config - TEST DISABLED
ok 5 scheduled task run - no update check when disabled in ENV - TEST DISABLED
ok 6 steampipe install
ok 7 steampipe service start
ok 8 steampipe service restart
ok 9 steampipe service stop
ok 10 steampipe service start --database-port 8765
ok 11 steampipe service start --database-listen local --database-port 8765
ok 12 steampipe plugin install
ok 13 steampipe plugin list
ok 14 steampipe plugin uninstall
ok 15 steampipe query chaos
ok 16 public schema insert select all types
ok 17 query json
ok 18 query csv
ok 19 query line
ok 20 query line long
ok 21 query csv header off
ok 22 query table header off
ok 23 select * from chaos.chaos_high_row_count order by column_0
ok 24 select id, string_column, json_column, boolean_column from chaos.chaos_all_column_types where id='0'
ok 25 select * from chaos.chaos_high_column_count order by column_0
ok 26 select * from chaos.chaos_hydrate_columns_dependency where id='0'
ok 27 select * from chaos.chaos_list_error
ok 28 select panic from chaos.chaos_get_errors where id=0
ok 29 select error from chaos_transform_error
ok 30 select * from chaos.chaos_hydrate_delay
ok 31 select * from chaos.chaos_parallel_hydrate_columns  where id='0'
ok 32 select float32_data, id, int64_data, uint16_data from chaos.chaos_all_numeric_column  where id='31'
ok 33 select transform_method_column from chaos_transforms order by id
ok 34 select parent_should_ignore_error from chaos.chaos_list_parent_child
ok 35 select from_qual_column from chaos_transforms where id=2
ok 36 service start, no config, add connection, query
ok 37 service start, no config, delete connection, query with no restart
ok 38 service start, no config, add connection, query with prefix
ok 39 service start, no config, delete connection, query with prefix
ok 40 service start, no config, query with prefix, add connection, query with prefix
ok 41 service start, no config, query with prefix, delete connection, query with prefix
ok 42 table with header
ok 43 table no header
ok 44 csv header
ok 45 csv no header
ok 46 csv | separator
ok 47 csv | separator no header
ok 48 json
ok 49 line
ok 50 timer on
ok 51 select query install directory
ok 52 named query current folder
ok 53 named query workspace folder
ok 54 sql file
ok 55 sql glob
ok 56 sql glob csv no header
ok 57 steampipe check cis_v130
ok 58 steampipe check cis_v130 - output csv
ok 59 steampipe check cis_v130 - output csv - | separator
ok 60 steampipe check cis_v130 - output csv - no header
ok 61 steampipe check cis_v130 - output json
ok 62 steampipe check cis_v130 - export csv
ok 63 steampipe check cis_v130 - export json
ok 64 steampipe check search_path_prefix when passed through command line
ok 65 steampipe check search_path when passed through command line
ok 66 steampipe check search_path and search_path_prefix when passed through command line
ok 67 steampipe check search_path_prefix when passed in the control
ok 68 steampipe check search_path when passed in the control
ok 69 steampipe check search_path and search_path_prefix when passed in the control
ok 70 steampipe aggregator connection wildcard check
```