### PR TITLE
Limit control execution thread count to equal number of connections to avoid potential thread safety issue causing nre. Closes #1254

### DIFF
--- a/constants/control_execute.go
+++ b/constants/control_execute.go
@@ -2,7 +2,7 @@ package constants
 
 // ParallelControlMultiplier is used to determine the nbumber of goroutines to start for the control run
 // this is a multiplier for the max db connections which are configred
-const ParallelControlMultiplier = 3
+const ParallelControlMultiplier = 1
 
 // The maximum number of seconds to wait for control queries to finish cancelling
 const QueryCancellationTimeout = 30


### PR DESCRIPTION
…