### PR TITLE
Fixes issue where implicit service was always using a default port. Closes #1753

### DIFF
--- a/cmdconfig/viper.go
+++ b/cmdconfig/viper.go
@@ -37,9 +37,10 @@ func SetViperDefaults(configMap map[string]interface{}) {
 // for keys which do not have a corresponding command flag, we need a separate defaulting mechanism
 func setBaseDefaults() {
 	defaults := map[string]interface{}{
-		constants.ArgUpdateCheck: true,
-		constants.ArgTelemetry:   constants.TelemetryInfo,
-		constants.ArgInstallDir:  filepaths.DefaultInstallDir,
+		constants.ArgUpdateCheck:  true,
+		constants.ArgTelemetry:    constants.TelemetryInfo,
+		constants.ArgInstallDir:   filepaths.DefaultInstallDir,
+		constants.ArgDatabasePort: constants.DatabaseDefaultPort,
 	}
 
 	for k, v := range defaults {

--- a/db/db_local/local_db_client.go
+++ b/db/db_local/local_db_client.go
@@ -35,7 +35,7 @@ func GetLocalClient(ctx context.Context, invoker constants.Invoker) (db_common.C
 		return nil, err
 	}
 
-	startResult := StartServices(ctx, constants.DatabaseDefaultPort, ListenTypeLocal, invoker)
+	startResult := StartServices(ctx, viper.GetInt(constants.ArgDatabasePort), ListenTypeLocal, invoker)
 	if startResult.Error != nil {
 		return nil, startResult.Error
 	}


### PR DESCRIPTION
Implicit service will now use the port defined in `database.port` from `config/*.spc` but fallback to the `9193` default when it is not set.