### PR TITLE
Consolidates setting of CLI flag shorthand

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -55,33 +55,33 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag(constants.ArgHeader, "", true, "Include column headers for csv and table output").
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for check").
-		AddStringFlag(constants.ArgSeparator, "", ",", "Separator string for csv output").
-		AddStringFlag(constants.ArgOutput, "", constants.OutputFormatText, "Output format: brief, csv, html, json, md, text, snapshot or none").
-		AddBoolFlag(constants.ArgTiming, "", false, "Turn on the timer which reports check time").
-		AddStringSliceFlag(constants.ArgSearchPath, "", nil, "Set a custom search_path for the steampipe user for a check session (comma-separated)").
-		AddStringSliceFlag(constants.ArgSearchPathPrefix, "", nil, "Set a prefix to the current search path for a check session (comma-separated)").
-		AddStringFlag(constants.ArgTheme, "", "dark", "Set the output theme for 'text' output: light, dark or plain").
-		AddStringSliceFlag(constants.ArgExport, "", nil, "Export output to file, supported formats: csv, html, json, md, nunit3, sps (snapshot), asff").
-		AddBoolFlag(constants.ArgProgress, "", true, "Display control execution progress").
-		AddBoolFlag(constants.ArgDryRun, "", false, "Show which controls will be run without running them").
-		AddStringSliceFlag(constants.ArgTag, "", nil, "Filter controls based on their tag values ('--tag key=value')").
-		AddStringSliceFlag(constants.ArgVarFile, "", nil, "Specify an .spvar file containing variable values").
+		AddBoolFlag(constants.ArgHeader, true, "Include column headers for csv and table output").
+		AddBoolFlag(constants.ArgHelp, false, "Help for check", cmdconfig.FlagOptions.WithShortHand("h")).
+		AddStringFlag(constants.ArgSeparator, ",", "Separator string for csv output").
+		AddStringFlag(constants.ArgOutput, constants.OutputFormatText, "Output format: brief, csv, html, json, md, text, snapshot or none").
+		AddBoolFlag(constants.ArgTiming, false, "Turn on the timer which reports check time").
+		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a check session (comma-separated)").
+		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a check session (comma-separated)").
+		AddStringFlag(constants.ArgTheme, "dark", "Set the output theme for 'text' output: light, dark or plain").
+		AddStringSliceFlag(constants.ArgExport, nil, "Export output to file, supported formats: csv, html, json, md, nunit3, sps (snapshot), asff").
+		AddBoolFlag(constants.ArgProgress, true, "Display control execution progress").
+		AddBoolFlag(constants.ArgDryRun, false, "Show which controls will be run without running them").
+		AddStringSliceFlag(constants.ArgTag, nil, "Filter controls based on their tag values ('--tag key=value')").
+		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag
 		// Cobra will interpret values passed to a StringSliceFlag as CSV,
 		// where args passed to StringArrayFlag are not parsed and used raw
