### PR TITLE
Fix routing error occurring in Storybook

### DIFF
--- a/ui/dashboard/src/utils/storybook.tsx
+++ b/ui/dashboard/src/utils/storybook.tsx
@@ -4,6 +4,7 @@ import { buildComponentsMap } from "../components";
 import { DashboardContext, DashboardSearch } from "../hooks/useDashboard";
 import { noop } from "./func";
 import { useStorybookTheme } from "../hooks/useStorybookTheme";
+import { BrowserRouter } from "react-router-dom";
 
 type PanelStoryDecoratorProps = {
   definition: any;
@@ -118,7 +119,9 @@ export const PanelStoryDecorator = ({
         progress: 100,
       }}
     >
-      <Dashboard />
+      <BrowserRouter>
+        <Dashboard />
+      </BrowserRouter>
     </DashboardContext.Provider>
   );
 };


### PR DESCRIPTION
Fixes #2458 

**Problem:**

In the Storybook configuration an error was occurring that blocked developers from navigating to different components. The error was occurring because the useNavigate hook is used somewhere in the component tree, and this hook is only allowed to be used inside of a Router component.

**Solution:**

Inside of the `PanelStoryDecorator` component, I wrapped `Dashboard` with the `BrowserRouter` component from react-router.