### PR TITLE
Improve help messages when a plugin is installed but the connection is not configured. Closes #2319

### DIFF
--- a/pkg/display/plugin_install.go
+++ b/pkg/display/plugin_install.go
@@ -146,13 +146,11 @@ func PrintInstallReports(reports PluginInstallReports, isUpdateReport bool) {
 			}
 			fmt.Println()
 			fmt.Printf(
-				"To update %s which %s already installed, please run %s\n",
-				utils.Pluralize("plugin", len(canBeUpdated)),
-				utils.Pluralize("is", len(canBeUpdated)),
-				constants.Bold(fmt.Sprintf(
-					"steampipe plugin update %s",
-					strings.Join(pluginList, " "),
-				)),
+				"To update %s %s: %s\nTo update all plugins: %s",
+				utils.Pluralize("this", len(pluginList)),
+				utils.Pluralize("plugin", len(pluginList)),
+				constants.Bold(fmt.Sprintf("steampipe plugin update %s", strings.Join(pluginList, " "))),
+				constants.Bold(fmt.Sprintln("steampipe plugin update --all")),
 			)
 		}
 	}

--- a/pkg/query/metaquery/handlers.go
+++ b/pkg/query/metaquery/handlers.go
@@ -291,7 +291,7 @@ func inspect(ctx context.Context, input *HandlerInput) error {
 					return inspectTable(schema, tableOrConnection, input)
 				}
 			}
-			return fmt.Errorf("Could not find connection or table called %s", tableOrConnection)
+			return fmt.Errorf("Could not find connection or table called %s. Is the plugin installed? Is the connection configured?", tableOrConnection)
 		}
 
 		fmt.Printf(`


### PR DESCRIPTION
`To update plugin which is already installed, please run steampipe plugin update was` was changed to:

![Screenshot 2022-08-16 at 5 29 46 PM](https://user-images.githubusercontent.com/45908484/184874590-c4d583da-4065-40ed-965d-439ab320b42d.png)
![Screenshot 2022-08-16 at 5 30 39 PM](https://user-images.githubusercontent.com/45908484/184874612-d6f1cf65-e54a-42f0-8ab2-7c9ad731dc47.png)

`Error: Could not find connection or table called aws` was changed to:

![Screenshot 2022-08-16 at 5 33 21 PM](https://user-images.githubusercontent.com/45908484/184875018-c3b96a83-6caf-478b-8836-982868cb80ac.png)