-		AddStringArrayFlag(constants.ArgVariable, "", nil, "Specify the value of a variable").
-		AddStringFlag(constants.ArgWhere, "", "", "SQL 'where' clause, or named query, used to filter controls (cannot be used with '--tag')").
-		AddIntFlag(constants.ArgDatabaseQueryTimeout, "", constants.DatabaseDefaultCheckQueryTimeout, "The query timeout").
-		AddIntFlag(constants.ArgMaxParallel, "", constants.DefaultMaxConnections, "The maximum number of parallel executions", cmdconfig.FlagOptions.Hidden()).
-		AddBoolFlag(constants.ArgModInstall, "", true, "Specify whether to install mod dependencies before running the check").
-		AddBoolFlag(constants.ArgInput, "", true, "Enable interactive prompts").
-		AddBoolFlag(constants.ArgSnapshot, "", false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").
-		AddBoolFlag(constants.ArgShare, "", false, "Create snapshot in Steampipe Cloud with 'anyone_with_link' visibility").
-		AddStringArrayFlag(constants.ArgSnapshotTag, "", nil, "Specify tags to set on the snapshot").
-		AddStringFlag(constants.ArgSnapshotLocation, "", "", "The location to write snapshots - either a local file path or a Steampipe Cloud workspace").
-		AddStringFlag(constants.ArgSnapshotTitle, "", "", "The title to give a snapshot")
+		AddStringArrayFlag(constants.ArgVariable, nil, "Specify the value of a variable").
+		AddStringFlag(constants.ArgWhere, "", "SQL 'where' clause, or named query, used to filter controls (cannot be used with '--tag')").
+		AddIntFlag(constants.ArgDatabaseQueryTimeout, constants.DatabaseDefaultCheckQueryTimeout, "The query timeout").
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions", cmdconfig.FlagOptions.Hidden()).
+		AddBoolFlag(constants.ArgModInstall, true, "Specify whether to install mod dependencies before running the check").
+		AddBoolFlag(constants.ArgInput, true, "Enable interactive prompts").
+		AddBoolFlag(constants.ArgSnapshot, false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").
+		AddBoolFlag(constants.ArgShare, false, "Create snapshot in Steampipe Cloud with 'anyone_with_link' visibility").
+		AddStringArrayFlag(constants.ArgSnapshotTag, nil, "Specify tags to set on the snapshot").
+		AddStringFlag(constants.ArgSnapshotLocation, "", "The location to write snapshots - either a local file path or a Steampipe Cloud workspace").
+		AddStringFlag(constants.ArgSnapshotTitle, "", "The title to give a snapshot")
 
 	cmd.AddCommand(getListSubCmd(listSubCmdOptions{parentCmd: cmd}))
 	return cmd

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -24,7 +24,7 @@ func generateCompletionScriptsCmd() *cobra.Command {
 
 	cmd.SetHelpFunc(completionHelp)
 
-	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, "h", false, "Help for completion")
+	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, false, "Help for completion", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -43,31 +43,31 @@ The current mod is the working directory, or the directory specified by the --mo
 	}
 
 	cmdconfig.OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for dashboard").
-		AddBoolFlag(constants.ArgModInstall, "", true, "Specify whether to install mod dependencies before running the dashboard").
-		AddStringFlag(constants.ArgDashboardListen, "", string(dashboardserver.ListenTypeLocal), "Accept connections from: local (localhost only) or network (open)").
-		AddIntFlag(constants.ArgDashboardPort, "", constants.DashboardServerDefaultPort, "Dashboard server port").
-		AddBoolFlag(constants.ArgBrowser, "", true, "Specify whether to launch the browser after starting the dashboard server").
-		AddStringSliceFlag(constants.ArgSearchPath, "", nil, "Set a custom search_path for the steampipe user for a dashboard session (comma-separated)").
-		AddStringSliceFlag(constants.ArgSearchPathPrefix, "", nil, "Set a prefix to the current search path for a dashboard session (comma-separated)").
-		AddStringSliceFlag(constants.ArgVarFile, "", nil, "Specify an .spvar file containing variable values").
-		AddBoolFlag(constants.ArgProgress, "", true, "Display dashboard execution progress respected when a dashboard name argument is passed").
+		AddBoolFlag(constants.ArgHelp, false, "Help for dashboard", cmdconfig.FlagOptions.WithShortHand("h")).
+		AddBoolFlag(constants.ArgModInstall, true, "Specify whether to install mod dependencies before running the dashboard").
+		AddStringFlag(constants.ArgDashboardListen, string(dashboardserver.ListenTypeLocal), "Accept connections from: local (localhost only) or network (open)").
+		AddIntFlag(constants.ArgDashboardPort, constants.DashboardServerDefaultPort, "Dashboard server port").
+		AddBoolFlag(constants.ArgBrowser, true, "Specify whether to launch the browser after starting the dashboard server").
+		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a dashboard session (comma-separated)").
+		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a dashboard session (comma-separated)").
+		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values").
+		AddBoolFlag(constants.ArgProgress, true, "Display dashboard execution progress respected when a dashboard name argument is passed").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag
 		// Cobra will interpret values passed to a StringSliceFlag as CSV, where args passed to StringArrayFlag are not parsed and used raw
-		AddStringArrayFlag(constants.ArgVariable, "", nil, "Specify the value of a variable").
-		AddBoolFlag(constants.ArgInput, "", true, "Enable interactive prompts").
-		AddStringFlag(constants.ArgOutput, "", constants.OutputFormatNone, "Select a console output format: none, snapshot").
-		AddBoolFlag(constants.ArgSnapshot, "", false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").
-		AddBoolFlag(constants.ArgShare, "", false, "Create snapshot in Steampipe Cloud with 'anyone_with_link' visibility").
-		AddStringFlag(constants.ArgSnapshotLocation, "", "", "The location to write snapshots - either a local file path or a Steampipe Cloud workspace").
-		AddStringFlag(constants.ArgSnapshotTitle, "", "", "The title to give a snapshot").
+		AddStringArrayFlag(constants.ArgVariable, nil, "Specify the value of a variable").
+		AddBoolFlag(constants.ArgInput, true, "Enable interactive prompts").
+		AddStringFlag(constants.ArgOutput, constants.OutputFormatNone, "Select a console output format: none, snapshot").
+		AddBoolFlag(constants.ArgSnapshot, false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").
+		AddBoolFlag(constants.ArgShare, false, "Create snapshot in Steampipe Cloud with 'anyone_with_link' visibility").
+		AddStringFlag(constants.ArgSnapshotLocation, "", "The location to write snapshots - either a local file path or a Steampipe Cloud workspace").
+		AddStringFlag(constants.ArgSnapshotTitle, "", "The title to give a snapshot").
 		// NOTE: use StringArrayFlag for ArgDashboardInput, not StringSliceFlag
 		// Cobra will interpret values passed to a StringSliceFlag as CSV, where args passed to StringArrayFlag are not parsed and used raw
-		AddStringArrayFlag(constants.ArgDashboardInput, "", nil, "Specify the value of a dashboard input").
-		AddStringArrayFlag(constants.ArgSnapshotTag, "", nil, "Specify tags to set on the snapshot").
-		AddStringSliceFlag(constants.ArgExport, "", nil, "Export output to file, supported format: sps (snapshot)").
+		AddStringArrayFlag(constants.ArgDashboardInput, nil, "Specify the value of a dashboard input").
+		AddStringArrayFlag(constants.ArgSnapshotTag, nil, "Specify tags to set on the snapshot").
+		AddStringSliceFlag(constants.ArgExport, nil, "Export output to file, supported format: sps (snapshot)").
 		// hidden flags that are used internally
-		AddBoolFlag(constants.ArgServiceMode, "", false, "Hidden flag to specify whether this is starting as a service", cmdconfig.FlagOptions.Hidden())
+		AddBoolFlag(constants.ArgServiceMode, false, "Hidden flag to specify whether this is starting as a service", cmdconfig.FlagOptions.Hidden())
 
 	cmd.AddCommand(getListSubCmd(listSubCmdOptions{parentCmd: cmd}))
 

--- a/cmd/login.go
+++ b/cmd/login.go
@@ -4,14 +4,15 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/turbot/steampipe/pkg/cloud"
 	"github.com/turbot/steampipe/pkg/cmdconfig"
 	"github.com/turbot/steampipe/pkg/constants"
 	"github.com/turbot/steampipe/pkg/error_helpers"
-	"log"
-	"os"
 )
 
 func loginCmd() *cobra.Command {
@@ -24,7 +25,7 @@ func loginCmd() *cobra.Command {
 		Long:             `Login to Steampipe Cloud.`,
 	}
 
-	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, "h", false, "Help for dashboard")
+	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, false, "Help for dashboard", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }

--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -68,9 +68,9 @@ func modInstallCmd() *cobra.Command {
 	}
 
 	cmdconfig.OnCmd(cmd).
-		AddBoolFlag(constants.ArgPrune, "", true, "Remove unused dependencies after installation is complete").
-		AddBoolFlag(constants.ArgDryRun, "", false, "Show which mods would be installed/updated/uninstalled without modifying them").
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for install")
+		AddBoolFlag(constants.ArgPrune, true, "Remove unused dependencies after installation is complete").
+		AddBoolFlag(constants.ArgDryRun, false, "Show which mods would be installed/updated/uninstalled without modifying them").
+		AddBoolFlag(constants.ArgHelp, false, "Help for install", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }
@@ -104,9 +104,9 @@ func modUninstallCmd() *cobra.Command {
 	}
 
 	cmdconfig.OnCmd(cmd).
-		AddBoolFlag(constants.ArgPrune, "", true, "Remove unused dependencies after uninstallation is complete").
-		AddBoolFlag(constants.ArgDryRun, "", false, "Show which mods would be uninstalled without modifying them").
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for uninstall")
+		AddBoolFlag(constants.ArgPrune, true, "Remove unused dependencies after uninstallation is complete").
+		AddBoolFlag(constants.ArgDryRun, false, "Show which mods would be uninstalled without modifying them").
+		AddBoolFlag(constants.ArgHelp, false, "Help for uninstall", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }
@@ -139,9 +139,9 @@ func modUpdateCmd() *cobra.Command {
 	}
 
 	cmdconfig.OnCmd(cmd).
-		AddBoolFlag(constants.ArgPrune, "", true, "Remove unused dependencies after update is complete").
-		AddBoolFlag(constants.ArgDryRun, "", false, "Show which mods would be updated without modifying them").
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for update")
+		AddBoolFlag(constants.ArgPrune, true, "Remove unused dependencies after update is complete").
+		AddBoolFlag(constants.ArgDryRun, false, "Show which mods would be updated without modifying them").
+		AddBoolFlag(constants.ArgHelp, false, "Help for update", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }
@@ -174,7 +174,7 @@ func modListCmd() *cobra.Command {
 		Long:  `List currently installed mods.`,
 	}
 
-	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, "h", false, "Help for list")
+	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, false, "Help for list", cmdconfig.FlagOptions.WithShortHand("h"))
 	return cmd
 }
 
