### PR TITLE
Migrate all json config files to use snake case property names. Closes #1730

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ import (
 	"github.com/turbot/steampipe/db/db_local"
 	"github.com/turbot/steampipe/filepaths"
 	"github.com/turbot/steampipe/migrate"
+	"github.com/turbot/steampipe/ociinstaller/versionfile"
 	"github.com/turbot/steampipe/pluginmanager"
 	"github.com/turbot/steampipe/statefile"
 	"github.com/turbot/steampipe/statushooks"
@@ -146,7 +147,8 @@ func migrateLegacyFiles() error {
 		migrate.Migrate(pluginmanager.LegacyPluginManagerState{}, pluginmanager.PluginManagerState{}, pluginmanager.LegacyStateFilePath()),
 		migrate.Migrate(db_local.LegacyRunningDBInstanceInfo{}, db_local.RunningDBInstanceInfo{}, db_local.LegacyStateFilePath()),
 		migrate.Migrate(dashboardserver.LegacyDashboardServiceState{}, dashboardserver.DashboardServiceState{}, dashboardserver.LegacyStateFilePath()),
-		// migrate.Migrate(versionfile.LegacyPluginVersionFile{}, versionfile.PluginVersionFile{}, versionfile.LegacyVersionsFilePath()),
+		migrate.Migrate(versionfile.LegacyPluginVersionFile{}, versionfile.PluginVersionFile{}, versionfile.LegacyPluginVersionsFilePath()),
+		migrate.Migrate(versionfile.LegacyDatabaseVersionFile{}, versionfile.DatabaseVersionFile{}, versionfile.LegacyDbVersionsFilePath()),
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,8 +124,8 @@ func initGlobalConfig() {
 	var cmd = viper.Get(constants.ConfigKeyActiveCommand).(*cobra.Command)
 
 	// migrate all legacy config files
-	if cmd.Name() != "plugin-manager" {
-		utils.FailOnErrorWithMessage(migrateLegacyFiles(), "failed to migrate legacy files")
+	if cmd.Name() != constants.PluginManager {
+		utils.FailOnErrorWithMessage(migrateLegacyFiles(), "failed to migrate steampipe data files")
 	}
 
 	// load config (this sets the global config steampipeconfig.Config)
@@ -138,17 +138,19 @@ func initGlobalConfig() {
 	cmdconfig.SetViperDefaults(steampipeconfig.GlobalConfig.ConfigMap())
 
 	// now validate all config values have appropriate values
-	utils.FailOnErrorWithMessage(validateConfig(), "failed to validate config")
+	err = validateConfig()
+	utils.FailOnErrorWithMessage(err, "failed to validate config")
 }
 
+// migrate all data files to use snake casing for property names
 func migrateLegacyFiles() error {
 	return utils.CombineErrors(
-		migrate.Migrate(statefile.LegacyState{}, statefile.State{}, statefile.LegacyStateFilePath()),
-		migrate.Migrate(pluginmanager.LegacyPluginManagerState{}, pluginmanager.PluginManagerState{}, pluginmanager.LegacyStateFilePath()),
-		migrate.Migrate(db_local.LegacyRunningDBInstanceInfo{}, db_local.RunningDBInstanceInfo{}, db_local.LegacyStateFilePath()),
-		migrate.Migrate(dashboardserver.LegacyDashboardServiceState{}, dashboardserver.DashboardServiceState{}, dashboardserver.LegacyStateFilePath()),
-		migrate.Migrate(versionfile.LegacyPluginVersionFile{}, versionfile.PluginVersionFile{}, versionfile.LegacyPluginVersionsFilePath()),
-		migrate.Migrate(versionfile.LegacyDatabaseVersionFile{}, versionfile.DatabaseVersionFile{}, versionfile.LegacyDbVersionsFilePath()),
+		migrate.Migrate(statefile.LegacyState{}, &statefile.State{}, filepaths.LegacyStateFilePath()),
+		migrate.Migrate(pluginmanager.LegacyPluginManagerState{}, &pluginmanager.PluginManagerState{}, filepaths.PluginManagerStateFilePath()),
+		migrate.Migrate(db_local.LegacyRunningDBInstanceInfo{}, &db_local.RunningDBInstanceInfo{}, filepaths.RunningInfoFilePath()),
+		migrate.Migrate(dashboardserver.LegacyDashboardServiceState{}, &dashboardserver.DashboardServiceState{}, filepaths.DashboardServiceStateFilePath()),
+		migrate.Migrate(versionfile.LegacyPluginVersionFile{}, &versionfile.PluginVersionFile{}, filepaths.PluginVersionFilePath()),
+		migrate.Migrate(versionfile.LegacyDatabaseVersionFile{}, &versionfile.DatabaseVersionFile{}, filepaths.DatabaseVersionFilePath()),
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,9 +123,10 @@ func initGlobalConfig() {
 
 	var cmd = viper.Get(constants.ConfigKeyActiveCommand).(*cobra.Command)
 
-	// migrate all legacy config files
-	if cmd.Name() != constants.PluginManager {
-		utils.FailOnErrorWithMessage(migrateLegacyFiles(), "failed to migrate steampipe data files")
+	// migrate all legacy config files to use snake casing
+	if cmd.Name() != "plugin-manager" {
+		err := migrateLegacyFiles()
+		utils.FailOnErrorWithMessage(err, "failed to migrate steampipe data files")
 	}
 
 	// load config (this sets the global config steampipeconfig.Config)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -123,7 +123,7 @@ func initGlobalConfig() {
 
 	var cmd = viper.Get(constants.ConfigKeyActiveCommand).(*cobra.Command)
 
-	// migrate all legacy config files to use snake casing(migrated in v0.14.0)
+	// migrate all legacy config files to use snake casing (migrated in v0.14.0)
 	err := migrateLegacyFiles()
 	utils.FailOnErrorWithMessage(err, "failed to migrate steampipe data files")
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 	"github.com/turbot/steampipe/constants"
 	"github.com/turbot/steampipe/filepaths"
 	"github.com/turbot/steampipe/migrate"
+	"github.com/turbot/steampipe/pluginmanager"
 	"github.com/turbot/steampipe/statefile"
 	"github.com/turbot/steampipe/statushooks"
 	"github.com/turbot/steampipe/steampipeconfig"
@@ -140,7 +141,7 @@ func initGlobalConfig() {
 func migrateLegacyFiles() error {
 	return utils.CombineErrors(
 		migrate.Migrate(statefile.LegacyState{}, statefile.State{}, statefile.LegacyStateFilePath()),
-		// migrate.Migrate(pluginmanager.LegacyPluginManagerState{}, pluginmanager.PluginManagerState{}, pluginmanager.LegacyStateFilePath()),
+		migrate.Migrate(pluginmanager.LegacyPluginManagerState{}, pluginmanager.PluginManagerState{}, pluginmanager.LegacyStateFilePath()),
 		// migrate.Migrate(db_local.LegacyRunningDBInstanceInfo{}, db_local.RunningDBInstanceInfo{}, db_local.LegacyStateFilePath()),
 		// migrate.Migrate(versionfile.LegacyPluginVersionFile{}, versionfile.PluginVersionFile{}, versionfile.LegacyVersionsFilePath()),
 	)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,7 +149,6 @@ func migrateLegacyFiles() error {
 		migrate.Migrate(dashboardserver.LegacyDashboardServiceState{}, dashboardserver.DashboardServiceState{}, dashboardserver.LegacyStateFilePath()),
 		migrate.Migrate(versionfile.LegacyPluginVersionFile{}, versionfile.PluginVersionFile{}, versionfile.LegacyPluginVersionsFilePath()),
 		migrate.Migrate(versionfile.LegacyDatabaseVersionFile{}, versionfile.DatabaseVersionFile{}, versionfile.LegacyDbVersionsFilePath()),
-		migrate.Migrate(steampipeconfig.LegacyConnectionData{}, steampipeconfig.ConnectionData{}, steampipeconfig.LegacyStateFilePath()),
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -149,6 +149,7 @@ func migrateLegacyFiles() error {
 		migrate.Migrate(dashboardserver.LegacyDashboardServiceState{}, dashboardserver.DashboardServiceState{}, dashboardserver.LegacyStateFilePath()),
 		migrate.Migrate(versionfile.LegacyPluginVersionFile{}, versionfile.PluginVersionFile{}, versionfile.LegacyPluginVersionsFilePath()),
 		migrate.Migrate(versionfile.LegacyDatabaseVersionFile{}, versionfile.DatabaseVersionFile{}, versionfile.LegacyDbVersionsFilePath()),
+		migrate.Migrate(steampipeconfig.LegacyConnectionData{}, steampipeconfig.ConnectionData{}, steampipeconfig.LegacyStateFilePath()),
 	)
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,8 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v3/logging"
 	"github.com/turbot/steampipe/cmdconfig"
 	"github.com/turbot/steampipe/constants"
+	"github.com/turbot/steampipe/dashboard/dashboardserver"
+	"github.com/turbot/steampipe/db/db_local"
 	"github.com/turbot/steampipe/filepaths"
 	"github.com/turbot/steampipe/migrate"
 	"github.com/turbot/steampipe/pluginmanager"
@@ -142,7 +144,8 @@ func migrateLegacyFiles() error {
 	return utils.CombineErrors(
 		migrate.Migrate(statefile.LegacyState{}, statefile.State{}, statefile.LegacyStateFilePath()),
 		migrate.Migrate(pluginmanager.LegacyPluginManagerState{}, pluginmanager.PluginManagerState{}, pluginmanager.LegacyStateFilePath()),
-		// migrate.Migrate(db_local.LegacyRunningDBInstanceInfo{}, db_local.RunningDBInstanceInfo{}, db_local.LegacyStateFilePath()),
+		migrate.Migrate(db_local.LegacyRunningDBInstanceInfo{}, db_local.RunningDBInstanceInfo{}, db_local.LegacyStateFilePath()),
+		migrate.Migrate(dashboardserver.LegacyDashboardServiceState{}, dashboardserver.DashboardServiceState{}, dashboardserver.LegacyStateFilePath()),
 		// migrate.Migrate(versionfile.LegacyPluginVersionFile{}, versionfile.PluginVersionFile{}, versionfile.LegacyVersionsFilePath()),
 	)
 }

--- a/constants/migrate.go
+++ b/constants/migrate.go
@@ -1,8 +1,0 @@
-package constants
-
-// constants used while migration of steampipe data files
-const (
-	SchemaVersion = "20220407"
-	StructVersion = 20220407
-	PluginManager = "plugin-manager"
-)

--- a/constants/migrate.go
+++ b/constants/migrate.go
@@ -1,0 +1,8 @@
+package constants
+
+// constants used while migration of steampipe data files
+const (
+	SchemaVersion = "20220407"
+	StructVersion = 20220407
+	PluginManager = "plugin-manager"
+)

--- a/dashboard/dashboardserver/service.go
+++ b/dashboard/dashboardserver/service.go
@@ -23,13 +23,13 @@ import (
 type ServiceState string
 
 const (
-	ServiceStateRunning ServiceState = "running"
-	ServiceStateError   ServiceState = "running"
-	StructVersion                    = 20220411
+	ServiceStateRunning       ServiceState = "running"
+	ServiceStateError         ServiceState = "running"
+	ServiceStateStructVersion              = 20220411
 )
 
 // LegacyDashboardServiceState is a struct used to migrate the
-// DashboardServiceState to serialize with snake case property names
+// DashboardServiceState to serialize with snake case property names(migrated in v0.14.0)
 type LegacyDashboardServiceState struct {
 	State      ServiceState
 	Error      string
@@ -49,15 +49,14 @@ type DashboardServiceState struct {
 	StructVersion int64        `json:"struct_version"`
 }
 
-// IsValid checks whether the struct was correctly deserialized,
-// by checking if the StructVersion is populated
+// IsValid checks whether the struct was correctly deserialized, by checking if the StructVersion is populated
 func (s DashboardServiceState) IsValid() bool {
 	return s.StructVersion > 0
 }
 
 func (s *DashboardServiceState) MigrateFrom(prev interface{}) migrate.Migrateable {
 	legacyState := prev.(LegacyDashboardServiceState)
-	s.StructVersion = StructVersion
+	s.StructVersion = ServiceStateStructVersion
 	s.State = legacyState.State
 	s.Error = legacyState.Error
 	s.Pid = legacyState.Pid
@@ -247,7 +246,7 @@ func (f *DashboardServiceState) Save() error {
 func (f *DashboardServiceState) write(path string) error {
 	versionFileJSON, err := json.MarshalIndent(f, "", "  ")
 	if err != nil {
-		log.Println("[ERROR]", "Error while writing version file", err)
+		log.Println("Error while writing version file", err)
 		return err
 	}
 	return os.WriteFile(path, versionFileJSON, 0644)

--- a/dashboard/dashboardserver/service.go
+++ b/dashboard/dashboardserver/service.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -27,6 +27,8 @@ const (
 	ServiceStateError   ServiceState = "running"
 )
 
+// LegacyDashboardServiceState is the legacy dashboard service state struct, which was
+// used in the legacy dashboard service state file
 type LegacyDashboardServiceState struct {
 	State      ServiceState
 	Error      string
@@ -50,9 +52,9 @@ func (s DashboardServiceState) IsValid() bool {
 	return len(s.SchemaVersion) > 0
 }
 
-func (s DashboardServiceState) MigrateFrom(oldI interface{}) migrate.Migrateable {
-	old := oldI.(LegacyDashboardServiceState)
-	s.SchemaVersion = "20220407"
+func (s *DashboardServiceState) MigrateFrom(legacyState interface{}) migrate.Migrateable {
+	old := legacyState.(LegacyDashboardServiceState)
+	s.SchemaVersion = constants.SchemaVersion
 	s.State = old.State
 	s.Error = old.Error
 	s.Pid = old.Pid
@@ -61,23 +63,6 @@ func (s DashboardServiceState) MigrateFrom(oldI interface{}) migrate.Migrateable
 	s.Listen = old.Listen
 
 	return s
-}
-
-func (s DashboardServiceState) WriteOut() error {
-	// ensure internal dirs exists
-	if err := os.MkdirAll(filepaths.EnsureInternalDir(), os.ModePerm); err != nil {
-		return err
-	}
-	stateFilePath := filepath.Join(filepaths.EnsureInternalDir(), "dashboard_service.json")
-	// if there is an existing file it must be bad/corrupt, so delete it
-	_ = os.Remove(stateFilePath)
-	// save state file
-	file, _ := json.MarshalIndent(s, "", " ")
-	return os.WriteFile(stateFilePath, file, 0644)
-}
-
-func LegacyStateFilePath() string {
-	return filepath.Join(filepaths.EnsureInternalDir(), "dashboard_service.json")
 }
 
 func GetDashboardServiceState() (*DashboardServiceState, error) {
@@ -249,4 +234,19 @@ func loadServiceStateFile() (*DashboardServiceState, error) {
 	}
 	err = json.Unmarshal(stateBytes, state)
 	return state, err
+}
+
+// Save writes the config
+func (f *DashboardServiceState) Save() error {
+	versionFilePath := filepaths.DashboardServiceStateFilePath()
+	return f.write(versionFilePath)
+}
+
+func (f *DashboardServiceState) write(path string) error {
+	versionFileJSON, err := json.MarshalIndent(f, "", "  ")
+	if err != nil {
+		log.Println("[ERROR]", "Error while writing version file", err)
+		return err
+	}
+	return os.WriteFile(path, versionFileJSON, 0644)
 }

--- a/dashboard/dashboardserver/service.go
+++ b/dashboard/dashboardserver/service.go
@@ -25,10 +25,11 @@ type ServiceState string
 const (
 	ServiceStateRunning ServiceState = "running"
 	ServiceStateError   ServiceState = "running"
+	StructVersion                    = 20220411
 )
 
-// LegacyDashboardServiceState is the legacy dashboard service state struct, which was
-// used in the legacy dashboard service state file
+// LegacyDashboardServiceState is a struct used to migrate the
+// DashboardServiceState to serialize with snake case property names
 type LegacyDashboardServiceState struct {
 	State      ServiceState
 	Error      string
@@ -45,22 +46,24 @@ type DashboardServiceState struct {
 	Port          int          `json:"port"`
 	ListenType    string       `json:"listen_type"`
 	Listen        []string     `json:"listen"`
-	SchemaVersion string       `json:"schema_version"`
+	StructVersion int64        `json:"struct_version"`
 }
 
+// IsValid checks whether the struct was correctly deserialized,
+// by checking if the StructVersion is populated
 func (s DashboardServiceState) IsValid() bool {
-	return len(s.SchemaVersion) > 0
+	return s.StructVersion > 0
 }
 
-func (s *DashboardServiceState) MigrateFrom(legacyState interface{}) migrate.Migrateable {
-	old := legacyState.(LegacyDashboardServiceState)
-	s.SchemaVersion = constants.SchemaVersion
-	s.State = old.State
-	s.Error = old.Error
-	s.Pid = old.Pid
-	s.Port = old.Port
-	s.ListenType = old.ListenType
-	s.Listen = old.Listen
+func (s *DashboardServiceState) MigrateFrom(prev interface{}) migrate.Migrateable {
+	legacyState := prev.(LegacyDashboardServiceState)
+	s.StructVersion = StructVersion
+	s.State = legacyState.State
+	s.Error = legacyState.Error
+	s.Pid = legacyState.Pid
+	s.Port = legacyState.Port
+	s.ListenType = legacyState.ListenType
+	s.Listen = legacyState.Listen
 
 	return s
 }
@@ -236,7 +239,6 @@ func loadServiceStateFile() (*DashboardServiceState, error) {
 	return state, err
 }
 
-// Save writes the config
 func (f *DashboardServiceState) Save() error {
 	versionFilePath := filepaths.DashboardServiceStateFilePath()
 	return f.write(versionFilePath)

--- a/db/db_local/running_info.go
+++ b/db/db_local/running_info.go
@@ -14,10 +14,10 @@ import (
 	"github.com/turbot/steampipe/utils"
 )
 
-const StructVersion = 20220411
+const RunningDBStructVersion = 20220411
 
 // LegacyRunningDBInstanceInfo is a struct used to migrate the
-// RunningDBInstanceInfo to serialize with snake case property names
+// RunningDBInstanceInfo to serialize with snake case property names(migrated in v0.14.0)
 type LegacyRunningDBInstanceInfo struct {
 	Pid        int
 	Port       int
@@ -50,7 +50,7 @@ func (s RunningDBInstanceInfo) IsValid() bool {
 
 func (s *RunningDBInstanceInfo) MigrateFrom(prev interface{}) migrate.Migrateable {
 	legacyState := prev.(LegacyRunningDBInstanceInfo)
-	s.StructVersion = StructVersion
+	s.StructVersion = RunningDBStructVersion
 	s.Pid = legacyState.Pid
 	s.Port = legacyState.Port
 	s.Listen = legacyState.Listen

--- a/db/db_local/running_info.go
+++ b/db/db_local/running_info.go
@@ -14,8 +14,10 @@ import (
 	"github.com/turbot/steampipe/utils"
 )
 
-// LegacyRunningDBInstanceInfo is the legacy running db instance info struct, which was used
-// in the legacy steampipe.json state file
+const StructVersion = 20220411
+
+// LegacyRunningDBInstanceInfo is a struct used to migrate the
+// RunningDBInstanceInfo to serialize with snake case property names
 type LegacyRunningDBInstanceInfo struct {
 	Pid        int
 	Port       int
@@ -37,24 +39,26 @@ type RunningDBInstanceInfo struct {
 	Password      string            `json:"password"`
 	User          string            `json:"user"`
 	Database      string            `json:"database"`
-	SchemaVersion string            `json:"schema_version"`
+	StructVersion int64             `json:"struct_version"`
 }
 
+// IsValid checks whether the struct was correctly deserialized,
+// by checking if the StructVersion is populated
 func (s RunningDBInstanceInfo) IsValid() bool {
-	return len(s.SchemaVersion) > 0
+	return s.StructVersion > 0
 }
 
-func (s *RunningDBInstanceInfo) MigrateFrom(legacyState interface{}) migrate.Migrateable {
-	old := legacyState.(LegacyRunningDBInstanceInfo)
-	s.SchemaVersion = constants.SchemaVersion
-	s.Pid = old.Pid
-	s.Port = old.Port
-	s.Listen = old.Listen
-	s.ListenType = old.ListenType
-	s.Invoker = old.Invoker
-	s.Password = old.Password
-	s.User = old.User
-	s.Database = old.Database
+func (s *RunningDBInstanceInfo) MigrateFrom(prev interface{}) migrate.Migrateable {
+	legacyState := prev.(LegacyRunningDBInstanceInfo)
+	s.StructVersion = StructVersion
+	s.Pid = legacyState.Pid
+	s.Port = legacyState.Port
+	s.Listen = legacyState.Listen
+	s.ListenType = legacyState.ListenType
+	s.Invoker = legacyState.Invoker
+	s.Password = legacyState.Password
+	s.User = legacyState.User
+	s.Database = legacyState.Database
 
 	return s
 }

--- a/filepaths/steampipe.go
+++ b/filepaths/steampipe.go
@@ -125,3 +125,7 @@ func PluginManagerStateFilePath() string {
 func DashboardServiceStateFilePath() string {
 	return filepath.Join(EnsureInternalDir(), dashboardServerStateFileName)
 }
+
+func StateFileName() string {
+	return stateFileName
+}

--- a/filepaths/steampipe.go
+++ b/filepaths/steampipe.go
@@ -16,6 +16,8 @@ const (
 	databaseRunningInfoFileName  = "steampipe.json"
 	pluginManagerStateFileName   = "plugin_manager.json"
 	dashboardServerStateFileName = "dashboard_service.json"
+	stateFileName                = "update_check.json"
+	legacyStateFileName          = "update-check.json"
 )
 
 var SteampipeDir string
@@ -75,6 +77,16 @@ func EnsureDashboardAssetsDir() string {
 // LegacyDashboardAssetsDir returns the path to the legacy report assets folder
 func LegacyDashboardAssetsDir() string {
 	return steampipeSubDir("report")
+}
+
+// LegacyStateFilePath returns the path of the legacy update-check.json state file
+func LegacyStateFilePath() string {
+	return filepath.Join(EnsureInternalDir(), legacyStateFileName)
+}
+
+// StateFilePath returns the path of the update_check.json state file
+func StateFilePath() string {
+	return filepath.Join(EnsureInternalDir(), stateFileName)
 }
 
 // ConnectionStatePath returns the path of the connections state file

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -2,7 +2,6 @@ package migrate
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/turbot/steampipe/utils"
@@ -14,20 +13,18 @@ type Migrateable interface {
 	WriteOut() error
 }
 
-func Migrate(old interface{}, new Migrateable, oldPath string) error {
+func Migrate[O any, T Migrateable](old O, new T, oldPath string) error {
 	stateFileContent, err := os.ReadFile(oldPath)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		fmt.Println("Could not read file")
 		return err
 	}
 
-	// / deserialize into new
-	err = json.Unmarshal(stateFileContent, new)
+	// deserialize into new
+	err = json.Unmarshal(stateFileContent, &new)
 	if err != nil {
-		fmt.Println("Could not parse file")
 		return err
 	}
 
@@ -37,11 +34,10 @@ func Migrate(old interface{}, new Migrateable, oldPath string) error {
 	}
 
 	// if schemaVersion is not available, deserialize into old
-	err = json.Unmarshal(stateFileContent, old)
+	err = json.Unmarshal(stateFileContent, &old)
 	if err != nil {
-		fmt.Println("Could not parse file")
 		return err
 	}
-	new = new.MigrateFrom(old)
-	return utils.CombineErrors(os.Remove(oldPath), new.WriteOut())
+	x := new.MigrateFrom(old)
+	return utils.CombineErrors(os.Remove(oldPath), x.WriteOut())
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -10,7 +10,7 @@ import (
 type Migrateable interface {
 	MigrateFrom(old interface{}) Migrateable
 	IsValid() bool
-	WriteOut() error
+	Save() error
 }
 
 func Migrate[O any, T Migrateable](old O, new T, oldPath string) error {
@@ -39,5 +39,5 @@ func Migrate[O any, T Migrateable](old O, new T, oldPath string) error {
 		return err
 	}
 	x := new.MigrateFrom(old)
-	return utils.CombineErrors(os.Remove(oldPath), x.WriteOut())
+	return utils.CombineErrors(os.Remove(oldPath), x.Save())
 }

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,0 +1,47 @@
+package migrate
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/turbot/steampipe/utils"
+)
+
+type Migrateable interface {
+	MigrateFrom(old interface{}) Migrateable
+	IsValid() bool
+	WriteOut() error
+}
+
+func Migrate(old interface{}, new Migrateable, oldPath string) error {
+	stateFileContent, err := os.ReadFile(oldPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		fmt.Println("Could not read file")
+		return err
+	}
+
+	// / deserialize into new
+	err = json.Unmarshal(stateFileContent, new)
+	if err != nil {
+		fmt.Println("Could not parse file")
+		return err
+	}
+
+	// check for schemaVersion
+	if new.IsValid() {
+		return nil
+	}
+
+	// if schemaVersion is not available, deserialize into old
+	err = json.Unmarshal(stateFileContent, old)
+	if err != nil {
+		fmt.Println("Could not parse file")
+		return err
+	}
+	new = new.MigrateFrom(old)
+	return utils.CombineErrors(os.Remove(oldPath), new.WriteOut())
+}

--- a/ociinstaller/versionfile/db_version_file.go
+++ b/ociinstaller/versionfile/db_version_file.go
@@ -11,10 +11,10 @@ import (
 	"github.com/turbot/steampipe/migrate"
 )
 
-const StructVersion = 20220411
+const DatabaseStructVersion = 20220411
 
 // LegacyDatabaseVersionFile is a struct used to migrate the
-// DatabaseVersionFile to serialize with snake case property names
+// DatabaseVersionFile to serialize with snake case property names(migrated in v0.14.0)
 type LegacyDatabaseVersionFile struct {
 	FdwExtension LegacyInstalledVersion `json:"fdwExtension"`
 	EmbeddedDB   LegacyInstalledVersion `json:"embeddedDB"`
@@ -41,7 +41,7 @@ func (s DatabaseVersionFile) IsValid() bool {
 
 func (s *DatabaseVersionFile) MigrateFrom(prev interface{}) migrate.Migrateable {
 	legacyState := prev.(LegacyDatabaseVersionFile)
-	s.StructVersion = StructVersion
+	s.StructVersion = DatabaseStructVersion
 	s.FdwExtension.Name = legacyState.FdwExtension.Name
 	s.FdwExtension.Version = legacyState.FdwExtension.Version
 	s.FdwExtension.ImageDigest = legacyState.FdwExtension.ImageDigest

--- a/ociinstaller/versionfile/legacy_version_file.go
+++ b/ociinstaller/versionfile/legacy_version_file.go
@@ -9,14 +9,14 @@ import (
 	"github.com/turbot/steampipe/filepaths"
 )
 
-type LegacyVersionFile struct {
+type LegacyCompositeVersionFile struct {
 	Plugins      map[string]*InstalledVersion `json:"plugins"`
 	FdwExtension InstalledVersion             `json:"fdwExtension"`
 	EmbeddedDB   InstalledVersion             `json:"embeddedDB"`
 }
 
 // LoadLegacyVersionFile loads the legacy version file, or returns nil if it does not exist
-func LoadLegacyVersionFile() (*LegacyVersionFile, error) {
+func LoadLegacyVersionFile() (*LegacyCompositeVersionFile, error) {
 	versionFilePath := filepaths.LegacyVersionFilePath()
 	if helpers.FileExists(versionFilePath) {
 		return readLegacyVersionFile(versionFilePath)
@@ -24,10 +24,10 @@ func LoadLegacyVersionFile() (*LegacyVersionFile, error) {
 	return nil, nil
 }
 
-func readLegacyVersionFile(path string) (*LegacyVersionFile, error) {
+func readLegacyVersionFile(path string) (*LegacyCompositeVersionFile, error) {
 	file, _ := os.ReadFile(path)
 
-	var data LegacyVersionFile
+	var data LegacyCompositeVersionFile
 
 	if err := json.Unmarshal([]byte(file), &data); err != nil {
 		log.Println("[ERROR]", "Error while reading version file", err)
@@ -77,7 +77,7 @@ func migrateVersionFiles() (*PluginVersionFile, *DatabaseVersionFile, error) {
 }
 
 // delete the file on disk if it exists
-func (f *LegacyVersionFile) delete() {
+func (f *LegacyCompositeVersionFile) delete() {
 	versionFilePath := filepaths.LegacyVersionFilePath()
 	if helpers.FileExists(versionFilePath) {
 		os.Remove(versionFilePath)

--- a/ociinstaller/versionfile/legacy_version_file.go
+++ b/ociinstaller/versionfile/legacy_version_file.go
@@ -9,6 +9,8 @@ import (
 	"github.com/turbot/steampipe/filepaths"
 )
 
+// LegacyCompositeVersionFile is the composite version file used before v0.7.0, which contained
+// both db and plugin properties, now split into two different files
 type LegacyCompositeVersionFile struct {
 	Plugins      map[string]*InstalledVersion `json:"plugins"`
 	FdwExtension InstalledVersion             `json:"fdwExtension"`

--- a/ociinstaller/versionfile/plugin_version_file.go
+++ b/ociinstaller/versionfile/plugin_version_file.go
@@ -10,8 +10,10 @@ import (
 	"github.com/turbot/steampipe/migrate"
 )
 
+const PluginStructVersion = 20220411
+
 // LegacyPluginVersionFile is a struct used to migrate the
-// PluginVersionFile to serialize with snake case property names
+// PluginVersionFile to serialize with snake case property names(migrated in v0.14.0)
 type LegacyPluginVersionFile struct {
 	Plugins map[string]*LegacyInstalledVersion `json:"plugins"`
 }
@@ -29,7 +31,7 @@ func (s PluginVersionFile) IsValid() bool {
 
 func (s *PluginVersionFile) MigrateFrom(prev interface{}) migrate.Migrateable {
 	legacyState := prev.(LegacyPluginVersionFile)
-	s.StructVersion = StructVersion
+	s.StructVersion = PluginStructVersion
 	s.Plugins = make(map[string]*InstalledVersion, len(legacyState.Plugins))
 	for p, i := range legacyState.Plugins {
 		s.Plugins[p] = &InstalledVersion{

--- a/pluginmanager/grpc/proto/simple_addr.go
+++ b/pluginmanager/grpc/proto/simple_addr.go
@@ -3,8 +3,8 @@ package proto
 import "net"
 
 type SimpleAddr struct {
-	NetworkString string `json:"Network"`
-	AddressString string `json:"String"`
+	NetworkString string `json:"network"`
+	AddressString string `json:"string"`
 }
 
 func NewSimpleAddr(addr net.Addr) *SimpleAddr {

--- a/pluginmanager/state.go
+++ b/pluginmanager/state.go
@@ -15,10 +15,10 @@ import (
 	"github.com/turbot/steampipe/utils"
 )
 
-const StructVersion = 20220411
+const PluginManagerStructVersion = 20220411
 
 // LegacyPluginManagerState is a struct used to migrate the
-// PluginManagerState to serialize with snake case property names
+// PluginManagerState to serialize with snake case property names(migrated in v0.14.0)
 type LegacyPluginManagerState struct {
 	Protocol        plugin.Protocol
 	ProtocolVersion int
@@ -60,7 +60,7 @@ func (s PluginManagerState) IsValid() bool {
 
 func (s *PluginManagerState) MigrateFrom(prev interface{}) migrate.Migrateable {
 	legacyState := prev.(LegacyPluginManagerState)
-	s.StructVersion = StructVersion
+	s.StructVersion = PluginManagerStructVersion
 	s.Protocol = legacyState.Protocol
 	s.ProtocolVersion = legacyState.ProtocolVersion
 	s.Addr = legacyState.Addr

--- a/statefile/load.go
+++ b/statefile/load.go
@@ -12,10 +12,10 @@ import (
 	"github.com/turbot/steampipe/migrate"
 )
 
-const StructVersion = 20220411
+const StateStructVersion = 20220411
 
 // LegacyState is a struct used to migrate the
-// State to serialize with snake case property names
+// State to serialize with snake case property names(migrated in v0.14.0)
 type LegacyState struct {
 	LastCheck      string `json:"lastChecked"`    // an RFC3339 encoded time stamp
 	InstallationID string `json:"installationId"` // a UUIDv4 string
@@ -36,7 +36,7 @@ func (s State) IsValid() bool {
 
 func (s *State) MigrateFrom(prev interface{}) migrate.Migrateable {
 	legacyState := prev.(LegacyState)
-	s.StructVersion = StructVersion
+	s.StructVersion = StateStructVersion
 	s.LastCheck = legacyState.LastCheck
 	s.InstallationID = legacyState.InstallationID
 

--- a/statefile/load.go
+++ b/statefile/load.go
@@ -31,7 +31,7 @@ type State struct {
 // IsValid checks whether the struct was correctly deserialized,
 // by checking if the StructVersion is populated
 func (s State) IsValid() bool {
-	return StructVersion > 0
+	return s.StructVersion > 0
 }
 
 func (s *State) MigrateFrom(prev interface{}) migrate.Migrateable {

--- a/statefile/load.go
+++ b/statefile/load.go
@@ -9,14 +9,52 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/turbot/steampipe/filepaths"
+	"github.com/turbot/steampipe/migrate"
 )
 
-const updateStateFileName = "update-check.json"
+const legacyStateFileName = "update-check.json"
+const updateStateFileName = "update_check.json"
 
 // State :: the state of the installation
-type State struct {
+type LegacyState struct {
 	LastCheck      string `json:"lastChecked"`    // an RFC3339 encoded time stamp
 	InstallationID string `json:"installationId"` // a UUIDv4 string
+}
+
+type State struct {
+	LastCheck      string `json:"last_checked"`    // an RFC3339 encoded time stamp
+	InstallationID string `json:"installation_id"` // a UUIDv4 string
+	SchemaVersion  string `json:"schema_version"`
+}
+
+func (s State) IsValid() bool {
+	return len(s.SchemaVersion) > 0
+}
+
+func (s State) MigrateFrom(oldI interface{}) migrate.Migrateable {
+	old := oldI.(LegacyState)
+	s.SchemaVersion = "20220407"
+	s.LastCheck = old.LastCheck
+	s.InstallationID = old.InstallationID
+
+	return s
+}
+
+func (s State) WriteOut() error {
+	// ensure internal dirs exists
+	if err := os.MkdirAll(filepaths.EnsureInternalDir(), os.ModePerm); err != nil {
+		return err
+	}
+	stateFilePath := filepath.Join(filepaths.EnsureInternalDir(), updateStateFileName)
+	// if there is an existing file it must be bad/corrupt, so delete it
+	_ = os.Remove(stateFilePath)
+	// save state file
+	file, _ := json.MarshalIndent(s, "", " ")
+	return os.WriteFile(stateFilePath, file, 0644)
+}
+
+func LegacyStateFilePath() string {
+	return filepath.Join(filepaths.EnsureInternalDir(), legacyStateFileName)
 }
 
 func LoadState() (State, error) {

--- a/statefile/save.go
+++ b/statefile/save.go
@@ -14,7 +14,7 @@ func (s *State) Save() error {
 	s.LastCheck = nowTimeString()
 	// ensure internal dirs exists
 	_ = os.MkdirAll(filepaths.EnsureInternalDir(), os.ModePerm)
-	stateFilePath := filepath.Join(filepaths.EnsureInternalDir(), updateStateFileName)
+	stateFilePath := filepath.Join(filepaths.EnsureInternalDir(), filepaths.StateFileName())
 	// if there is an existing file it must be bad/corrupt, so delete it
 	_ = os.Remove(stateFilePath)
 	// save state file

--- a/steampipeconfig/connection_data.go
+++ b/steampipeconfig/connection_data.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/turbot/steampipe/constants"
 	"github.com/turbot/steampipe/filepaths"
 	"github.com/turbot/steampipe/migrate"
 	"github.com/turbot/steampipe/steampipeconfig/modconfig"
@@ -51,18 +50,20 @@ type ConnectionData struct {
 	ModTime time.Time `json:"mod_time"`
 }
 
+// IsValid checks whether the struct was correctly deserialized,
+// by checking if the StructVersion is populated
 func (s ConnectionData) IsValid() bool {
 	return s.StructVersion > 0
 }
 
-func (s *ConnectionData) MigrateFrom(legacyState interface{}) migrate.Migrateable {
-	old := legacyState.(LegacyConnectionData)
-	s.StructVersion = constants.StructVersion
-	s.Plugin = old.Plugin
-	s.SchemaMode = old.SchemaMode
-	s.SchemaHash = old.SchemaHash
-	s.ModTime = old.ModTime
-	s.Connection = old.Connection
+func (s *ConnectionData) MigrateFrom(prev interface{}) migrate.Migrateable {
+	legacyState := prev.(LegacyConnectionData)
+	s.StructVersion = ConnectionDataStructVersion
+	s.Plugin = legacyState.Plugin
+	s.SchemaMode = legacyState.SchemaMode
+	s.SchemaHash = legacyState.SchemaHash
+	s.ModTime = legacyState.ModTime
+	s.Connection = legacyState.Connection
 
 	return s
 }
@@ -92,7 +93,6 @@ func (p *ConnectionData) Equals(other *ConnectionData) bool {
 		p.Connection.Equals(other.Connection)
 }
 
-// Save writes the config
 func (f *ConnectionData) Save() error {
 	versionFilePath := filepaths.ConnectionStatePath()
 	return f.write(versionFilePath)

--- a/steampipeconfig/connection_data_map.go
+++ b/steampipeconfig/connection_data_map.go
@@ -57,7 +57,7 @@ func NewConnectionDataMap(connectionMap map[string]*modconfig.Connection) (Conne
 		remoteSchema := connection.Plugin
 		pluginPath, err := pluginmanager.GetPluginPath(connection.Plugin, connection.PluginShortName)
 		if err != nil {
-			err := fmt.Errorf("failed to load connection '%s': %v\n%s", connection.Name, err, connection.DeclRange)
+			err := fmt.Errorf("failed to load connection '%s': %v\n%v", connection.Name, err, connection.DeclRange)
 			return nil, nil, err
 		}
 		// if plugin is not installed, the path will be returned as empty

--- a/steampipeconfig/modconfig/connection.go
+++ b/steampipeconfig/modconfig/connection.go
@@ -64,13 +64,48 @@ type Connection struct {
 
 	// options
 	Options   *options.Connection `json:"options,omitempty"`
-	DeclRange hcl.Range           `json:"decl_range,omitempty"`
+	DeclRange Range               `json:"decl_range,omitempty"`
+}
+
+// Range represents a span of characters between two positions in a source file.
+// This is a direct re-implementation of hcl.Range, allowing us to control JSON serialization
+type Range struct {
+	// Filename is the name of the file into which this range's positions point.
+	Filename string `json:"filename,omitempty"`
+
+	// Start and End represent the bounds of this range. Start is inclusive and End is exclusive.
+	Start Pos `json:"start,omitempty"`
+	End   Pos `json:"end,omitempty"`
+}
+
+func NewRange(sourceRange hcl.Range) Range {
+	return Range{
+		Filename: sourceRange.Filename,
+		Start:    NewPos(sourceRange.Start),
+		End:      NewPos(sourceRange.End),
+	}
+}
+
+// Pos represents a single position in a source file
+// This is a direct re-implementation of hcl.Pos, allowing us to control JSON serialization
+type Pos struct {
+	Line   int `json:"line,omitempty"`
+	Column int `json:"column,omitempty"`
+	Byte   int `json:"byte,omitempty"`
+}
+
+func NewPos(sourcePos hcl.Pos) Pos {
+	return Pos{
+		Line:   sourcePos.Line,
+		Column: sourcePos.Column,
+		Byte:   sourcePos.Byte,
+	}
 }
 
 func NewConnection(block *hcl.Block) *Connection {
 	return &Connection{
 		Name:      block.Labels[0],
-		DeclRange: block.TypeRange,
+		DeclRange: NewRange(block.TypeRange),
 	}
 }
 

--- a/steampipeconfig/modconfig/connection.go
+++ b/steampipeconfig/modconfig/connection.go
@@ -21,7 +21,7 @@ const (
 // (Partial as the connection config, which is plugin specific, is stored as raw HCL.
 // This will be parsed by the plugin)
 // json tags needed as this is stored in the connection state file
-type Connection struct {
+type LegacyConnection struct {
 	// connection name
 	Name string
 	// The name of plugin as mentioned in config
@@ -42,6 +42,29 @@ type Connection struct {
 	// options
 	Options   *options.Connection `json:"Options,omitempty"`
 	DeclRange hcl.Range
+}
+
+type Connection struct {
+	// connection name
+	Name string `json:"name,omitempty"`
+	// The name of plugin as mentioned in config
+	PluginShortName string `json:"plugin_short_name,omitempty"`
+	// The fully qualified name of the plugin. derived from the short name
+	Plugin string `json:"plugin,omitempty"`
+	// Type - supported values: "aggregator"
+	Type string `json:"type,omitempty"`
+	// this is a list of names or wildcards which are resolved to connections
+	// (only valid for "aggregator" type)
+	ConnectionNames []string `json:"connections,omitempty"`
+	// a list of the resolved child connections
+	// (only valid for "aggregator" type)
+	Connections map[string]*Connection `json:"-"`
+	// unparsed HCL of plugin specific connection config
+	Config string `json:"config,omitempty"`
+
+	// options
+	Options   *options.Connection `json:"options,omitempty"`
+	DeclRange hcl.Range           `json:"decl_range,omitempty"`
 }
 
 func NewConnection(block *hcl.Block) *Connection {

--- a/steampipeconfig/modconfig/connection.go
+++ b/steampipeconfig/modconfig/connection.go
@@ -16,11 +16,8 @@ const (
 	ConnectionTypeAggregator = "aggregator"
 )
 
-// Connection is a struct representing the partially parsed connection
-//
-// (Partial as the connection config, which is plugin specific, is stored as raw HCL.
-// This will be parsed by the plugin)
-// json tags needed as this is stored in the connection state file
+// LegacyConnection is the legacy connection struct, which was used in the legacy
+// connection state file
 type LegacyConnection struct {
 	// connection name
 	Name string
@@ -44,6 +41,11 @@ type LegacyConnection struct {
 	DeclRange hcl.Range
 }
 
+// Connection is a struct representing the partially parsed connection
+//
+// (Partial as the connection config, which is plugin specific, is stored as raw HCL.
+// This will be parsed by the plugin)
+// json tags needed as this is stored in the connection state file
 type Connection struct {
 	// connection name
 	Name string `json:"name,omitempty"`

--- a/steampipeconfig/versionmap/resolved_version_constraint.go
+++ b/steampipeconfig/versionmap/resolved_version_constraint.go
@@ -5,10 +5,10 @@ import (
 )
 
 type ResolvedVersionConstraint struct {
-	Name       string
-	Alias      string
-	Version    *semver.Version
-	Constraint string
+	Name       string          `json:"name,omitempty"`
+	Alias      string          `json:"alias,omitempty"`
+	Version    *semver.Version `json:"version,omitempty"`
+	Constraint string          `json:"constraint,omitempty"`
 }
 
 func NewResolvedVersionConstraint(name, alias string, version *semver.Version, constraintString string) *ResolvedVersionConstraint {

--- a/tests/acceptance/test_files/002.service.bats
+++ b/tests/acceptance/test_files/002.service.bats
@@ -74,15 +74,15 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run steampipe service start
 
     # set the `lastChecked` date in the update-check.json file to a past date
-    echo $(cat $STEAMPIPE_INSTALL_DIR/internal/update-check.json | jq '.lastChecked="2021-04-10T17:53:40+05:30"') > $STEAMPIPE_INSTALL_DIR/internal/update-check.json
+    echo $(cat $STEAMPIPE_INSTALL_DIR/internal/update_check.json | jq '.lastChecked="2021-04-10T17:53:40+05:30"') > $STEAMPIPE_INSTALL_DIR/internal/update_check.json
 
     # get the content of the current update-check.json file
-    checkFileContent=$(cat $STEAMPIPE_INSTALL_DIR/internal/update-check.json)
+    checkFileContent=$(cat $STEAMPIPE_INSTALL_DIR/internal/update_check.json)
 
     run steampipe service stop
 
     # get the content of the new update-check.json file
-    newCheckFileContent=$(cat $STEAMPIPE_INSTALL_DIR/internal/update-check.json)
+    newCheckFileContent=$(cat $STEAMPIPE_INSTALL_DIR/internal/update_check.json)
 
     assert_equal "$(echo $newCheckFileContent | jq '.lastChecked')" '"2021-04-10T17:53:40+05:30"'
 }

--- a/tests/acceptance/test_files/002.service.bats
+++ b/tests/acceptance/test_files/002.service.bats
@@ -40,16 +40,16 @@ load "$LIB_BATS_SUPPORT/load.bash"
   
   # Start the service
   run steampipe service start --install-dir $target_install_directory
+  echo $output
+  # Check if database name in the output is the same
+  assert_output --partial 'custom_db_name'
   
   # Extract password from the state file
-  db_name=$(cat $target_install_directory/internal/steampipe.json | jq .Database)
+  db_name=$(cat $target_install_directory/internal/steampipe.json | jq .database)
   echo $db_name
-  echo $output
   
   # Both should be equal
   assert_equal "$db_name" "\"custom_db_name\""
-  # Check if database name in the output is the same
-  assert_output --partial 'Database:           custom_db_name'
   
   run steampipe service stop --install-dir $target_install_directory
   
@@ -74,7 +74,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run steampipe service start
 
     # set the `lastChecked` date in the update-check.json file to a past date
-    echo $(cat $STEAMPIPE_INSTALL_DIR/internal/update_check.json | jq '.lastChecked="2021-04-10T17:53:40+05:30"') > $STEAMPIPE_INSTALL_DIR/internal/update_check.json
+    echo $(cat $STEAMPIPE_INSTALL_DIR/internal/update_check.json | jq '.last_checked="2021-04-10T17:53:40+05:30"') > $STEAMPIPE_INSTALL_DIR/internal/update_check.json
 
     # get the content of the current update-check.json file
     checkFileContent=$(cat $STEAMPIPE_INSTALL_DIR/internal/update_check.json)
@@ -84,7 +84,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
     # get the content of the new update-check.json file
     newCheckFileContent=$(cat $STEAMPIPE_INSTALL_DIR/internal/update_check.json)
 
-    assert_equal "$(echo $newCheckFileContent | jq '.lastChecked')" '"2021-04-10T17:53:40+05:30"'
+    assert_equal "$(echo $newCheckFileContent | jq '.last_checked')" '"2021-04-10T17:53:40+05:30"'
 }
 
 @test "start service, install plugin and query" {

--- a/tests/acceptance/test_files/003.service-password.bats
+++ b/tests/acceptance/test_files/003.service-password.bats
@@ -6,7 +6,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
   run steampipe service start
 
   # Extract password from the state file
-  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .Password)
+  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .password)
   echo $state_file_pass
 
   # Extract password stored in .passwd file
@@ -25,7 +25,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
   run steampipe service start --database-password "abcd-efgh-ijkl"
 
   # Extract password from the state file
-  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .Password)
+  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .password)
   echo $state_file_pass
 
   # Both should be equal
@@ -42,7 +42,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
   run steampipe service start
 
   # Extract password from the state file
-  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .Password)
+  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .password)
   echo $state_file_pass
 
   # Both should be equal
@@ -59,7 +59,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
   run steampipe service start --database-password "abcd-efgh-ijkl"
 
   # Extract password from the state file
-  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .Password)
+  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .password)
   echo $state_file_pass
 
   # Both should be equal
@@ -76,7 +76,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
   run steampipe service start
 
   # Extract password from the state file
-  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .Password)
+  state_file_pass=$(cat $STEAMPIPE_INSTALL_DIR/internal/steampipe.json | jq .password)
   echo $state_file_pass
 
   # Extract password stored in new .passwd file

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -329,21 +329,3 @@ func (w *Workspace) verifyResourceRuntimeDependencies() error {
 	}
 	return nil
 }
-
-// migrate all data files to use snake casing for property names
-// func migrateLegacyFiles() error {
-
-// skip migration for plugin manager commands because the plugin-manager will have
-// been started by some other steampipe command, which would have done the migration already
-// if viper.Get(constants.ConfigKeyActiveCommand).(*cobra.Command).Name() == "plugin-manager" {
-// 	return nil
-// }
-// return utils.CombineErrors(
-// 	migrate.Migrate(statefile.LegacyState{}, &statefile.State{}, filepaths.LegacyStateFilePath()),
-// 	migrate.Migrate(pluginmanager.LegacyPluginManagerState{}, &pluginmanager.PluginManagerState{}, filepaths.PluginManagerStateFilePath()),
-// 	migrate.Migrate(db_local.LegacyRunningDBInstanceInfo{}, &db_local.RunningDBInstanceInfo{}, filepaths.RunningInfoFilePath()),
-// 	migrate.Migrate(dashboardserver.LegacyDashboardServiceState{}, &dashboardserver.DashboardServiceState{}, filepaths.DashboardServiceStateFilePath()),
-// 	migrate.Migrate(versionfile.LegacyPluginVersionFile{}, &versionfile.PluginVersionFile{}, filepaths.PluginVersionFilePath()),
-// 	migrate.Migrate(versionfile.LegacyDatabaseVersionFile{}, &versionfile.DatabaseVersionFile{}, filepaths.DatabaseVersionFilePath()),
-// )
-// }

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -58,10 +58,6 @@ func Load(ctx context.Context, workspacePath string) (*Workspace, error) {
 		Path: workspacePath,
 	}
 
-	// migrate legacy workspace lock files in the directory to use snake casing(migrated in v0.14.0)
-	err := migrate.Migrate(versionmap.DependencyVersionMap{}, &versionmap.WorkspaceLock{}, filepaths.WorkspaceLockPath(workspacePath))
-	utils.FailOnErrorWithMessage(err, "failed to migrate legacy workspace lock files")
-
 	// check whether the workspace contains a modfile
 	// this will determine whether we load files recursively, and create pseudo resources for sql files
 	workspace.setModfileExists()
@@ -75,6 +71,10 @@ func Load(ctx context.Context, workspacePath string) (*Workspace, error) {
 	if err := workspace.loadWorkspaceMod(ctx); err != nil {
 		return nil, err
 	}
+
+	// migrate legacy workspace lock files in the directory to use snake casing(migrated in v0.14.0)
+	err := migrate.Migrate(versionmap.DependencyVersionMap{}, &versionmap.WorkspaceLock{}, filepaths.WorkspaceLockPath(workspacePath))
+	utils.FailOnErrorWithMessage(err, "failed to migrate legacy workspace lock files")
 
 	// return context error so calling code can handle cancellations
 	return workspace, nil

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -72,7 +72,7 @@ func Load(ctx context.Context, workspacePath string) (*Workspace, error) {
 		return nil, err
 	}
 
-	// migrate legacy workspace lock files in the directory to use snake casing(migrated in v0.14.0)
+	// migrate legacy workspace lock files in the directory to use snake casing (migrated in v0.14.0)
 	err := migrate.Migrate(versionmap.DependencyVersionMap{}, &versionmap.WorkspaceLock{}, filepaths.WorkspaceLockPath(workspacePath))
 	utils.FailOnErrorWithMessage(err, "failed to migrate legacy workspace lock files")
 


### PR DESCRIPTION
Rebased with https://github.com/turbot/steampipe/pull/1790 to use go 1.18 generics.
Merge https://github.com/turbot/steampipe/pull/1790  before merging this.