### PR TITLE
show `Time` at the end of the query results when `timing:ON`. closes #1177

### DIFF
--- a/display/display.go
+++ b/display/display.go
@@ -274,16 +274,16 @@ func displayTable(result *queryresult.Result) {
 		utils.ShowError(err)
 		fmt.Println()
 	}
-	// if timer is turned on
-	if cmdconfig.Viper().GetBool(constants.ArgTimer) {
-		// put in the time information in the buffer
-		outbuf.WriteString(fmt.Sprintf("\nTime: %v\n", <-result.Duration))
-	}
 	// write out the table to the buffer
 	t.Render()
 
 	// page out the table
 	ShowPaged(outbuf.String())
+
+	// if timer is turned on
+	if cmdconfig.Viper().GetBool(constants.ArgTimer) {
+		fmt.Printf("\nTime: %v\n", <-result.Duration)
+	}
 }
 
 type displayResultsFunc func(row []interface{}, result *queryresult.Result)


### PR DESCRIPTION
Before(Time at the beginning):

![Screenshot 2021-11-25 at 4 56 48 PM](https://user-images.githubusercontent.com/45908484/143433406-729fe843-3352-44c6-9dc1-b1a7115e4405.png)

Now(Time at the end):

![Screenshot 2021-11-25 at 4 58 37 PM](https://user-images.githubusercontent.com/45908484/143433833-b57359dd-9a30-4b02-b203-91c8b6284b1c.png)

