### PR TITLE
`bash`/`zsh` completion. Closes #481

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -50,23 +50,23 @@ func checkCmd() *cobra.Command {
 		Long: `Execute one of more Steampipe benchmarks and controls.
 
 You may specify one or more benchmarks or controls to run (separated by a space), or run 'steampipe check all' to run all controls in the workspace.`,
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
-			if err != nil {
-				return []string{}, cobra.ShellCompDirectiveError
-			}
-			defer workspace.Close()
+		// ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// 	workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+		// 	if err != nil {
+		// 		return []string{}, cobra.ShellCompDirectiveError
+		// 	}
+		// 	defer workspace.Close()
 
-			completions := []string{}
+		// 	completions := []string{}
 
-			for _, item := range workspace.GetSortedBenchmarksAndControlNames() {
-				if strings.HasPrefix(item, toComplete) {
-					completions = append(completions, item)
-				}
-			}
+		// 	for _, item := range workspace.GetSortedBenchmarksAndControlNames() {
+		// 		if strings.HasPrefix(item, toComplete) {
+		// 			completions = append(completions, item)
+		// 		}
+		// 	}
 
-			return completions, cobra.ShellCompDirectiveNoFileComp
-		},
+		// 	return completions, cobra.ShellCompDirectiveNoFileComp
+		// },
 	}
 
 	cmdconfig.

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -50,23 +50,23 @@ func checkCmd() *cobra.Command {
 		Long: `Execute one of more Steampipe benchmarks and controls.
 
 You may specify one or more benchmarks or controls to run (separated by a space), or run 'steampipe check all' to run all controls in the workspace.`,
-		// ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// 	workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
-		// 	if err != nil {
-		// 		return []string{}, cobra.ShellCompDirectiveError
-		// 	}
-		// 	defer workspace.Close()
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+			if err != nil {
+				return []string{}, cobra.ShellCompDirectiveError
+			}
+			defer workspace.Close()
 
-		// 	completions := []string{}
+			completions := []string{}
 
-		// 	for _, item := range workspace.GetSortedBenchmarksAndControlNames() {
-		// 		if strings.HasPrefix(item, toComplete) {
-		// 			completions = append(completions, item)
-		// 		}
-		// 	}
+			for _, item := range workspace.GetSortedBenchmarksAndControlNames() {
+				if strings.HasPrefix(item, toComplete) {
+					completions = append(completions, item)
+				}
+			}
 
-		// 	return completions, cobra.ShellCompDirectiveNoFileComp
-		// },
+			return completions, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 
 	cmdconfig.

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -50,6 +50,23 @@ func checkCmd() *cobra.Command {
 		Long: `Execute one of more Steampipe benchmarks and controls.
 
 You may specify one or more benchmarks or controls to run (separated by a space), or run 'steampipe check all' to run all controls in the workspace.`,
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+			if err != nil {
+				return []string{}, cobra.ShellCompDirectiveError
+			}
+			defer workspace.Close()
+
+			completions := []string{}
+
+			for _, item := range workspace.GetSortedBenchmarksAndControlNames() {
+				if strings.HasPrefix(item, toComplete) {
+					completions = append(completions, item)
+				}
+			}
+
+			return completions, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 
 	cmdconfig.

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -51,15 +51,14 @@ func checkCmd() *cobra.Command {
 
 You may specify one or more benchmarks or controls to run (separated by a space), or run 'steampipe check all' to run all controls in the workspace.`,
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+			workspaceResources, err := workspace.LoadResourceNames(viper.GetString(constants.ArgWorkspace))
 			if err != nil {
 				return []string{}, cobra.ShellCompDirectiveError
 			}
-			defer workspace.Close()
 
 			completions := []string{}
 
-			for _, item := range workspace.GetSortedBenchmarksAndControlNames() {
+			for _, item := range workspaceResources.GetSortedBenchmarksAndControlNames() {
 				if strings.HasPrefix(item, toComplete) {
 					completions = append(completions, item)
 				}

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -62,7 +62,7 @@ func runGenCompletionScriptsCmd(cmd *cobra.Command, args []string) {
 
 	switch completionFor {
 	case "bash":
-		cmd.Root().GenBashCompletion(os.Stdout)
+		cmd.Root().GenBashCompletionV2(os.Stdout, true)
 	case "zsh":
 		cmd.Root().GenZshCompletion(os.Stdout)
 	case "fish":

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/turbot/steampipe/cmdconfig"
+	"github.com/turbot/steampipe/utils"
+)
+
+func generateCompletionScriptsCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:                   "completion [bash|zsh|fish]",
+		Args:                  cobra.ExactValidArgs(1),
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish"},
+		Run:                   runGenCompletionScriptsCmd,
+		Short:                 "Generate completion script",
+		Long: `
+To load completions:
+    Bash:
+        # To load for the current session
+        $ source <(steampipe completion bash)
+        
+        # To load completions for every session, execute once:
+        # Linux:
+        $ steampipe completion bash > /etc/bash_completion.d/steampipe
+        
+        # macOS:
+        $ steampipe completion bash > /usr/local/etc/bash_completion.d/steampipe
+    
+    Zsh:
+        # If shell completion is not already enabled in your environment,
+        # you will need to enable it.  You can execute the following once:
+        $ echo "autoload -U compinit; compinit" >> ~/.zshrc
+        
+        # To load completions for each session, execute once:
+        $ steampipe completion zsh > "${fpath[1]}/steampipe"
+        
+        # You will need to start a new shell for this setup to take effect.
+        
+    fish:
+        
+        $ steampipe completion fish | source
+        
+        # To load completions for each session, execute once:
+        $ steampipe completion fish > ~/.config/fish/completions/steampipe.fish
+`,
+	}
+
+	cmd.ResetFlags()
+
+	cmdconfig.
+		OnCmd(cmd)
+
+	return cmd
+}
+
+func runGenCompletionScriptsCmd(cmd *cobra.Command, args []string) {
+	completionFor := args[0]
+
+	switch completionFor {
+	case "bash":
+		cmd.Root().GenBashCompletion(os.Stdout)
+	case "zsh":
+		cmd.Root().GenZshCompletion(os.Stdout)
+	case "fish":
+		cmd.Root().GenFishCompletion(os.Stdout, true)
+	default:
+		utils.ShowError(fmt.Errorf("completion for '%s' is not supported yet", completionFor))
+	}
+}

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -7,7 +7,6 @@ import (
 	"log"
 	"os"
 	"os/signal"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -45,20 +44,20 @@ Examples:
   # Run a specific query directly
   steampipe query "select * from cloud"`,
 
-		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
-			if err != nil {
-				return []string{}, cobra.ShellCompDirectiveError
-			}
-			defer workspace.Close()
-			namedQueries := []string{}
-			for _, name := range workspace.GetSortedNamedQueryNames() {
-				if strings.HasPrefix(name, toComplete) {
-					namedQueries = append(namedQueries, name)
-				}
-			}
-			return namedQueries, cobra.ShellCompDirectiveNoFileComp
-		},
+		// ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		// 	workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+		// 	if err != nil {
+		// 		return []string{}, cobra.ShellCompDirectiveError
+		// 	}
+		// 	defer workspace.Close()
+		// 	namedQueries := []string{}
+		// 	for _, name := range workspace.GetSortedNamedQueryNames() {
+		// 		if strings.HasPrefix(name, toComplete) {
+		// 			namedQueries = append(namedQueries, name)
+		// 		}
+		// 	}
+		// 	return namedQueries, cobra.ShellCompDirectiveNoFileComp
+		// },
 	}
 
 	// Notes:

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -44,20 +45,20 @@ Examples:
   # Run a specific query directly
   steampipe query "select * from cloud"`,
 
-		// ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		// 	workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
-		// 	if err != nil {
-		// 		return []string{}, cobra.ShellCompDirectiveError
-		// 	}
-		// 	defer workspace.Close()
-		// 	namedQueries := []string{}
-		// 	for _, name := range workspace.GetSortedNamedQueryNames() {
-		// 		if strings.HasPrefix(name, toComplete) {
-		// 			namedQueries = append(namedQueries, name)
-		// 		}
-		// 	}
-		// 	return namedQueries, cobra.ShellCompDirectiveNoFileComp
-		// },
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+			if err != nil {
+				return []string{}, cobra.ShellCompDirectiveError
+			}
+			defer workspace.Close()
+			namedQueries := []string{}
+			for _, name := range workspace.GetSortedNamedQueryNames() {
+				if strings.HasPrefix(name, toComplete) {
+					namedQueries = append(namedQueries, name)
+				}
+			}
+			return namedQueries, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 
 	// Notes:

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -46,11 +46,10 @@ Examples:
   steampipe query "select * from cloud"`,
 
 		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+			workspace, err := workspace.LoadResourceNames(viper.GetString(constants.ArgWorkspace))
 			if err != nil {
 				return []string{}, cobra.ShellCompDirectiveError
 			}
-			defer workspace.Close()
 			namedQueries := []string{}
 			for _, name := range workspace.GetSortedNamedQueryNames() {
 				if strings.HasPrefix(name, toComplete) {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/signal"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -43,6 +44,21 @@ Examples:
 
   # Run a specific query directly
   steampipe query "select * from cloud"`,
+
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			workspace, err := workspace.Load(viper.GetString(constants.ArgWorkspace))
+			if err != nil {
+				return []string{}, cobra.ShellCompDirectiveError
+			}
+			defer workspace.Close()
+			namedQueries := []string{}
+			for _, name := range workspace.GetSortedNamedQueryNames() {
+				if strings.HasPrefix(name, toComplete) {
+					namedQueries = append(namedQueries, name)
+				}
+			}
+			return namedQueries, cobra.ShellCompDirectiveNoFileComp
+		},
 	}
 
 	// Notes:

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -73,6 +73,10 @@ func InitCmd() {
 
 	AddCommands()
 
+	// disable auto completion generation, since we don't want to support
+	// powershell yet - and there's no way to disable powershell in the default generator
+	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -137,11 +141,13 @@ func setInstallDir() {
 
 func AddCommands() {
 	// explicitly initialise commands here rather than in init functions to allow us to handle errors from the config load
-	rootCmd.AddCommand(pluginCmd())
-	rootCmd.AddCommand(queryCmd())
-	rootCmd.AddCommand(checkCmd())
-	rootCmd.AddCommand(serviceCmd())
-	rootCmd.AddCommand(generateCompletionScriptsCmd())
+	rootCmd.AddCommand(
+		pluginCmd(),
+		queryCmd(),
+		checkCmd(),
+		serviceCmd(),
+		generateCompletionScriptsCmd(),
+	)
 }
 
 func Execute() int {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,6 +141,7 @@ func AddCommands() {
 	rootCmd.AddCommand(queryCmd())
 	rootCmd.AddCommand(checkCmd())
 	rootCmd.AddCommand(serviceCmd())
+	rootCmd.AddCommand(generateCompletionScriptsCmd())
 }
 
 func Execute() int {

--- a/go.mod
+++ b/go.mod
@@ -53,7 +53,7 @@ require (
 	github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18
 	github.com/shirou/gopsutil v3.20.11+incompatible
 	github.com/sirupsen/logrus v1.8.1
-	github.com/spf13/cobra v1.1.3
+	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.8.1
 	github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b

--- a/go.sum
+++ b/go.sum
@@ -155,7 +155,6 @@ github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-simplejson v0.5.0/go.mod h1:cXHtHw4XUPsvGaxgjIAn8PhEWG9NfngEKAMDJEczWVA=
-github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmatcuk/doublestar v1.1.5/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
@@ -211,7 +210,6 @@ github.com/containerd/typeurl v0.0.0-20180627222232-a93fcdb778cd/go.mod h1:Cm3kw
 github.com/coreos/bbolt v1.3.0/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
-github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-etcd v2.0.0+incompatible/go.mod h1:Jez6KQU2B/sWsbdaef3ED8NzMklzPG4d5KIOhIy30Tk=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
@@ -429,9 +427,8 @@ github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33 h1:893HsJqtxp9z1S
 github.com/gorilla/handlers v0.0.0-20150720190736-60c7bfde3e33/go.mod h1:Qkdc/uu4tH4g6mTK6auzZ766c4CA0Ng8+o/OAirnOIQ=
 github.com/gorilla/mux v1.7.2 h1:zoNxOV7WjqXptQOVngLmcSQgXmgk4NMz1HibBchjl/I=
 github.com/gorilla/mux v1.7.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
+github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
-github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
-github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.8.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -580,7 +577,6 @@ github.com/logrusorgru/aurora v2.0.3+incompatible h1:tOpm7WcpBTn4fjmVfgpQq0EfczG
 github.com/logrusorgru/aurora v2.0.3+incompatible/go.mod h1:7rIyQOR62GCctdiQpZ/zOJlFyk6y+94wXzv6RNZgaR4=
 github.com/lusis/go-artifactory v0.0.0-20160115162124-7e4ce345df82/go.mod h1:y54tfGmO3NKssKveTEFFzH8C/akrSOy/iW9qEAUDV84=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
-github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.5 h1:b6kJs+EmPFMYGkow9GiUyCyOvIwYetYJ3fSaWak/Gls=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mailru/easyjson v0.0.0-20160728113105-d5b7844b561a/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
@@ -793,8 +789,8 @@ github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKv
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
-github.com/spf13/cobra v1.1.3 h1:xghbfqPkxzxP3C/f3n5DdpAbdKLj4ZE4BWQI362l53M=
-github.com/spf13/cobra v1.1.3/go.mod h1:pGADOWyqRD/YMrPZigI/zbliZ2wVD/23d+is3pSWzOo=
+github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
+github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -807,7 +803,6 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
-github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
 github.com/spf13/viper v1.8.1 h1:Kq1fyeebqsBfbjZj4EL7gj2IO0mMaiyjYUWcUsl2O44=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
 github.com/stevenle/topsort v0.0.0-20130922064739-8130c1d7596b h1:wJSBFlabo96ySlmSX0a02WAPyGxagzTo9c5sk3sHP3E=
@@ -1331,7 +1326,6 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gemnasium/logrus-airbrake-hook.v2 v2.1.2/go.mod h1:Xk6kEKp8OKb+X14hQBKWaSkCsqBpgog8nAV2xsGOxlo=
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
-gopkg.in/ini.v1 v1.51.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.62.0 h1:duBzk771uxoUuOlyRLkHsygud9+5lrlGjdFBb4mSKDU=
 gopkg.in/ini.v1 v1.62.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/olahol/melody.v1 v1.0.0-20170518105555-d52139073376 h1:sY2a+y0j4iDrajJcorb+a0hJIQ6uakU5gybjfLWHlXo=

--- a/steampipeconfig/modconfig/workspace_resources.go
+++ b/steampipeconfig/modconfig/workspace_resources.go
@@ -1,5 +1,7 @@
 package modconfig
 
+import "sort"
+
 type WorkspaceResources struct {
 	Query     map[string]bool
 	Control   map[string]bool
@@ -29,4 +31,34 @@ func (r *WorkspaceResources) Merge(other *WorkspaceResources) *WorkspaceResource
 	//	r.Panel[k] = true
 	//}
 	return r
+}
+
+// GetSortedBenchmarksAndControlNames gives back a list of the benchmarks
+// and controls in the current workspace.
+// The list is sorted alphabetically - with the benchmarks first
+func (w *WorkspaceResources) GetSortedBenchmarksAndControlNames() []string {
+	benchmarkList := []string{}
+	controlList := []string{}
+
+	for key := range w.Benchmark {
+		benchmarkList = append(benchmarkList, key)
+	}
+
+	for key := range w.Control {
+		controlList = append(controlList, key)
+	}
+
+	sort.Strings(benchmarkList)
+	sort.Strings(controlList)
+
+	return append(benchmarkList, controlList...)
+}
+
+func (w *WorkspaceResources) GetSortedNamedQueryNames() []string {
+	namedQueries := []string{}
+	for key := range w.Query {
+		namedQueries = append(namedQueries, key)
+	}
+	sort.Strings(namedQueries)
+	return namedQueries
 }

--- a/task/runner.go
+++ b/task/runner.go
@@ -88,7 +88,7 @@ func (r *Runner) shouldRun() bool {
 
 	cmd := viper.Get(constants.ConfigKeyActiveCommand).(*cobra.Command)
 	cmdArgs := viper.GetStringSlice(constants.ConfigKeyActiveCommandArgs)
-	if isServiceStopCmd(cmd) || isBatchQueryCmd(cmd, cmdArgs) {
+	if isServiceStopCmd(cmd) || isBatchQueryCmd(cmd, cmdArgs) || isCompletionCmd(cmd) {
 		// no scheduled tasks for `service stop` and `query <sql>`
 		return false
 	}
@@ -108,6 +108,10 @@ func (r *Runner) shouldRun() bool {
 
 func isServiceStopCmd(cmd *cobra.Command) bool {
 	return cmd.Parent() != nil && cmd.Parent().Name() == "service" && cmd.Name() == "stop"
+}
+
+func isCompletionCmd(cmd *cobra.Command) bool {
+	return cmd.Name() == "completion"
 }
 
 func isBatchQueryCmd(cmd *cobra.Command, cmdArgs []string) bool {

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 
@@ -89,36 +88,6 @@ func LoadResourceNames(workspacePath string) (*modconfig.WorkspaceResources, err
 	}
 
 	return workspace.loadWorkspaceResourceName()
-}
-
-// GetSortedBenchmarksAndControlNames gives back a list of the benchmarks
-// and controls in the current workspace.
-// The list is sorted alphabetically - with the benchmarks first
-func (w *Workspace) GetSortedBenchmarksAndControlNames() []string {
-	benchmarkList := []string{}
-	controlList := []string{}
-
-	for key := range w.BenchmarkMap {
-		benchmarkList = append(benchmarkList, key)
-	}
-
-	for key := range w.ControlMap {
-		controlList = append(controlList, key)
-	}
-
-	sort.Strings(benchmarkList)
-	sort.Strings(controlList)
-
-	return append(benchmarkList, controlList...)
-}
-
-func (w *Workspace) GetSortedNamedQueryNames() []string {
-	namedQueries := []string{}
-	for key := range w.QueryMap {
-		namedQueries = append(namedQueries, key)
-	}
-	sort.Strings(namedQueries)
-	return namedQueries
 }
 
 func (w *Workspace) SetupWatcher(client db_common.Client, errorHandler func(error)) error {

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -88,6 +89,36 @@ func LoadResourceNames(workspacePath string) (*modconfig.WorkspaceResources, err
 	}
 
 	return workspace.loadWorkspaceResourceName()
+}
+
+// GetSortedBenchmarksAndControlNames gives back a list of the benchmarks
+// and controls in the current workspace.
+// The list is sorted alphabetically - with the benchmarks first
+func (w *Workspace) GetSortedBenchmarksAndControlNames() []string {
+	benchmarkList := []string{}
+	controlList := []string{}
+
+	for key := range w.BenchmarkMap {
+		benchmarkList = append(benchmarkList, key)
+	}
+
+	for key := range w.ControlMap {
+		controlList = append(controlList, key)
+	}
+
+	sort.Strings(benchmarkList)
+	sort.Strings(controlList)
+
+	return append(benchmarkList, controlList...)
+}
+
+func (w *Workspace) GetSortedNamedQueryNames() []string {
+	namedQueries := []string{}
+	for key := range w.QueryMap {
+		namedQueries = append(namedQueries, key)
+	}
+	sort.Strings(namedQueries)
+	return namedQueries
 }
 
 func (w *Workspace) SetupWatcher(client db_common.Client, errorHandler func(error)) error {


### PR DESCRIPTION
**To make this work on bash in Mac, follow the steps:**

- Install bash-completion: `brew install bash-completion`

   ```Bash completion is a bash function that allows you to auto complete commands or arguments by typing partially commands or arguments, then pressing the [Tab] key. This will help you when writing the bash command in terminal.```
   Bash completion will be installed in `<brew --prefix>/etc/bash_completion.d`

- For it to work, add this to your `~/.bash_profile`:
   `[ -f <brew --prefix>/etc/bash_completion ] && . <brew --prefix>/etc/bash_completion`

-  Restart your bash session:
    `source ~/.bash_profile`

Once you have completed the steps, your bash auto-completion should work.