### PR TITLE
When a benchmark is added to a dashboard using base, ensure width is inherited. Closes #1964

### DIFF
--- a/steampipeconfig/modconfig/control.go
+++ b/steampipeconfig/modconfig/control.go
@@ -417,6 +417,9 @@ func (c *Control) setBaseProperties(resourceMapProvider ModResourcesProvider) {
 	if c.Params == nil {
 		c.Params = c.Base.Params
 	}
+	if c.Width == nil {
+		c.Width = c.Base.Width
+	}
 	if c.Type == nil {
 		c.Type = c.Base.Type
 	}


### PR DESCRIPTION
…