### PR TITLE
Fix issues reported by the 'unused', 'staticcheck', 'gosimple' linters. closes #1360

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,18 @@
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - errcheck
+    - gosimple
+    - govet
+    - ineffassign
+    - staticcheck
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+
+run:
+  timeout: 5m
+  skip-dirs:
+    - "tests/acceptance"

--- a/interactive/interactive_client.go
+++ b/interactive/interactive_client.go
@@ -58,9 +58,6 @@ type InteractiveClient struct {
 	schemaMetadata *schema.Metadata
 
 	highlighter *Highlighter
-
-	// status update hooks
-	statusHook statushooks.StatusHooks
 }
 
 func getHighlighter(theme string) *Highlighter {

--- a/pluginmanager/plugin_manager.go
+++ b/pluginmanager/plugin_manager.go
@@ -28,7 +28,6 @@ type PluginManager struct {
 	pb.UnimplementedPluginManagerServer
 
 	Plugins          map[string]*runningPlugin
-	configDir        string
 	mut              sync.Mutex
 	connectionConfig map[string]*pb.ConnectionConfig
 	logger           hclog.Logger

--- a/query/metaquery/completers.go
+++ b/query/metaquery/completers.go
@@ -31,7 +31,7 @@ func Complete(input *CompleterInput) []prompt.Suggest {
 
 func completerFromArgsOf(cmd string) completer {
 	return func(input *CompleterInput) []prompt.Suggest {
-		metaQueryDefinition, _ := metaQueryDefinitions[cmd]
+		metaQueryDefinition := metaQueryDefinitions[cmd]
 		suggestions := make([]prompt.Suggest, len(metaQueryDefinition.args))
 		for idx, arg := range metaQueryDefinition.args {
 			suggestions[idx] = prompt.Suggest{Text: arg.value, Description: arg.description, Output: arg.value}

--- a/steampipeconfig/connection_test.go
+++ b/steampipeconfig/connection_test.go
@@ -438,8 +438,8 @@ func TestGetConnectionsToUpdate(t *testing.T) {
 		updates, res := NewConnectionUpdates([]string{"a", "b"})
 
 		if res.Error != nil && test.expected != "ERROR" {
-			continue
 			t.Fatalf("NewConnectionUpdates failed with unexpected error: %v", err)
+			continue
 		}
 
 		expectedUpdates := test.expected.(*ConnectionUpdates)
@@ -521,7 +521,7 @@ func resetConfig(test getConnectionsToUpdateTest) {
 	connectionStatePath := filepaths.ConnectionStatePath()
 
 	os.Remove(connectionStatePath)
-    for i := range test.required {
+	for i := range test.required {
 		os.Remove(connectionConfigPath(i))
 	}
 }

--- a/steampipeconfig/parse/decode.go
+++ b/steampipeconfig/parse/decode.go
@@ -10,6 +10,7 @@ import (
 	"github.com/turbot/steampipe/steampipeconfig/modconfig"
 	"github.com/turbot/steampipe/steampipeconfig/modconfig/var_config"
 	"github.com/turbot/steampipe/utils"
+	"github.com/zclconf/go-cty/cty"
 )
 
 // A consistent detail message for all "not a valid identifier" diagnostics.
@@ -295,7 +296,8 @@ func decodeParam(block *hcl.Block, runCtx *RunContext, parentName string) (*modc
 		diags = append(diags, valDiags...)
 	}
 	if attr, exists := content.Attributes["default"]; exists {
-		v, diags := attr.Expr.Value(runCtx.EvalCtx)
+		var v cty.Value
+		v, diags = attr.Expr.Value(runCtx.EvalCtx)
 		if diags.HasErrors() {
 			return nil, diags
 		}


### PR DESCRIPTION
@kaidaguerre Is this function needed for reporting?
```
cmd/report.go:14:6: func `runReportCmd` is unused (unused)
func runReportCmd(cmd *cobra.Command, args []string) {
     ^
```