@@ -208,7 +208,7 @@ func modInitCmd() *cobra.Command {
 		Long:  `Initialize the current directory with a mod.sp file.`,
 	}
 
-	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, "h", false, "Help for init")
+	cmdconfig.OnCmd(cmd).AddBoolFlag(constants.ArgHelp, false, "Help for init", cmdconfig.FlagOptions.WithShortHand("h"))
 	return cmd
 }
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -87,7 +87,7 @@ Examples:
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for plugin install")
+		AddBoolFlag(constants.ArgHelp, false, "Help for plugin install", cmdconfig.FlagOptions.WithShortHand("h"))
 	return cmd
 }
 
@@ -116,8 +116,8 @@ Examples:
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag(constants.ArgAll, "", false, "Update all plugins to its latest available version").
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for plugin update")
+		AddBoolFlag(constants.ArgAll, false, "Update all plugins to its latest available version").
+		AddBoolFlag(constants.ArgHelp, false, "Help for plugin update", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }
@@ -144,8 +144,8 @@ Examples:
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag("outdated", "", false, "Check each plugin in the list for updates").
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for plugin list")
+		AddBoolFlag("outdated", false, "Check each plugin in the list for updates").
+		AddBoolFlag(constants.ArgHelp, false, "Help for plugin list", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }
@@ -172,7 +172,7 @@ Example:
 	}
 
 	cmdconfig.OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for plugin uninstall")
