### PR TITLE
refactor: move from io/ioutil to io and os packages

### DIFF
--- a/db/db_common/api.go
+++ b/db/db_common/api.go
@@ -3,7 +3,7 @@ package db_common
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 )
 
@@ -93,7 +93,7 @@ func fetchAPIData(url, bearer string, client *http.Client) (map[string]interface
 		return nil, err
 	}
 	defer resp.Body.Close()
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/db/db_local/install.go
+++ b/db/db_local/install.go
@@ -3,7 +3,6 @@ package db_local
 import (
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -398,7 +397,7 @@ func initDatabase() error {
 
 	// intentionally overwriting existing pg_hba.conf with a minimal config which only allows root
 	// so that we can setup the database and permissions
-	return ioutil.WriteFile(getPgHbaConfLocation(), []byte(constants.MinimalPgHbaContent), 0600)
+	return os.WriteFile(getPgHbaConfLocation(), []byte(constants.MinimalPgHbaContent), 0600)
 }
 
 func installDatabaseWithPermissions(databaseName string, rawClient *sql.DB) error {
@@ -471,7 +470,7 @@ func installDatabaseWithPermissions(databaseName string, rawClient *sql.DB) erro
 
 func writePgHbaContent(databaseName string, username string) error {
 	content := fmt.Sprintf(constants.PgHbaTemplate, databaseName, username)
-	return ioutil.WriteFile(getPgHbaConfLocation(), []byte(content), 0600)
+	return os.WriteFile(getPgHbaConfLocation(), []byte(content), 0600)
 }
 
 func installForeignServer(databaseName string, rawClient *sql.DB) error {
@@ -507,5 +506,5 @@ func updateDownloadedBinarySignature() error {
 		return err
 	}
 	installedSignature := fmt.Sprintf("%s|%s", versionInfo.EmbeddedDB.ImageDigest, versionInfo.FdwExtension.ImageDigest)
-	return ioutil.WriteFile(getDBSignatureLocation(), []byte(installedSignature), 0755)
+	return os.WriteFile(getDBSignatureLocation(), []byte(installedSignature), 0755)
 }

--- a/db/db_local/logs.go
+++ b/db/db_local/logs.go
@@ -1,7 +1,6 @@
 package db_local
 
 import (
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -12,16 +11,22 @@ const logRetentionDays = 7
 
 func TrimLogs() {
 	fileLocation := getDatabaseLogDirectory()
-	files, err := ioutil.ReadDir(fileLocation)
+	files, err := os.ReadDir(fileLocation)
 	if err != nil {
 		log.Fatal(err)
 	}
 	for _, file := range files {
-		fileName := file.Name()
+		fi, err := file.Info()
+		if err != nil {
+			continue
+		}
+
+		fileName := fi.Name()
 		if filepath.Ext(fileName) != ".log" {
 			continue
 		}
-		age := time.Now().Sub(file.ModTime()).Hours()
+
+		age := time.Now().Sub(fi.ModTime()).Hours()
 		if age > logRetentionDays*24 {
 			logPath := filepath.Join(fileLocation, fileName)
 			err := os.Remove(logPath)

--- a/db/db_local/password.go
+++ b/db/db_local/password.go
@@ -2,7 +2,6 @@ package db_local
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -18,7 +17,7 @@ type Passwords struct {
 }
 
 func writePasswordFile(password string) error {
-	return ioutil.WriteFile(getPasswordFileLocation(), []byte(password), 0600)
+	return os.WriteFile(getPasswordFileLocation(), []byte(password), 0600)
 }
 
 // readPasswordFile reads the password file and returns it contents.
@@ -32,7 +31,7 @@ func readPasswordFile() (string, error) {
 		}
 		return p, nil
 	}
-	contentBytes, err := ioutil.ReadFile(getPasswordFileLocation())
+	contentBytes, err := os.ReadFile(getPasswordFileLocation())
 	if err != nil {
 		return "", err
 	}
@@ -67,7 +66,7 @@ func migrateLegacyPasswordFile() error {
 }
 
 func getLegacyPasswords() (*Passwords, error) {
-	contentBytes, err := ioutil.ReadFile(getLegacyPasswordFileLocation())
+	contentBytes, err := os.ReadFile(getLegacyPasswordFileLocation())
 	if err != nil {
 		return nil, err
 	}

--- a/db/db_local/running_info.go
+++ b/db/db_local/running_info.go
@@ -3,7 +3,6 @@ package db_local
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -29,7 +28,7 @@ func (r *RunningDBInstanceInfo) Save() error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(constants.RunningInfoFilePath(), content, 0644)
+	return os.WriteFile(constants.RunningInfoFilePath(), content, 0644)
 }
 
 func (r *RunningDBInstanceInfo) String() string {
@@ -55,7 +54,7 @@ func loadRunningInstanceInfo() (*RunningDBInstanceInfo, error) {
 		return nil, nil
 	}
 
-	fileContent, err := ioutil.ReadFile(constants.RunningInfoFilePath())
+	fileContent, err := os.ReadFile(constants.RunningInfoFilePath())
 	if err != nil {
 		return nil, err
 	}

--- a/db/db_local/service.go
+++ b/db/db_local/service.go
@@ -2,7 +2,6 @@ package db_local
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
@@ -98,7 +97,7 @@ func errorIfUnknownService() error {
 	}
 
 	// read the content of the postmaster.pid file
-	fileContent, err := ioutil.ReadFile(getPostmasterPidLocation())
+	fileContent, err := os.ReadFile(getPostmasterPidLocation())
 	if err != nil {
 		return err
 	}

--- a/db/db_local/ssl.go
+++ b/db/db_local/ssl.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/big"
 	"os"
@@ -129,7 +128,7 @@ func parseCertificateInLocation(location string) (*x509.Certificate, error) {
 	utils.LogTime("db_local.parseCertificateInLocation start")
 	defer utils.LogTime("db_local.parseCertificateInLocation end")
 
-	rootCertRaw, err := ioutil.ReadFile(getRootCertLocation())
+	rootCertRaw, err := os.ReadFile(getRootCertLocation())
 	if err != nil {
 		// if we can't read the certificate, then there's a problem with permissions
 		return nil, err
@@ -301,7 +300,7 @@ func ensureRootPrivateKey() (*rsa.PrivateKey, error) {
 func loadRootPrivateKey() (*rsa.PrivateKey, error) {
 	location := getRootCertKeyLocation()
 
-	priv, err := ioutil.ReadFile(location)
+	priv, err := os.ReadFile(location)
 	if err != nil {
 		log.Printf("[TRACE] loadRootPrivateKey - failed to load key from %s: %s", location, err.Error())
 		return nil, err
@@ -335,5 +334,5 @@ func loadRootPrivateKey() (*rsa.PrivateKey, error) {
 }
 
 func writeCertFile(filePath string, cert string) error {
-	return ioutil.WriteFile(filePath, []byte(cert), 0600)
+	return os.WriteFile(filePath, []byte(cert), 0600)
 }

--- a/db/db_local/start_services.go
+++ b/db/db_local/start_services.go
@@ -3,7 +3,6 @@ package db_local
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net"
 	"os"
@@ -265,11 +264,11 @@ func retrieveDatabaseNameFromService(port int) (string, error) {
 
 func writePGConf() error {
 	// Apply default settings in conf files
-	err := ioutil.WriteFile(getPostgresqlConfLocation(), []byte(constants.PostgresqlConfContent), 0600)
+	err := os.WriteFile(getPostgresqlConfLocation(), []byte(constants.PostgresqlConfContent), 0600)
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile(getSteampipeConfLocation(), []byte(constants.SteampipeConfContent), 0600)
+	err = os.WriteFile(getSteampipeConfLocation(), []byte(constants.SteampipeConfContent), 0600)
 	if err != nil {
 		return err
 	}

--- a/ociinstaller/versionfile/db_version_file.go
+++ b/ociinstaller/versionfile/db_version_file.go
@@ -2,7 +2,6 @@ package versionfile
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 	"time"
@@ -63,7 +62,7 @@ func LoadDatabaseVersionFile() (*DatabaseVersionFile, error) {
 }
 
 func readDatabaseVersionFile(path string) (*DatabaseVersionFile, error) {
-	file, _ := ioutil.ReadFile(path)
+	file, _ := os.ReadFile(path)
 	var data DatabaseVersionFile
 	if err := json.Unmarshal([]byte(file), &data); err != nil {
 		log.Println("[ERROR]", "Error while reading DB version file", err)

--- a/ociinstaller/versionfile/legacy_version_file.go
+++ b/ociinstaller/versionfile/legacy_version_file.go
@@ -2,7 +2,6 @@ package versionfile
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -26,7 +25,7 @@ func LoadLegacyVersionFile() (*LegacyVersionFile, error) {
 }
 
 func readLegacyVersionFile(path string) (*LegacyVersionFile, error) {
-	file, _ := ioutil.ReadFile(path)
+	file, _ := os.ReadFile(path)
 
 	var data LegacyVersionFile
 

--- a/ociinstaller/versionfile/plugin_version_file.go
+++ b/ociinstaller/versionfile/plugin_version_file.go
@@ -2,7 +2,6 @@ package versionfile
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"log"
 	"os"
 
@@ -46,7 +45,7 @@ func LoadPluginVersionFile() (*PluginVersionFile, error) {
 }
 
 func readPluginVersionFile(path string) (*PluginVersionFile, error) {
-	file, _ := ioutil.ReadFile(path)
+	file, _ := os.ReadFile(path)
 
 	var data PluginVersionFile
 

--- a/plugin/version_checker.go
+++ b/plugin/version_checker.go
@@ -3,7 +3,7 @@ package plugin
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/url"
 	"strings"
@@ -187,7 +187,7 @@ func (v *VersionChecker) requestServerForLatest(payload []versionCheckPayload) [
 		return nil
 	}
 
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		fmt.Printf("[TRACE] Error reading body stream")
 		return nil

--- a/plugin_manager/plugin_manager_client.go
+++ b/plugin_manager/plugin_manager_client.go
@@ -1,7 +1,7 @@
 package plugin_manager
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/hashicorp/go-hclog"
@@ -33,7 +33,7 @@ func NewPluginManagerClient(pluginManagerState *PluginManagerState) (*PluginMana
 
 func (c *PluginManagerClient) attachToPluginManager() error {
 	// discard logging from the plugin client (plugin logs will still flow through)
-	loggOpts := &hclog.LoggerOptions{Name: "plugin", Output: ioutil.Discard}
+	loggOpts := &hclog.LoggerOptions{Name: "plugin", Output: io.Discard}
 	logger := logging.NewLogger(loggOpts)
 
 	// construct a client using the plugin manager reaattach config

--- a/plugin_manager/plugin_path.go
+++ b/plugin_manager/plugin_path.go
@@ -2,7 +2,6 @@ package plugin_manager
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -31,7 +30,7 @@ func GetPluginPath(plugin, pluginShortName string) (string, error) {
 	}
 
 	// there should be just 1 file with extension pluginExtension (".plugin")
-	entries, err := ioutil.ReadDir(pluginFolder)
+	entries, err := os.ReadDir(pluginFolder)
 	if err != nil {
 		return "", fmt.Errorf("failed to load plugin %s: %v", remoteSchema, err)
 	}

--- a/statefile/load.go
+++ b/statefile/load.go
@@ -3,7 +3,6 @@ package statefile
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -30,7 +29,7 @@ func LoadState() (State, error) {
 		return currentState, err
 	}
 
-	stateFileContent, err := ioutil.ReadFile(stateFilePath)
+	stateFileContent, err := os.ReadFile(stateFilePath)
 	if err != nil {
 		fmt.Println("Could not read update state file")
 		return currentState, err

--- a/statefile/save.go
+++ b/statefile/save.go
@@ -2,7 +2,6 @@ package statefile
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -20,5 +19,5 @@ func (s *State) Save() error {
 	_ = os.Remove(stateFilePath)
 	// save state file
 	file, _ := json.MarshalIndent(s, "", " ")
-	return ioutil.WriteFile(stateFilePath, file, 0644)
+	return os.WriteFile(stateFilePath, file, 0644)
 }

--- a/steampipeconfig/connection_plugin.go
+++ b/steampipeconfig/connection_plugin.go
@@ -2,7 +2,7 @@ package steampipeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -129,7 +129,7 @@ func runPluginManagerInProcess() (*plugin_manager.PluginManager, error) {
 	}
 
 	// discard logging from the plugin client (plugin logs will still flow through)
-	loggOpts := &hclog.LoggerOptions{Name: "plugin", Output: ioutil.Discard}
+	loggOpts := &hclog.LoggerOptions{Name: "plugin", Output: io.Discard}
 	logger := logging.NewLogger(loggOpts)
 
 	// build config map

--- a/steampipeconfig/connection_state.go
+++ b/steampipeconfig/connection_state.go
@@ -3,8 +3,8 @@ package steampipeconfig
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/constants"
@@ -32,7 +32,7 @@ func loadConnectionStateFile() (ConnectionDataMap, error) {
 	if !helpers.FileExists(connectionStatePath) {
 		return connectionState, nil
 	}
-	jsonFile, err := ioutil.ReadFile(connectionStatePath)
+	jsonFile, err := os.ReadFile(connectionStatePath)
 	if err != nil {
 		return nil, fmt.Errorf("error loading %s: %v", connectionStatePath, err)
 	}
@@ -75,5 +75,5 @@ func SaveConnectionState(state ConnectionDataMap) error {
 
 func writeJson(data interface{}, path string) error {
 	j, _ := json.MarshalIndent(data, "", " ")
-	return ioutil.WriteFile(path, j, 0644)
+	return os.WriteFile(path, j, 0644)
 }

--- a/steampipeconfig/connection_test.go
+++ b/steampipeconfig/connection_test.go
@@ -2,7 +2,6 @@ package steampipeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -505,7 +504,7 @@ func setup(test getConnectionsToUpdateTest) {
 
 func setupTestConfig(test getConnectionsToUpdateTest) {
 	for i, config := range test.required {
-		ioutil.WriteFile(connectionConfigPath(i), []byte(config), 0644)
+		os.WriteFile(connectionConfigPath(i), []byte(config), 0644)
 	}
 	os.MkdirAll(constants.InternalDir(), os.ModePerm)
 	writeJson(test.current, constants.ConnectionStatePath())

--- a/steampipeconfig/input_vars/collect_variables.go
+++ b/steampipeconfig/input_vars/collect_variables.go
@@ -2,7 +2,6 @@ package input_vars
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -63,7 +62,7 @@ func CollectVariableValues(workspacePath string, variableFileArgs []string, vari
 		diags = diags.Append(moreDiags)
 	}
 
-	if infos, err := ioutil.ReadDir("."); err == nil {
+	if infos, err := os.ReadDir("."); err == nil {
 		// "infos" is already sorted by name, so we just need to filter it here.
 		for _, info := range infos {
 			name := info.Name()
@@ -123,7 +122,7 @@ func CollectVariableValues(workspacePath string, variableFileArgs []string, vari
 func addVarsFromFile(filename string, sourceType ValueSourceType, to map[string]UnparsedVariableValue) tfdiags.Diagnostics {
 	var diags tfdiags.Diagnostics
 
-	src, err := ioutil.ReadFile(filename)
+	src, err := os.ReadFile(filename)
 	if err != nil {
 		if os.IsNotExist(err) {
 			diags = diags.Append(tfdiags.Sourceless(

--- a/steampipeconfig/load_config.go
+++ b/steampipeconfig/load_config.go
@@ -2,7 +2,6 @@ package steampipeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -43,7 +42,7 @@ func LoadConnectionConfig() (*SteampipeConfig, error) {
 func ensureDefaultConfigFile(configFolder string) error {
 	defaultConfigFile := filepath.Join(configFolder, defaultConfigFileName)
 	if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
-		err = ioutil.WriteFile(defaultConfigFile, []byte(constants.DefaultSPCContent), 0755)
+		err = os.WriteFile(defaultConfigFile, []byte(constants.DefaultSPCContent), 0755)
 		if err != nil {
 			return err
 		}

--- a/steampipeconfig/load_mod.go
+++ b/steampipeconfig/load_mod.go
@@ -2,7 +2,6 @@ package steampipeconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -149,7 +148,7 @@ func loadModDependency(modDependency *modconfig.ModVersion, runCtx *parse.RunCon
 
 func findInstalledDependency(modDependency *modconfig.ModVersion, parentFolder string) (string, *goVersion.Version, error) {
 	shortDepName := filepath.Base(modDependency.Name)
-	entries, err := ioutil.ReadDir(parentFolder)
+	entries, err := os.ReadDir(parentFolder)
 	if err != nil {
 		return "", nil, fmt.Errorf("mod dependency %s is not installed", modDependency.Name)
 	}

--- a/steampipeconfig/modconfig/panel.go
+++ b/steampipeconfig/modconfig/panel.go
@@ -2,7 +2,7 @@ package modconfig
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/hashicorp/hcl/v2"
@@ -56,7 +56,7 @@ func (p *Panel) InitialiseFromFile(modPath, filePath string) (MappableResource, 
 		return nil, nil, fmt.Errorf("Panel.InitialiseFromFile must be called with markdown files only - filepath: '%s'", filePath)
 	}
 
-	markdownBytes, err := ioutil.ReadFile(filePath)
+	markdownBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/steampipeconfig/modconfig/query.go
+++ b/steampipeconfig/modconfig/query.go
@@ -2,8 +2,8 @@ package modconfig
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -125,7 +125,7 @@ func (q *Query) InitialiseFromFile(modPath, filePath string) (MappableResource, 
 		return nil, nil, fmt.Errorf("Query.InitialiseFromFile must be called with .sql files only - filepath: '%s'", filePath)
 	}
 
-	sqlBytes, err := ioutil.ReadFile(filePath)
+	sqlBytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/steampipeconfig/parse/parser.go
+++ b/steampipeconfig/parse/parser.go
@@ -2,7 +2,7 @@ package parse
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -24,7 +24,7 @@ func LoadFileData(paths ...string) (map[string][]byte, hcl.Diagnostics) {
 	var fileData = map[string][]byte{}
 
 	for _, configPath := range paths {
-		data, err := ioutil.ReadFile(configPath)
+		data, err := os.ReadFile(configPath)
 
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
@@ -201,7 +201,7 @@ func parseYamlFile(filename string) (*hcl.File, hcl.Diagnostics) {
 	}
 	defer f.Close()
 
-	src, err := ioutil.ReadAll(f)
+	src, err := io.ReadAll(f)
 	if err != nil {
 		return nil, hcl.Diagnostics{
 			{

--- a/task/version_checker.go
+++ b/task/version_checker.go
@@ -3,7 +3,7 @@ package task
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/url"
 	"os"
@@ -112,7 +112,7 @@ func (c *versionChecker) doCheckRequest() {
 	if err != nil {
 		return
 	}
-	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/utils/fs_permissions.go
+++ b/utils/fs_permissions.go
@@ -1,13 +1,12 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 )
 
 func EnsureDirectoryPermission(directoryPath string) error {
 	// verify that we can read and write to the directory
-	tmpFile, err := ioutil.TempFile(directoryPath, "tmp")
+	tmpFile, err := os.CreateTemp(directoryPath, "tmp")
 	if err != nil {
 		return err
 	}

--- a/utils/wsl.go
+++ b/utils/wsl.go
@@ -1,7 +1,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"os"
 	"runtime"
 	"strings"
 )
@@ -13,7 +13,7 @@ func IsWSL() (bool, error) {
 		return false, nil
 	}
 	// https://github.com/Microsoft/WSL/issues/2299#issuecomment-361366982
-	osReleaseContent, err := ioutil.ReadFile("/proc/version")
+	osReleaseContent, err := os.ReadFile("/proc/version")
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.