### PR TITLE
Add support for logging process output if `initdb` fails. Closes #800

### DIFF
--- a/db/local_db/install.go
+++ b/db/local_db/install.go
@@ -246,10 +246,11 @@ func initDatabase() error {
 		"--debug",
 	)
 
-	log.Printf("[TRACE] %s", initDbProcess.String())
+	log.Printf("[TRACE] initdb start: %s", initDbProcess.String())
 
-	runError := initDbProcess.Run()
+	output, runError := initDbProcess.CombinedOutput()
 	if runError != nil {
+		log.Printf("[TRACE] initdb failed:\n %s", string(output))
 		return runError
 	}
 


### PR DESCRIPTION
```
[pskr@e00c42fd1b14 ~]$ STEAMPIPE_LOG=trace steampipe query
Welcome to Steampipe v0.7.3
For more information, type .help
2021-08-27T07:30:53.963Z [TRACE] steampipe: db.EnsureDbAndStartService start
   > 2021-08-27T07:30:53.966Z [TRACE] steampipe: initdb start: /home/pskr/.steampipe/db/12.1.0/postgres/bin/initdb --auth=trust --username=root --pgdata=/home/pskr/.steampipe/db/12.1.0/data --encoding=UTF-8 --wal-segsize=1 --debug
2021-08-27T07:30:53.973Z [TRACE] steampipe: initdb failed:
 Running in debug mode.
The files belonging to this database system will be owned by user "pskr".
This user must also own the server process.

VERSION=12.1
PGDATA=/home/pskr/.steampipe/db/12.1.0/data
share_path=/home/pskr/.steampipe/db/12.1.0/postgres/share/postgresql
PGPATH=/home/pskr/.steampipe/db/12.1.0/postgres/bin
POSTGRES_SUPERUSERNAME=root
POSTGRES_BKI=/home/pskr/.steampipe/db/12.1.0/postgres/share/postgresql/postgres.bki
POSTGRES_DESCR=/home/pskr/.steampipe/db/12.1.0/postgres/share/postgresql/postgres.description
POSTGRES_SHDESCR=/home/pskr/.steampipe/db/12.1.0/postgres/share/postgresql/postgres.shdescription
POSTGRESQL_CONF_SAMPLE=/home/pskr/.steampipe/db/12.1.0/postgres/share/postgresql/postgresql.conf.sample
PG_HBA_SAMPLE=/home/pskr/.steampipe/db/12.1.0/postgres/share/postgresql/pg_hba.conf.sample
PG_IDENT_SAMPLE=/home/pskr/.steampipe/db/12.1.0/postgres/share/postgresql/pg_ident.conf.sample
initdb: error: invalid locale settings; check LANG and LC_* environment variables
2021-08-27T07:30:53.973Z [TRACE] steampipe: initDatabase failed: exit status 1
```