### PR TITLE
Fix the alignment of plugin update/install outputs. Closes #2417

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -253,7 +253,7 @@ func doPluginInstall(ctx context.Context, bar *uiprogress.Bar, pluginName string
 		bar.Set(len(pluginInstallSteps))
 		// let the bar append itself with "Already Installed"
 		bar.AppendFunc(func(b *uiprogress.Bar) string {
-			return helpers.TruncateString(constants.PluginAlreadyInstalled, 20)
+			return utils.Resize(constants.PluginAlreadyInstalled, 20)
 		})
 		report = &display.PluginInstallReport{
 			Plugin:         pluginName,
@@ -265,13 +265,13 @@ func doPluginInstall(ctx context.Context, bar *uiprogress.Bar, pluginName string
 		// let the bar append itself with the current installation step
 		bar.AppendFunc(func(b *uiprogress.Bar) string {
 			if report != nil && report.SkipReason == constants.PluginNotFound {
-				return helpers.TruncateString(constants.PluginNotFound, 20)
+				return utils.Resize(constants.PluginNotFound, 20)
 			} else {
 				if b.Current() == 0 {
 					// no install step to display yet
 					return ""
 				}
-				return helpers.TruncateString(pluginInstallSteps[b.Current()-1], 20)
+				return utils.Resize(pluginInstallSteps[b.Current()-1], 20)
 			}
 		})
 		report = installPlugin(ctx, pluginName, false, bar)
@@ -419,7 +419,7 @@ func doPluginUpdate(ctx context.Context, bar *uiprogress.Bar, pvr plugin.Version
 	if skip, skipReason := plugin.SkipUpdate(pvr); skip {
 		bar.AppendFunc(func(b *uiprogress.Bar) string {
 			// set the progress bar to append itself with "Already Installed"
-			return helpers.TruncateString(skipReason, 30)
+			return utils.Resize(skipReason, 30)
 		})
 		// set the progress bar to the maximum
 		bar.Set(len(pluginInstallSteps))
@@ -436,7 +436,7 @@ func doPluginUpdate(ctx context.Context, bar *uiprogress.Bar, pvr plugin.Version
 				// no install step to display yet
 				return ""
 			}
-			return helpers.TruncateString(pluginInstallSteps[b.Current()-1], 20)
+			return utils.Resize(pluginInstallSteps[b.Current()-1], 20)
 		})
 		report = installPlugin(ctx, pvr.Plugin.Name, true, bar)
 	}
@@ -447,7 +447,7 @@ func doPluginUpdate(ctx context.Context, bar *uiprogress.Bar, pvr plugin.Version
 func createProgressBar(plugin string, parentProgressBars *uiprogress.Progress) *uiprogress.Bar {
 	bar := parentProgressBars.AddBar(len(pluginInstallSteps))
 	bar.PrependFunc(func(b *uiprogress.Bar) string {
-		return helpers.TruncateString(plugin, 20)
+		return utils.Resize(plugin, 20)
 	})
 	return bar
 }

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"encoding/csv"
 	"strings"
 )
@@ -18,4 +19,37 @@ func SplitByRune(str string, r rune) []string {
 // SplitByWhitespace splits by the ' ' rune
 func SplitByWhitespace(str string) []string {
 	return SplitByRune(str, ' ')
+}
+
+// Resize resizes the string with the given length. It ellipses with '…' when the string's length exceeds
+// the desired length or pads spaces to the right of the string when length is smaller than desired
+func Resize(s string, length uint) string {
+	n := int(length)
+	if len(s) == n {
+		return s
+	}
+	// Pads only when length of the string smaller than len needed
+	s = PadRight(s, n, ' ')
+	if len(s) > n {
+		b := []byte(s)
+		var buf bytes.Buffer
+		for i := 0; i < n-3; i++ {
+			buf.WriteByte(b[i])
+		}
+		buf.WriteString("…  ")
+		s = buf.String()
+	}
+	return s
+}
+
+// PadRight returns a new string of a specified length in which the end of the current string is padded with spaces or with a specified Unicode character.
+func PadRight(str string, length int, pad byte) string {
+	if len(str) >= length {
+		return str
+	}
+	buf := bytes.NewBufferString(str)
+	for i := 0; i < length-len(str); i++ {
+		buf.WriteByte(pad)
+	}
+	return buf.String()
 }

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -33,10 +33,10 @@ func Resize(s string, length uint) string {
 	if len(s) > n {
 		b := []byte(s)
 		var buf bytes.Buffer
-		for i := 0; i < n-3; i++ {
+		for i := 0; i < n-1; i++ {
 			buf.WriteByte(b[i])
 		}
-		buf.WriteString("…  ")
+		buf.WriteString("…")
 		s = buf.String()
 	}
 	return s


### PR DESCRIPTION
```
➜  steampipe git:(main) ✗ steampipe plugin update --all

turbot/aws           [====================================================================] Latest already installed      
turbot/azure         [====================================================================] Latest already installed      
turbot/chaos         [====================================================================] Latest already installed      
turbot/crtsh         [====================================================================] Latest already installed      
turbot/gcp           [====================================================================] Latest already installed      
turbot/hackernews    [====================================================================] Latest already installed      
turbot/net           [====================================================================] Latest already installed      
turbot/steampipeclo… [====================================================================] Latest already installed 
```