### PR TITLE
Fix: typo about `output`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ steampipe check control.dns_ns_name_valid
 ```
  
 Available <a href="https://steampipe.io/docs/reference/cli/check?utm_id=gspreadme&utm_source=github&utm_medium=repo&utm_campaign=github&utm_content=readme#output-formats">formats</a> include JSON, CSV, HTML, and ASFF. 
-You can use <a href="https://steampipe.io/docs/develop/writing-control-output-templates?utm_id=gspreadme&utm_source=github&utm_medium=repo&utm_campaign=github&utm_content=readme">custom ouput templates</a> to create new output formats.
+You can use <a href="https://steampipe.io/docs/develop/writing-control-output-templates?utm_id=gspreadme&utm_source=github&utm_medium=repo&utm_campaign=github&utm_content=readme">custom output templates</a> to create new output formats.
 </details>
 
 <details>

--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func checkWsl1(ctx context.Context) {
 		error_helpers.ShowErrorWithMessage(ctx, err, "failed to check uname")
 		return
 	}
-	// convert the ouptut to a string of lowercase characters for ease of use
+	// convert the output to a string of lowercase characters for ease of use
 	op := strings.ToLower(string(output))
 
 	// if WSL2, return


### PR DESCRIPTION
## Description

Hello, everyone in the community. :)
I found some typo about `output` keyword in `README.md` and code comment.
And I fixed it.