+		AddBoolFlag(constants.ArgHelp, false, "Help for plugin uninstall", cmdconfig.FlagOptions.WithShortHand("h"))
 
 	return cmd
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -69,28 +69,28 @@ Examples:
 	// * In the future we may add --csv and --json flags as shortcuts for --output
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for query").
-		AddBoolFlag(constants.ArgHeader, "", true, "Include column headers csv and table output").
-		AddStringFlag(constants.ArgSeparator, "", ",", "Separator string for csv output").
-		AddStringFlag(constants.ArgOutput, "", "table", "Output format: line, csv, json, table or snapshot").
-		AddBoolFlag(constants.ArgTiming, "", false, "Turn on the timer which reports query time").
-		AddBoolFlag(constants.ArgWatch, "", true, "Watch SQL files in the current workspace (works only in interactive mode)").
-		AddStringSliceFlag(constants.ArgSearchPath, "", nil, "Set a custom search_path for the steampipe user for a query session (comma-separated)").
-		AddStringSliceFlag(constants.ArgSearchPathPrefix, "", nil, "Set a prefix to the current search path for a query session (comma-separated)").
-		AddStringSliceFlag(constants.ArgVarFile, "", nil, "Specify a file containing variable values").
+		AddBoolFlag(constants.ArgHelp, false, "Help for query", cmdconfig.FlagOptions.WithShortHand("h")).
+		AddBoolFlag(constants.ArgHeader, true, "Include column headers csv and table output").
+		AddStringFlag(constants.ArgSeparator, ",", "Separator string for csv output").
+		AddStringFlag(constants.ArgOutput, "table", "Output format: line, csv, json, table or snapshot").
+		AddBoolFlag(constants.ArgTiming, false, "Turn on the timer which reports query time").
+		AddBoolFlag(constants.ArgWatch, true, "Watch SQL files in the current workspace (works only in interactive mode)").
+		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a query session (comma-separated)").
+		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a query session (comma-separated)").
+		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify a file containing variable values").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag
 		// Cobra will interpret values passed to a StringSliceFlag as CSV,
 		// where args passed to StringArrayFlag are not parsed and used raw
