### PR TITLE
Use ellipsis char instead of 3 dots in plugin update when cutting off the plugin name. Closes #2355

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/gosuri/uiprogress"
-	"github.com/gosuri/uiprogress/util/strutil"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/turbot/go-kit/helpers"
@@ -254,7 +253,7 @@ func doPluginInstall(ctx context.Context, bar *uiprogress.Bar, pluginName string
 		bar.Set(len(pluginInstallSteps))
 		// let the bar append itself with "Already Installed"
 		bar.AppendFunc(func(b *uiprogress.Bar) string {
-			return strutil.Resize(constants.PluginAlreadyInstalled, 20)
+			return helpers.TruncateString(constants.PluginAlreadyInstalled, 20)
 		})
 		report = &display.PluginInstallReport{
 			Plugin:         pluginName,
@@ -266,13 +265,13 @@ func doPluginInstall(ctx context.Context, bar *uiprogress.Bar, pluginName string
 		// let the bar append itself with the current installation step
 		bar.AppendFunc(func(b *uiprogress.Bar) string {
 			if report != nil && report.SkipReason == constants.PluginNotFound {
-				return strutil.Resize(constants.PluginNotFound, 20)
+				return helpers.TruncateString(constants.PluginNotFound, 20)
 			} else {
 				if b.Current() == 0 {
 					// no install step to display yet
 					return ""
 				}
-				return strutil.Resize(pluginInstallSteps[b.Current()-1], 20)
+				return helpers.TruncateString(pluginInstallSteps[b.Current()-1], 20)
 			}
 		})
 		report = installPlugin(ctx, pluginName, false, bar)
@@ -420,7 +419,7 @@ func doPluginUpdate(ctx context.Context, bar *uiprogress.Bar, pvr plugin.Version
 	if skip, skipReason := plugin.SkipUpdate(pvr); skip {
 		bar.AppendFunc(func(b *uiprogress.Bar) string {
 			// set the progress bar to append itself with "Already Installed"
-			return strutil.Resize(skipReason, 30)
+			return helpers.TruncateString(skipReason, 30)
 		})
 		// set the progress bar to the maximum
 		bar.Set(len(pluginInstallSteps))
@@ -437,7 +436,7 @@ func doPluginUpdate(ctx context.Context, bar *uiprogress.Bar, pvr plugin.Version
 				// no install step to display yet
 				return ""
 			}
-			return strutil.Resize(pluginInstallSteps[b.Current()-1], 20)
+			return helpers.TruncateString(pluginInstallSteps[b.Current()-1], 20)
 		})
 		report = installPlugin(ctx, pvr.Plugin.Name, true, bar)
 	}
@@ -448,7 +447,7 @@ func doPluginUpdate(ctx context.Context, bar *uiprogress.Bar, pvr plugin.Version
 func createProgressBar(plugin string, parentProgressBars *uiprogress.Progress) *uiprogress.Bar {
 	bar := parentProgressBars.AddBar(len(pluginInstallSteps))
 	bar.PrependFunc(func(b *uiprogress.Bar) string {
-		return strutil.Resize(plugin, 20)
+		return helpers.TruncateString(plugin, 20)
 	})
 	return bar
 }


### PR DESCRIPTION
<img width="867" alt="Screenshot 2022-09-01 at 8 44 22 PM" src="https://user-images.githubusercontent.com/45908484/187950640-e7f09647-7bc1-4d12-bbe8-948564b5154e.png">
