### PR TITLE
Add better help message for invalid locale settings during initdb failure #1673

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	filehelpers "github.com/turbot/go-kit/files"
 	"github.com/turbot/go-kit/helpers"
@@ -31,6 +32,9 @@ func main() {
 
 	// ensure steampipe is not being run as root
 	checkRoot(ctx)
+
+	// ensure UTF-8 langpacks are installed
+	checkLangpacks(ctx)
 
 	// increase the soft ULIMIT to match the hard limit
 	err := setULimit()
@@ -82,5 +86,12 @@ To reduce security risk, use an unprivileged user account instead.`))
 		exitCode = constants.ExitCodeUnknownErrorPanic
 		utils.ShowError(ctx, fmt.Errorf("real and effective user IDs must match."))
 		os.Exit(exitCode)
+	}
+}
+
+func checkLangpacks(ctx context.Context) {
+	if !strings.Contains(os.Getenv("LC_CTYPE"), "UTF-8") {
+		utils.ShowError(ctx, fmt.Errorf(`UTF-8 langpacks need to be installed to run steampipe`))
+		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func checkLocaleSettings(ctx context.Context) {
 	// if there is a cannot set LC_CTYPE error, exit with an error message
 	if flag {
 		utils.ShowError(ctx, fmt.Errorf(`Failed to initialize database as the default langpack(%s) is not installed. 
-To fix, either set environment variable LC_ALL to 'C' or 'POSIX' or install the langpack mentioned in LC_CTYPE. [https://www.postgresql.org/docs/current/multibyte.html]`, strings.TrimSpace(string(lc_val))))
+To fix, either set environment variable LC_ALL to 'C' or 'POSIX' or install the langpack %s. [https://www.postgresql.org/docs/current/multibyte.html]`, strings.TrimSpace(string(lc_val)), strings.TrimSpace(strings.Trim(string(lc_val), "LC_CTYPE="))))
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 
 	filehelpers "github.com/turbot/go-kit/files"
@@ -33,8 +34,8 @@ func main() {
 	// ensure steampipe is not being run as root
 	checkRoot(ctx)
 
-	// ensure UTF-8 langpacks are installed
-	checkLangpacks(ctx)
+	// check default character set and locale settings
+	checkLocaleSettings(ctx)
 
 	// increase the soft ULIMIT to match the hard limit
 	err := setULimit()
@@ -89,9 +90,27 @@ To reduce security risk, use an unprivileged user account instead.`))
 	}
 }
 
-func checkLangpacks(ctx context.Context) {
-	if !strings.Contains(os.Getenv("LC_CTYPE"), "UTF-8") {
-		utils.ShowError(ctx, fmt.Errorf(`UTF-8 langpacks need to be installed to run steampipe`))
+func checkLocaleSettings(ctx context.Context) {
+	// run the locale command
+	output, err := exec.Command("locale").CombinedOutput()
+	if err != nil {
+		fmt.Printf("Error while checking locale settings %v", err.Error())
+		return
+	}
+	// store the value of LC_CTYPE
+	lc_val, err := exec.Command("bash", "-c", "locale | grep LC_CTYPE").Output()
+	if err != nil {
+		fmt.Printf("Error while checking locale settings %v", err.Error())
+		return
+	}
+
+	// check for cannot set LC_CTYPE error
+	flag := strings.Contains(string(output), "Cannot set LC_CTYPE to default locale")
+
+	// if there is a cannot set LC_CTYPE error, exit with an error message
+	if flag {
+		utils.ShowError(ctx, fmt.Errorf(`Failed to initialize database as the default langpack(%s) is not installed. 
+To fix, either set environment variable LC_ALL to 'C' or 'POSIX' or install the langpack mentioned in LC_CTYPE. [https://www.postgresql.org/docs/current/multibyte.html]`, strings.TrimSpace(string(lc_val))))
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -97,12 +97,16 @@ func checkLocaleSettings(ctx context.Context) {
 		fmt.Printf("Error while checking locale settings %v", err.Error())
 		return
 	}
-	// store the value of LC_CTYPE
-	lc_val, err := exec.Command("bash", "-c", "locale | grep LC_CTYPE").Output()
+	// store the output of 'locale | grep LC_CTYPE'
+	lc_output, err := exec.Command("bash", "-c", "locale | grep LC_CTYPE").Output()
 	if err != nil {
 		fmt.Printf("Error while checking locale settings %v", err.Error())
 		return
 	}
+
+	lc_val := strings.TrimSpace(string(lc_output))
+	// get the langpack name from the output
+	langpack_name := strings.TrimSpace(strings.Trim(string(lc_output), "LC_CTYPE="))
 
 	// check for cannot set LC_CTYPE error
 	flag := strings.Contains(string(output), "Cannot set LC_CTYPE to default locale")
@@ -110,7 +114,7 @@ func checkLocaleSettings(ctx context.Context) {
 	// if there is a cannot set LC_CTYPE error, exit with an error message
 	if flag {
 		utils.ShowError(ctx, fmt.Errorf(`Failed to initialize database as the default langpack(%s) is not installed. 
-To fix, either set environment variable LC_ALL to 'C' or 'POSIX' or install the langpack %s. [https://www.postgresql.org/docs/current/multibyte.html]`, strings.TrimSpace(string(lc_val)), strings.TrimSpace(strings.Trim(string(lc_val), "LC_CTYPE="))))
+To fix, either set environment variable LC_ALL to "C" or "POSIX" or install the langpack %s. [https://www.postgresql.org/docs/current/multibyte.html]`, lc_val, langpack_name))
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Here `LANG` and `LC_CTYPE` are set to `en_US.UTF-8`, but `en_US.UTF-8` langpack is not installed, hence we see the error ` Cannot set LC_CTYPE to default locale`. 
This causes `initdb` failure

<img width="1212" alt="Screenshot 2022-06-14 at 8 13 25 PM" src="https://user-images.githubusercontent.com/45908484/173606185-314d5ec2-8f64-4cf2-bcb2-a0c13d443c94.png">


