### PR TITLE
Adds support for starting `dashboard` server with `service start`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,11 @@ RUN steampipe query "select * from steampipe_mod"
 
 RUN rm -f /home/steampipe/.steampipe/internal/.passwd
 
+# expose postgres service default port
 EXPOSE 9193
+# expose dashboard server default port 
+EXPOSE 9194
+
 COPY docker-entrypoint.sh /usr/local/bin
 ENTRYPOINT [ "docker-entrypoint.sh" ]
 CMD [ "steampipe"]


### PR DESCRIPTION
Adds a `--dashboard` flag to `steampipe service start` which starts the `dashboard` server with the steampipe service.

Also adds support for `--dashboard-listen` and `--dashboard-port` flags in the `service start` command (ignored if `--dashboard` is not used).