### PR TITLE
Reverts update of google-github-actions/setup-gcloud from 0.6.2 to 1.0.0

### DIFF
--- a/.github/workflows/buildDBImage.yml
+++ b/.github/workflows/buildDBImage.yml
@@ -126,7 +126,7 @@ jobs:
             echo $JSON_STRING > annotations.json
 
       - name: Get GCloud CLI
-        uses: google-github-actions/setup-gcloud@v1.0.0
+        uses: google-github-actions/setup-gcloud@v0.6.2
         with:
           service_account_key: ${{ secrets.GCP_GITHUB_ACTION_PUSH_ARTIFACTS }}
           project_id: ${{ env.PROJECT_ID }}

--- a/.github/workflows/release_cli_and_assets.yml
+++ b/.github/workflows/release_cli_and_assets.yml
@@ -64,7 +64,7 @@ jobs:
         echo "VERSION=${trim}" >> $GITHUB_ENV
 
     - name: Get GCloud CLI
-      uses: google-github-actions/setup-gcloud@v1.0.0
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         service_account_key: ${{ secrets.GCP_GITHUB_ACTION_PUSH_ARTIFACTS }}
         project_id: ${{ env.PROJECT_ID }}
@@ -104,7 +104,7 @@ jobs:
         echo "VERSION=${trim}" >> $GITHUB_ENV
 
     - name: Get GCloud CLI
-      uses: google-github-actions/setup-gcloud@v1.0.0
+      uses: google-github-actions/setup-gcloud@v0.6.2
       with:
         service_account_key: ${{ secrets.GCP_GITHUB_ACTION_PUSH_ARTIFACTS }}
         project_id: ${{ env.PROJECT_ID }}
@@ -567,7 +567,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
 
     # - name: Setup GCloud
-    #   uses: google-github-actions/setup-gcloud@v1.0.0
+    #   uses: google-github-actions/setup-gcloud@v0.6.2
     #   with:
     #     service_account_key: ${{ secrets.GCP_GITHUB_ACTION_PUSH_ARTIFACTS }}
     #     project_id: ${{ env.PROJECT_ID }}


### PR DESCRIPTION
Reverts turbot/steampipe#2713

`google-github-actions/setup-gcloud` does not do authentication by itself anymore. Authentication is done by the `google-github-actions/auth` action.

This update breaks the authentication with with GCP Container Registry.