### PR TITLE
Handle `context canceled` error during control runs. Closes #757

### DIFF
--- a/constants/db.go
+++ b/constants/db.go
@@ -23,7 +23,7 @@ const (
 // constants for installing db and fdw images
 const (
 	DatabaseVersion = "12.1.0"
-	FdwVersion      = "0.2.0-rc.1"
+	FdwVersion      = "0.2.1"
 
 	// DefaultEmbeddedPostgresImage :: The 12.1.0 image uses the older jar format 12.1.0-v2 is the same version of postgres,
 	// just packaged as gzipped tar files (consistent with oras, faster to unzip).  Once everyone is

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -5,3 +5,5 @@ const EEXISTS = "EEXISTS"
 
 // ENOTEXISTS :: universal error string to denote that a resource does not exists
 const ENOTEXISTS = "ENOTEXISTS"
+
+const PluginCrashErrorSubString = "error reading from server: EOF"

--- a/constants/workspace.go
+++ b/constants/workspace.go
@@ -13,6 +13,7 @@ const (
 	WorkspaceDefaultModName = "local"
 	WorkspaceModFileName    = "mod.sp"
 	DefaultVarsFileName     = "steampipe.spvars"
+	MaxControlRunAttempts   = 3
 )
 
 func WorkspaceModPath(workspacePath string) string {

--- a/control/controlexecute/control_run.go
+++ b/control/controlexecute/control_run.go
@@ -135,7 +135,7 @@ func (r *ControlRun) Start(ctx context.Context, client db_common.Client) {
 		// is this an rpc EOF error - meaning that the plugin somehow crashed
 		if strings.Contains(err.Error(), constants.PluginCrashErrorSubString) {
 			if r.attempts > constants.MaxControlRunAttempts {
-				// if exceeded max retries - give up with the original error
+				// if exceeded max retries, give up
 				r.SetError(err)
 				return
 			}

--- a/control/controlexecute/control_run.go
+++ b/control/controlexecute/control_run.go
@@ -130,10 +130,12 @@ func (r *ControlRun) Start(ctx context.Context, client db_common.Client) {
 	// context and its parent alive longer than necessary.
 	defer cancel()
 
+	const pluginCrashErrorSubString = "error reading from server: EOF"
+
 	queryResult, err := client.Execute(ctx, query, false)
 	if err != nil {
 		// is this an rpc EOF error - meaning that the plugin somehow crashed
-		if strings.Contains(err.Error(), "error reading from server: EOF") {
+		if strings.Contains(err.Error(), pluginCrashErrorSubString) {
 			if r.attempts > constants.MaxControlRunAttempts {
 				// if exceeded max retries.
 				r.SetError(fmt.Errorf("max retry attempts exceeded"))

--- a/control/controlexecute/control_run.go
+++ b/control/controlexecute/control_run.go
@@ -71,7 +71,6 @@ func NewControlRun(control *modconfig.Control, group *ResultGroup, executionTree
 
 		executionTree: executionTree,
 		runStatus:     ControlRunReady,
-		attempts:      0,
 
 		group:    group,
 		doneChan: make(chan bool, 1),

--- a/control/controlexecute/control_run.go
+++ b/control/controlexecute/control_run.go
@@ -130,12 +130,10 @@ func (r *ControlRun) Start(ctx context.Context, client db_common.Client) {
 	// context and its parent alive longer than necessary.
 	defer cancel()
 
-	const pluginCrashErrorSubString = "error reading from server: EOF"
-
 	queryResult, err := client.Execute(ctx, query, false)
 	if err != nil {
 		// is this an rpc EOF error - meaning that the plugin somehow crashed
-		if strings.Contains(err.Error(), pluginCrashErrorSubString) {
+		if strings.Contains(err.Error(), constants.PluginCrashErrorSubString) {
 			if r.attempts > constants.MaxControlRunAttempts {
 				// if exceeded max retries.
 				r.SetError(err)

--- a/control/controlexecute/control_run.go
+++ b/control/controlexecute/control_run.go
@@ -139,10 +139,12 @@ func (r *ControlRun) Start(ctx context.Context, client db_common.Client) {
 				r.SetError(err)
 				return
 			}
-			// pass 'true' to disable spinner
+			// set a log line in the database logs for convenience - pass 'true' to disable spinner
 			_, _ = client.ExecuteSync(ctx, "-- Retrying...", true)
 			r.attempts++
-			// retry within the same context, so that we may timeout, even if the attempts haven't exceeded
+
+			// recurse into this function - but with the same context, so that we may timeout,
+			// even if the attempts haven't exceeded
 			r.Start(ctx, client)
 			return
 		}

--- a/control/controlexecute/control_run.go
+++ b/control/controlexecute/control_run.go
@@ -141,10 +141,10 @@ func (r *ControlRun) Start(ctx context.Context, client db_common.Client) {
 			}
 			// set a log line in the database logs for convenience - pass 'true' to disable spinner
 			_, _ = client.ExecuteSync(ctx, "-- Retrying...", true)
-			r.attempts++
 
 			// recurse into this function to retry
 			// use the same context, so that we respect the timeout
+			r.attempts++
 			r.Start(ctx, client)
 			return
 		}

--- a/tests/acceptance/test_data/sample_workspace/cis_v130/plugin_crash.sp
+++ b/tests/acceptance/test_data/sample_workspace/cis_v130/plugin_crash.sp
@@ -1,0 +1,29 @@
+benchmark "check_plugin_crash_benchmark" {
+  title         = "Benchmark to test the plugin crash bug while running controls"
+  children = [
+    control.plugin_chaos_test_1,
+    control.plugin_crash_test,
+    control.plugin_chaos_test_2
+  ]
+}
+
+control "plugin_chaos_test_1" {
+  title       = "Control to query a chaos table"
+  description = "Control to query a chaos table to test all flavours of integer and float data types"
+  sql         = query.check_plugincrash_normalquery1.sql
+  severity    = "high"
+}
+
+control "plugin_crash_test" {
+  title       = "Control to simulate a plugin crash"
+  description = "Control to query a chaos table that prints 50 rows and do an os.Exit(-1) to simulate a plugin crash"
+  sql         = "select * from chaos_plugin_crash"
+  severity    = "high"
+}
+
+control "plugin_chaos_test_2" {
+  title       = "Control to query a chaos table"
+  description = "Control to query a chaos table test the Get call with all the possible scenarios like errors, panics and delays"
+  sql         = query.check_plugincrash_normalquery2.sql
+  severity    = "high"
+}

--- a/tests/acceptance/test_data/sample_workspace/query/check_plugincrash_normalquery1.sql
+++ b/tests/acceptance/test_data/sample_workspace/query/check_plugincrash_normalquery1.sql
@@ -1,0 +1,8 @@
+select 
+    case
+        when mod(id,2)=0 then 'alarm'
+        when mod(id,2)=1 then 'ok'
+    end status,
+    int8_data as resource,
+    int16_data as reason
+from chaos_all_numeric_column

--- a/tests/acceptance/test_data/sample_workspace/query/check_plugincrash_normalquery2.sql
+++ b/tests/acceptance/test_data/sample_workspace/query/check_plugincrash_normalquery2.sql
@@ -1,0 +1,8 @@
+select 
+    case
+        when mod(id,2)=0 then 'alarm'
+        when mod(id,2)=1 then 'ok'
+    end status,
+    fatal_error as resource,
+    retryable_error as reason
+from chaos_get_errors limit 10

--- a/tests/acceptance/test_files/011.check-plugin-crash.bats
+++ b/tests/acceptance/test_files/011.check-plugin-crash.bats
@@ -1,0 +1,9 @@
+load "$LIB_BATS_ASSERT/load.bash"
+load "$LIB_BATS_SUPPORT/load.bash"
+
+@test "check whether the plugin is crashing or not" {
+  cd $WORKSPACE_DIR
+  run steampipe check benchmark.check_plugin_crash_benchmark
+  echo $output
+  [ $(echo $output | grep "ERROR: context canceled" | wc -l | tr -d ' ') -eq 0 ]
+}


### PR DESCRIPTION
### NOTE

The following steps should be followed before merging this PR:

1. Merge https://github.com/turbot/steampipe-postgres-fdw/pull/90 and publish a new FDW version.
2. Merge https://github.com/turbot/steampipe-plugin-chaos/pull/52 which creates a new chaos table to simulate the `context canceled` issue which would help us in adding acceptance tests. Publish a new chaos plugin version.
3. Update the `FdwVersion` in [db.go](https://github.com/turbot/steampipe/blob/main/constants/db.go#L26) to the new FDW version.
4. Merge this test.
