### PR TITLE
Fixes inconsistent output for `service` commands with `--dashboard`. Closes #1599

### DIFF
--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -99,7 +99,10 @@ func runDashboardCmd(cmd *cobra.Command, args []string) {
 		err = dashboardserver.OpenBrowser(fmt.Sprintf("http://localhost:%d", serverPort))
 		if err != nil {
 			log.Println("[TRACE] dashboard server started but failed to start client", err)
+		} else {
+			dashboardserver.OutputMessage(dashboardCtx, fmt.Sprintf("Visit http://localhost:%d", serverPort))
 		}
+		dashboardserver.OutputMessage(dashboardCtx, "Press Ctrl+C to exit")
 	}
 
 	// wait for the given context to cancel

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -176,9 +176,6 @@ func runServiceStartCmd(cmd *cobra.Command, args []string) {
 	}
 
 	if startResult.Status == db_local.ServiceAlreadyRunning {
-		if startResult.DbState.Invoker == constants.InvokerService {
-			fmt.Println("Steampipe service is already running.")
-		}
 
 		// check that we have the same port and listen parameters
 		if port != startResult.DbState.Port {
@@ -206,20 +203,28 @@ func runServiceStartCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	dashboardState, err := startDashboardServer(ctx)
-	if err != nil {
-		db_local.StopServices(ctx, false, constants.InvokerService)
-		utils.ShowError(ctx, err)
-		return
+	servicesStarted := (startResult.Status == db_local.ServiceStarted)
+
+	var dashboardState *dashboardserver.DashboardServiceState
+	if viper.GetBool(constants.ArgDashboard) {
+		dashboardState, err = dashboardserver.GetDashboardServiceState()
+		if err != nil {
+			db_local.StopServices(ctx, false, constants.InvokerService)
+			utils.ShowError(ctx, err)
+			return
+		}
+		if dashboardState == nil {
+			dashboardState, err = startDashboardServer(ctx)
+			if err != nil {
+				db_local.StopServices(ctx, false, constants.InvokerService)
+				utils.ShowError(ctx, err)
+				return
+			}
+			servicesStarted = true
+		}
 	}
 
-	// service was already running - and we didn't have to start the dashboard
-	if startResult.Status == db_local.ServiceAlreadyRunning && !viper.GetBool(constants.ArgDashboard) {
-		// nothing more to do
-		return
-	}
-
-	printStatus(ctx, startResult.DbState, startResult.PluginManagerState, dashboardState)
+	printStatus(ctx, startResult.DbState, startResult.PluginManagerState, dashboardState, !servicesStarted)
 
 	if viper.GetBool(constants.ArgForeground) {
 		runServiceInForeground(ctx, invoker)
@@ -228,38 +233,36 @@ func runServiceStartCmd(cmd *cobra.Command, args []string) {
 
 func startDashboardServer(ctx context.Context) (*dashboardserver.DashboardServiceState, error) {
 	var dashboardState *dashboardserver.DashboardServiceState
-	if viper.GetBool(constants.ArgDashboard) {
-		serverPort := dashboardserver.ListenPort(viper.GetInt(constants.ArgDashboardPort))
-		serverListen := dashboardserver.ListenType(viper.GetString(constants.ArgDashboardListen))
+	var err error
 
-		dashboardState, err := dashboardserver.GetDashboardServiceState()
+	serverPort := dashboardserver.ListenPort(viper.GetInt(constants.ArgDashboardPort))
+	serverListen := dashboardserver.ListenType(viper.GetString(constants.ArgDashboardListen))
+
+	dashboardState, err = dashboardserver.GetDashboardServiceState()
+	if err != nil {
+		return nil, err
+	}
+
+	if dashboardState == nil {
+		// try stopping the previous service
+		// StopDashboardService does nothing if the service is not running
+		err = dashboardserver.StopDashboardService(ctx)
 		if err != nil {
 			return nil, err
 		}
-
-		if dashboardState == nil {
-			// try stopping the previous service
-			// StopDashboardService does nothing if the service is not running
-			err = dashboardserver.StopDashboardService(ctx)
-			if err != nil {
-				return nil, err
-			}
-			// start dashboard service
-			err = dashboardserver.RunForService(ctx, serverListen, serverPort)
-			if err != nil {
-				return nil, err
-			}
-			// get the updated state
-			dashboardState, err = dashboardserver.GetDashboardServiceState()
-			if err != nil {
-				utils.ShowWarning(fmt.Sprintf("Started Dashboard server, but could not retrieve state: %v", err))
-			}
-			return dashboardState, err
-		} else {
-			fmt.Println("Dashboard service is already running.")
+		// start dashboard service
+		err = dashboardserver.RunForService(ctx, serverListen, serverPort)
+		if err != nil {
+			return nil, err
+		}
+		// get the updated state
+		dashboardState, err = dashboardserver.GetDashboardServiceState()
+		if err != nil {
+			utils.ShowWarning(fmt.Sprintf("Started Dashboard server, but could not retrieve state: %v", err))
 		}
 	}
-	return dashboardState, nil
+
+	return dashboardState, err
 }
 
 func runServiceInForeground(ctx context.Context, invoker constants.Invoker) {
@@ -364,9 +367,9 @@ to force a restart.
 	viper.Set(constants.ArgServicePassword, currentDbState.Password)
 
 	// start db
-	startResult := db_local.StartServices(cmd.Context(), currentDbState.Port, currentDbState.ListenType, currentDbState.Invoker)
-	utils.FailOnError(startResult.Error)
-	if startResult.Status == db_local.ServiceFailedToStart {
+	dbStartResult := db_local.StartServices(cmd.Context(), currentDbState.Port, currentDbState.ListenType, currentDbState.Invoker)
+	utils.FailOnError(dbStartResult.Error)
+	if dbStartResult.Status == db_local.ServiceFailedToStart {
 		fmt.Println("Steampipe service was stopped, but failed to restart.")
 		return
 	}
@@ -374,7 +377,6 @@ to force a restart.
 	// refresh connections
 	err = db_local.RefreshConnectionAndSearchPaths(cmd.Context(), constants.InvokerService)
 	utils.FailOnError(err)
-	fmt.Println("Steampipe service restarted.")
 
 	// if the dashboard was running, start it
 	if currentDashboardState != nil {
@@ -386,7 +388,7 @@ to force a restart.
 		utils.FailOnError(err)
 	}
 
-	printStatus(ctx, startResult.DbState, startResult.PluginManagerState, currentDashboardState)
+	printStatus(ctx, dbStartResult.DbState, dbStartResult.PluginManagerState, currentDashboardState, false)
 }
 
 func runServiceStatusCmd(cmd *cobra.Command, args []string) {
@@ -414,7 +416,7 @@ func runServiceStatusCmd(cmd *cobra.Command, args []string) {
 			utils.ShowError(ctx, composeStateError(dbStateErr, pmStateErr, dashboardStateErr))
 			return
 		}
-		printStatus(ctx, dbState, pmState, dashboardState)
+		printStatus(ctx, dbState, pmState, dashboardState, false)
 	}
 }
 
@@ -500,11 +502,12 @@ func runServiceStopCmd(cmd *cobra.Command, args []string) {
 
 	switch status {
 	case db_local.ServiceStopped:
-		if dbState != nil {
-			fmt.Printf("Steampipe service stopped [port %d].\n", dbState.Port)
-		} else {
-			fmt.Println("Steampipe service stopped.")
-		}
+		fmt.Println("Steampipe database service stopped.")
+		// if dbState != nil {
+		// 	fmt.Printf("Steampipe database service stopped [port %d].\n", dbState.Port)
+		// } else {
+		// 	fmt.Println("Steampipe database service stopped.")
+		// }
 	case db_local.ServiceNotRunning:
 		fmt.Println("Steampipe service is not running.")
 	case db_local.ServiceStopFailed:
@@ -573,7 +576,7 @@ func getServiceProcessDetails(process *psutils.Process) (string, string, string,
 	return fmt.Sprintf("%d", process.Pid), installDir, port, listenType
 }
 
-func printStatus(ctx context.Context, dbState *db_local.RunningDBInstanceInfo, pmState *pluginmanager.PluginManagerState, dashboardState *dashboardserver.DashboardServiceState) {
+func printStatus(ctx context.Context, dbState *db_local.RunningDBInstanceInfo, pmState *pluginmanager.PluginManagerState, dashboardState *dashboardserver.DashboardServiceState, addAlready bool) {
 	if dbState == nil && !pmState.Running {
 		fmt.Println("Service is not running")
 		return
@@ -583,6 +586,10 @@ func printStatus(ctx context.Context, dbState *db_local.RunningDBInstanceInfo, p
 
 	prefix := `Steampipe service is running:
 `
+	if addAlready {
+		prefix = `Steampipe service is already running:
+`
+	}
 	suffix := `
 Managing the Steampipe service:
 
@@ -623,12 +630,14 @@ Database:
 	dashboardMsg := ""
 
 	if dashboardState != nil {
+		browserUrl := fmt.Sprintf("http://localhost:%d/", dashboardState.Port)
 		dashboardMsg = fmt.Sprintf(`
 Dashboard:
 
   Host(s):  %v
   Port:     %v
-`, strings.Join(dashboardState.Listen, ", "), dashboardState.Port)
+  URL:      %v
+`, strings.Join(dashboardState.Listen, ", "), dashboardState.Port, browserUrl)
 	}
 
 	if dbState.Invoker == constants.InvokerService {

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -503,11 +503,6 @@ func runServiceStopCmd(cmd *cobra.Command, args []string) {
 	switch status {
 	case db_local.ServiceStopped:
 		fmt.Println("Steampipe database service stopped.")
-		// if dbState != nil {
-		// 	fmt.Printf("Steampipe database service stopped [port %d].\n", dbState.Port)
-		// } else {
-		// 	fmt.Println("Steampipe database service stopped.")
-		// }
 	case db_local.ServiceNotRunning:
 		fmt.Println("Steampipe service is not running.")
 	case db_local.ServiceStopFailed:

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -576,7 +576,7 @@ func getServiceProcessDetails(process *psutils.Process) (string, string, string,
 	return fmt.Sprintf("%d", process.Pid), installDir, port, listenType
 }
 
-func printStatus(ctx context.Context, dbState *db_local.RunningDBInstanceInfo, pmState *pluginmanager.PluginManagerState, dashboardState *dashboardserver.DashboardServiceState, addAlready bool) {
+func printStatus(ctx context.Context, dbState *db_local.RunningDBInstanceInfo, pmState *pluginmanager.PluginManagerState, dashboardState *dashboardserver.DashboardServiceState, alreadyRunning bool) {
 	if dbState == nil && !pmState.Running {
 		fmt.Println("Service is not running")
 		return
@@ -586,7 +586,7 @@ func printStatus(ctx context.Context, dbState *db_local.RunningDBInstanceInfo, p
 
 	prefix := `Steampipe service is running:
 `
-	if addAlready {
+	if alreadyRunning {
 		prefix = `Steampipe service is already running:
 `
 	}

--- a/dashboard/dashboardserver/output.go
+++ b/dashboard/dashboardserver/output.go
@@ -43,7 +43,7 @@ func output(_ context.Context, prefix string, msg interface{}) {
 	fmt.Fprintf(logSink, "%s %v\n", prefix, msg)
 }
 
-func outputMessage(ctx context.Context, msg string) {
+func OutputMessage(ctx context.Context, msg string) {
 	output(ctx, applyColor(messagePrefix, color.HiGreenString), msg)
 }
 

--- a/dashboard/dashboardserver/server.go
+++ b/dashboard/dashboardserver/server.go
@@ -67,7 +67,7 @@ func NewServer(ctx context.Context, dbClient db_common.Client, w *workspace.Work
 
 	w.RegisterDashboardEventHandler(server.HandleWorkspaceUpdate)
 	err := w.SetupWatcher(ctx, dbClient, func(c context.Context, e error) {})
-	outputMessage(ctx, "Workspace loaded")
+	OutputMessage(ctx, "Workspace loaded")
 
 	return server, err
 }
@@ -327,7 +327,7 @@ func (s *Server) HandleWorkspaceUpdate(event dashboardevents.DashboardEvent) {
 
 		// If) any deleted/new/changed dashboards, emit an available dashboards message to clients
 		if len(deletedDashboards) != 0 || len(newDashboards) != 0 || len(changedDashboards) != 0 {
-			outputMessage(s.context, "Available Dashboards updated")
+			OutputMessage(s.context, "Available Dashboards updated")
 			payload, payloadError = buildAvailableDashboardsPayload(s.workspace.GetResourceMaps())
 			if payloadError != nil {
 				return
@@ -453,7 +453,7 @@ func (s *Server) Init(ctx context.Context) {
 	})
 
 	s.webSocket.HandleMessage(s.handleMessageFunc(ctx))
-	outputMessage(ctx, "Initialization complete")
+	OutputMessage(ctx, "Initialization complete")
 }
 
 func (s *Server) handleMessageFunc(ctx context.Context) func(session *melody.Session, msg []byte) {

--- a/dashboard/dashboardserver/service.go
+++ b/dashboard/dashboardserver/service.go
@@ -64,7 +64,7 @@ func StopDashboardService(ctx context.Context) error {
 		return err
 	}
 	if !pidExists {
-		return os.Remove(filepaths.DashboardServiceStateFilePath())
+		return nil
 	}
 	process, err := process.NewProcessWithContext(ctx, int32(state.Pid))
 	if err != nil {


### PR DESCRIPTION
## `service start`
![Screenshot 2022-03-09 at 8 46 40 PM](https://user-images.githubusercontent.com/1114038/157471745-2b75e2ce-358c-4833-ba8d-31bd36b07020.png)

## `service start` (service already running
![Screenshot 2022-03-09 at 8 47 11 PM](https://user-images.githubusercontent.com/1114038/157471913-21375a7e-7fa0-47ad-a714-1bc30ca6b9dc.png)
)

## `service start --dashboard`
![Screenshot 2022-03-09 at 8 46 13 PM](https://user-images.githubusercontent.com/1114038/157471985-58481747-a7b0-4d62-8d39-3beb3fda2a42.png)

## `service start --dashboard` (already running)
![Screenshot 2022-03-09 at 8 47 35 PM](https://user-images.githubusercontent.com/1114038/157472215-b6104a04-a1ee-48b8-9b90-58dddca617f0.png)

