### PR TITLE
Update deprecated set-output and use GITHUB_OUTPUT environment files in our workflows. Closes #2572

### DIFF
--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Clean Version for Tag
         id: generate_docker_tag
         run: |
-          echo "::set-output name=docker_tag::${STEAMPIPE_VERSION#"v"}"
+          echo "docker_tag=${STEAMPIPE_VERSION#"v"}" >> $GITHUB_OUTPUT
           
       - name: Build and Push to Docker Hub
         id: docker_build
@@ -57,9 +57,9 @@ jobs:
       - name: Get pull request title
         id: pr_title
         run: >-
-          echo "::set-output name=PR_TITLE::$(
+          echo "PR_TITLE=$(
             gh pr view $STEAMPIPE_VERSION --json title | jq .title | tr -d '"'
-          )"
+          )" >> $GITHUB_OUTPUT
 
       - name: Output
         run: |

--- a/.github/workflows/release_cli_and_assets.yml
+++ b/.github/workflows/release_cli_and_assets.yml
@@ -214,7 +214,7 @@ jobs:
         cat annotations.json
         cat dashboard_ui_build/versions.json
         REF="${{ env.CORE_REPO }}/${{ env.ASSET_IMAGE_NAME }}:$GITHUB_RUN_ID"
-        echo "::set-output name=REF::$REF"
+        echo "REF=$REF" >> $GITHUB_OUTPUT
 
     - name: Push to registry
       run: |-

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Fetching Go Cache Paths
         id: go-cache-paths
         run: |
-          echo "::set-output name=go-build::$(go env GOCACHE)"
-          echo "::set-output name=go-mod::$(go env GOMODCACHE)"
+          echo "go-build=$(go env GOCACHE)" >> $GITHUB_OUTPUT
+          echo "go-mod=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
 
       # used to speedup go test
       - name: Go Build Cache

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -64,4 +64,4 @@ else
 fi
 
 # Setting the exit_code, to use in the github workflow(This only gets set to 0 when the above bats test suite passes)
-echo "::set-output name=exit_code::$(echo $?)"
+echo "exit_code=$(echo $?)" >> $GITHUB_OUTPUT


### PR DESCRIPTION
… in the workflows