-		AddStringArrayFlag(constants.ArgVariable, "", nil, "Specify the value of a variable").
-		AddBoolFlag(constants.ArgInput, "", true, "Enable interactive prompts").
-		AddBoolFlag(constants.ArgSnapshot, "", false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").
-		AddBoolFlag(constants.ArgShare, "", false, "Create snapshot in Steampipe Cloud with 'anyone_with_link' visibility").
-		AddStringArrayFlag(constants.ArgSnapshotTag, "", nil, "Specify tags to set on the snapshot").
-		AddStringFlag(constants.ArgSnapshotTitle, "", "", "The title to give a snapshot").
-		AddIntFlag(constants.ArgDatabaseQueryTimeout, "", 0, "The query timeout").
-		AddStringSliceFlag(constants.ArgExport, "", nil, "Export output to file, supported format: sps (snapshot)").
-		AddStringFlag(constants.ArgSnapshotLocation, "", "", "The location to write snapshots - either a local file path or a Steampipe Cloud workspace").
-		AddBoolFlag(constants.ArgProgress, "", true, "Display snapshot upload status")
+		AddStringArrayFlag(constants.ArgVariable, nil, "Specify the value of a variable").
+		AddBoolFlag(constants.ArgInput, true, "Enable interactive prompts").
+		AddBoolFlag(constants.ArgSnapshot, false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").
+		AddBoolFlag(constants.ArgShare, false, "Create snapshot in Steampipe Cloud with 'anyone_with_link' visibility").
+		AddStringArrayFlag(constants.ArgSnapshotTag, nil, "Specify tags to set on the snapshot").
+		AddStringFlag(constants.ArgSnapshotTitle, "", "The title to give a snapshot").
+		AddIntFlag(constants.ArgDatabaseQueryTimeout, 0, "The query timeout").
+		AddStringSliceFlag(constants.ArgExport, nil, "Export output to file, supported format: sps (snapshot)").
+		AddStringFlag(constants.ArgSnapshotLocation, "", "The location to write snapshots - either a local file path or a Steampipe Cloud workspace").
+		AddBoolFlag(constants.ArgProgress, true, "Display snapshot upload status")
 
 	cmd.AddCommand(getListSubCmd(listSubCmdOptions{parentCmd: cmd}))
 

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -58,30 +58,30 @@ connection from any Postgres compatible database client.`,
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for service start").
+		AddBoolFlag(constants.ArgHelp, false, "Help for service start", cmdconfig.FlagOptions.WithShortHand("h")).
 		// for now default port to -1 so we fall back to the default of the deprecated arg
-		AddIntFlag(constants.ArgDatabasePort, "", constants.DatabaseDefaultPort, "Database service port").
+		AddIntFlag(constants.ArgDatabasePort, constants.DatabaseDefaultPort, "Database service port").
 		// for now default listen address to empty so we fall back to the default of the deprecated arg
-		AddStringFlag(constants.ArgListenAddress, "", string(db_local.ListenTypeNetwork), "Accept connections from: local (localhost only) or network (open) (postgres)").
-		AddStringFlag(constants.ArgServicePassword, "", "", "Set the database password for this session").
+		AddStringFlag(constants.ArgListenAddress, string(db_local.ListenTypeNetwork), "Accept connections from: local (localhost only) or network (open) (postgres)").
+		AddStringFlag(constants.ArgServicePassword, "", "Set the database password for this session").
 		// default is false and hides the database user password from service start prompt
-		AddBoolFlag(constants.ArgServiceShowPassword, "", false, "View database password for connecting from another machine").
+		AddBoolFlag(constants.ArgServiceShowPassword, false, "View database password for connecting from another machine").
 		// dashboard server
-		AddBoolFlag(constants.ArgDashboard, "", false, "Run the dashboard webserver with the service").
-		AddStringFlag(constants.ArgDashboardListen, "", string(dashboardserver.ListenTypeNetwork), "Accept connections from: local (localhost only) or network (open) (dashboard)").
-		AddIntFlag(constants.ArgDashboardPort, "", constants.DashboardServerDefaultPort, "Report server port").
+		AddBoolFlag(constants.ArgDashboard, false, "Run the dashboard webserver with the service").
+		AddStringFlag(constants.ArgDashboardListen, string(dashboardserver.ListenTypeNetwork), "Accept connections from: local (localhost only) or network (open) (dashboard)").
+		AddIntFlag(constants.ArgDashboardPort, constants.DashboardServerDefaultPort, "Report server port").
 		// foreground enables the service to run in the foreground - till exit
-		AddBoolFlag(constants.ArgForeground, "", false, "Run the service in the foreground").
+		AddBoolFlag(constants.ArgForeground, false, "Run the service in the foreground").
 
 		// flags relevant only if the --dashboard arg is used:
-		AddStringSliceFlag(constants.ArgVarFile, "", nil, "Specify an .spvar file containing variable values (only applies if '--dashboard' flag is also set)").
+		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values (only applies if '--dashboard' flag is also set)").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag
 		// Cobra will interpret values passed to a StringSliceFlag as CSV,
 		// where args passed to StringArrayFlag are not parsed and used raw
-		AddStringArrayFlag(constants.ArgVariable, "", nil, "Specify the value of a variable (only applies if '--dashboard' flag is also set)").
+		AddStringArrayFlag(constants.ArgVariable, nil, "Specify the value of a variable (only applies if '--dashboard' flag is also set)").
 
 		// hidden flags for internal use
-		AddStringFlag(constants.ArgInvoker, "", string(constants.InvokerService), "Invoked by \"service\" or \"query\"", cmdconfig.FlagOptions.Hidden())
+		AddStringFlag(constants.ArgInvoker, string(constants.InvokerService), "Invoked by \"service\" or \"query\"", cmdconfig.FlagOptions.Hidden())
 
 	return cmd
 }
@@ -99,10 +99,10 @@ Report current status of the Steampipe database service.`,
 	}
 
 	cmdconfig.OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for service status").
+		AddBoolFlag(constants.ArgHelp, false, "Help for service status", cmdconfig.FlagOptions.WithShortHand("h")).
 		// default is false and hides the database user password from service start prompt
-		AddBoolFlag(constants.ArgServiceShowPassword, "", false, "View database password for connecting from another machine").
-		AddBoolFlag(constants.ArgAll, "", false, "Bypasses the INSTALL_DIR and reports status of all running steampipe services")
+		AddBoolFlag(constants.ArgServiceShowPassword, false, "View database password for connecting from another machine").
+		AddBoolFlag(constants.ArgAll, false, "Bypasses the INSTALL_DIR and reports status of all running steampipe services")
 
 	return cmd
 }
