### PR TITLE
Fixes issue where documentation link was missing after a non-turbot plugin was installed. closes #1075

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -245,10 +245,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 		}
 		org := image.Config.Plugin.Organization
 		name := image.Config.Plugin.Name
-		docURL := ""
-		if org == "turbot" {
-			docURL = fmt.Sprintf("https://hub.steampipe.io/plugins/%s/%s", org, name)
-		}
+		docURL := fmt.Sprintf("https://hub.steampipe.io/plugins/%s/%s", org, name)
 		installReports = append(installReports, display.InstallReport{
 			Skipped:        false,
 			Plugin:         p,
@@ -407,10 +404,7 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 		}
 		org := image.Config.Plugin.Organization
 		name := image.Config.Plugin.Name
-		docURL := ""
-		if org == "turbot" {
-			docURL = fmt.Sprintf("https://hub.steampipe.io/plugins/%s/%s", org, name)
-		}
+		docURL := fmt.Sprintf("https://hub.steampipe.io/plugins/%s/%s", org, name)
 		updateReports = append(updateReports, display.InstallReport{
 			Plugin:         fmt.Sprintf("%s@%s", report.CheckResponse.Name, report.CheckResponse.Stream),
 			Skipped:        false,


### PR DESCRIPTION
![Screenshot 2021-11-08 at 7 58 43 PM](https://user-images.githubusercontent.com/45908484/140760048-d3322bff-be55-407f-9771-c9c9bd13e928.png)