@@ -119,8 +119,8 @@ func serviceStopCmd() *cobra.Command {
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for service stop").
-		AddBoolFlag(constants.ArgForce, "", false, "Forces all services to shutdown, releasing all open connections and ports")
+		AddBoolFlag(constants.ArgHelp, false, "Help for service stop", cmdconfig.FlagOptions.WithShortHand("h")).
+		AddBoolFlag(constants.ArgForce, false, "Forces all services to shutdown, releasing all open connections and ports")
 
 	return cmd
 }
@@ -137,8 +137,8 @@ func serviceRestartCmd() *cobra.Command {
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for service restart").
-		AddBoolFlag(constants.ArgForce, "", false, "Forces the service to restart, releasing all open connections and ports")
+		AddBoolFlag(constants.ArgHelp, false, "Help for service restart", cmdconfig.FlagOptions.WithShortHand("h")).
+		AddBoolFlag(constants.ArgForce, false, "Forces the service to restart, releasing all open connections and ports")
 
 	return cmd
 }

--- a/cmd/variable.go
+++ b/cmd/variable.go
@@ -49,9 +49,9 @@ Example:
 
 	cmdconfig.
 		OnCmd(cmd).
-		AddBoolFlag("outdated", "", false, "Check each variable in the list for updates").
-		AddBoolFlag(constants.ArgHelp, "h", false, "Help for variable list").
-		AddStringFlag(constants.ArgOutput, "", constants.OutputFormatTable, "Select a console output format: table or json")
+		AddBoolFlag("outdated", false, "Check each variable in the list for updates").
+		AddBoolFlag(constants.ArgHelp, false, "Help for variable list", cmdconfig.FlagOptions.WithShortHand("h")).
+		AddStringFlag(constants.ArgOutput, constants.OutputFormatTable, "Select a console output format: table or json")
 
 	return cmd
 }

--- a/pkg/cmdconfig/builder.go
+++ b/pkg/cmdconfig/builder.go
@@ -51,8 +51,8 @@ func OnCmd(cmd *cobra.Command) *CmdBuilder {
 }
 
 // AddStringFlag is a helper function to add a string flag to a command
-func (c *CmdBuilder) AddStringFlag(name string, shorthand string, defaultValue string, desc string, opts ...flagOpt) *CmdBuilder {
-	c.cmd.Flags().StringP(name, shorthand, defaultValue, desc)
+func (c *CmdBuilder) AddStringFlag(name string, defaultValue string, desc string, opts ...flagOpt) *CmdBuilder {
+	c.cmd.Flags().String(name, defaultValue, desc)
 	c.bindings[name] = c.cmd.Flags().Lookup(name)
 	for _, o := range opts {
 		o(c.cmd, name, name)
@@ -62,8 +62,8 @@ func (c *CmdBuilder) AddStringFlag(name string, shorthand string, defaultValue s
 }
 
 // AddIntFlag is a helper function to add an integer flag to a command
-func (c *CmdBuilder) AddIntFlag(name, shorthand string, defaultValue int, desc string, opts ...flagOpt) *CmdBuilder {
-	c.cmd.Flags().IntP(name, shorthand, defaultValue, desc)
+func (c *CmdBuilder) AddIntFlag(name string, defaultValue int, desc string, opts ...flagOpt) *CmdBuilder {
+	c.cmd.Flags().Int(name, defaultValue, desc)
 	c.bindings[name] = c.cmd.Flags().Lookup(name)
 	for _, o := range opts {
 		o(c.cmd, name, name)
@@ -72,8 +72,8 @@ func (c *CmdBuilder) AddIntFlag(name, shorthand string, defaultValue int, desc s
 }
 
 // AddBoolFlag ia s helper function to add a boolean flag to a command
-func (c *CmdBuilder) AddBoolFlag(name, shorthand string, defaultValue bool, desc string, opts ...flagOpt) *CmdBuilder {
-	c.cmd.Flags().BoolP(name, shorthand, defaultValue, desc)
+func (c *CmdBuilder) AddBoolFlag(name string, defaultValue bool, desc string, opts ...flagOpt) *CmdBuilder {
+	c.cmd.Flags().Bool(name, defaultValue, desc)
 	c.bindings[name] = c.cmd.Flags().Lookup(name)
 	for _, o := range opts {
 		o(c.cmd, name, name)
@@ -82,8 +82,8 @@ func (c *CmdBuilder) AddBoolFlag(name, shorthand string, defaultValue bool, desc
 }
 
 // AddStringSliceFlag is a helper function to add a flag that accepts an array of strings
-func (c *CmdBuilder) AddStringSliceFlag(name, shorthand string, defaultValue []string, desc string, opts ...flagOpt) *CmdBuilder {
-	c.cmd.Flags().StringSliceP(name, shorthand, defaultValue, desc)
+func (c *CmdBuilder) AddStringSliceFlag(name string, defaultValue []string, desc string, opts ...flagOpt) *CmdBuilder {
+	c.cmd.Flags().StringSlice(name, defaultValue, desc)
 	c.bindings[name] = c.cmd.Flags().Lookup(name)
 	for _, o := range opts {
 		o(c.cmd, name, name)
@@ -92,8 +92,8 @@ func (c *CmdBuilder) AddStringSliceFlag(name, shorthand string, defaultValue []s
 }
 
 // AddStringArrayFlag is a helper function to add a flag that accepts an array of strings
-func (c *CmdBuilder) AddStringArrayFlag(name, shorthand string, defaultValue []string, desc string, opts ...flagOpt) *CmdBuilder {
-	c.cmd.Flags().StringArrayP(name, shorthand, defaultValue, desc)
+func (c *CmdBuilder) AddStringArrayFlag(name string, defaultValue []string, desc string, opts ...flagOpt) *CmdBuilder {
+	c.cmd.Flags().StringArray(name, defaultValue, desc)
 	c.bindings[name] = c.cmd.Flags().Lookup(name)
 	for _, o := range opts {
 		o(c.cmd, name, name)
@@ -102,8 +102,8 @@ func (c *CmdBuilder) AddStringArrayFlag(name, shorthand string, defaultValue []s
 }
 
 // AddStringMapStringFlag is a helper function to add a flag that accepts a map of strings
-func (c *CmdBuilder) AddStringMapStringFlag(name, shorthand string, defaultValue map[string]string, desc string, opts ...flagOpt) *CmdBuilder {
-	c.cmd.Flags().StringToStringP(name, shorthand, defaultValue, desc)
+func (c *CmdBuilder) AddStringMapStringFlag(name string, defaultValue map[string]string, desc string, opts ...flagOpt) *CmdBuilder {
+	c.cmd.Flags().StringToString(name, defaultValue, desc)
 	c.bindings[name] = c.cmd.Flags().Lookup(name)
 	for _, o := range opts {
 		o(c.cmd, name, name)

--- a/pkg/cmdconfig/cmd_flags.go
+++ b/pkg/cmdconfig/cmd_flags.go
@@ -14,15 +14,17 @@ type flagOpt func(c *cobra.Command, name string, key string)
 
 // FlagOptions :: shortcut for common flag options
 var FlagOptions = struct {
-	Required    func() flagOpt
-	Hidden      func() flagOpt
-	Deprecated  func(string) flagOpt
-	NoOptDefVal func(string) flagOpt
+	Required      func() flagOpt
+	Hidden        func() flagOpt
+	Deprecated    func(string) flagOpt
+	NoOptDefVal   func(string) flagOpt
+	WithShortHand func(string) flagOpt
 }{
-	Required:    requiredOpt,
-	Hidden:      hiddenOpt,
-	Deprecated:  deprecatedOpt,
-	NoOptDefVal: noOptDefValOpt,
+	Required:      requiredOpt,
+	Hidden:        hiddenOpt,
+	Deprecated:    deprecatedOpt,
+	NoOptDefVal:   noOptDefValOpt,
+	WithShortHand: withShortHand,
 }
 
 // Helper function to mark a flag as required
@@ -51,5 +53,11 @@ func deprecatedOpt(replacement string) flagOpt {
 func noOptDefValOpt(noOptDefVal string) flagOpt {
 	return func(c *cobra.Command, name, key string) {
 		c.Flag(name).NoOptDefVal = noOptDefVal
+	}
+}
+
+func withShortHand(shorthand string) flagOpt {
+	return func(c *cobra.Command, name, key string) {
+		c.Flag(name).Shorthand = shorthand
 	}
 }


### PR DESCRIPTION
We had the provision to set shorthand for CLI flags through our helpers, but we never used them anyway - and have always left them blank (empty string), except for `--help`

This PR moves the shorthand setting to a `FlagOption` and updates the helper signatures to not have a shorthand setting.

Further on, when configuring a CLI flag, if a short hand is required, the developer will have to use the flag option.

See usage in the `--help` flag setting for any of the current CLI commands.