### PR TITLE
Adds a '--max-parallel' (hidden) flag to 'steampipe dashboard'. 

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -74,7 +74,7 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 		AddStringArrayFlag(constants.ArgVariable, nil, "Specify the value of a variable").
 		AddStringFlag(constants.ArgWhere, "", "SQL 'where' clause, or named query, used to filter controls (cannot be used with '--tag')").
 		AddIntFlag(constants.ArgDatabaseQueryTimeout, constants.DatabaseDefaultCheckQueryTimeout, "The query timeout").
-		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions").
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of database connections to open").
 		AddBoolFlag(constants.ArgModInstall, true, "Specify whether to install mod dependencies before running the check").
 		AddBoolFlag(constants.ArgInput, true, "Enable interactive prompts").
 		AddBoolFlag(constants.ArgSnapshot, false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -74,7 +74,7 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 		AddStringArrayFlag(constants.ArgVariable, nil, "Specify the value of a variable").
 		AddStringFlag(constants.ArgWhere, "", "SQL 'where' clause, or named query, used to filter controls (cannot be used with '--tag')").
 		AddIntFlag(constants.ArgDatabaseQueryTimeout, constants.DatabaseDefaultCheckQueryTimeout, "The query timeout").
-		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of database connections to open").
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of concurrent database connections to open").
 		AddBoolFlag(constants.ArgModInstall, true, "Specify whether to install mod dependencies before running the check").
 		AddBoolFlag(constants.ArgInput, true, "Enable interactive prompts").
 		AddBoolFlag(constants.ArgSnapshot, false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -74,7 +74,7 @@ You may specify one or more benchmarks or controls to run (separated by a space)
 		AddStringArrayFlag(constants.ArgVariable, nil, "Specify the value of a variable").
 		AddStringFlag(constants.ArgWhere, "", "SQL 'where' clause, or named query, used to filter controls (cannot be used with '--tag')").
 		AddIntFlag(constants.ArgDatabaseQueryTimeout, constants.DatabaseDefaultCheckQueryTimeout, "The query timeout").
-		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions", cmdconfig.FlagOptions.Hidden()).
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions").
 		AddBoolFlag(constants.ArgModInstall, true, "Specify whether to install mod dependencies before running the check").
 		AddBoolFlag(constants.ArgInput, true, "Enable interactive prompts").
 		AddBoolFlag(constants.ArgSnapshot, false, "Create snapshot in Steampipe Cloud with the default (workspace) visibility").

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -50,6 +50,7 @@ The current mod is the working directory, or the directory specified by the --mo
 		AddBoolFlag(constants.ArgBrowser, true, "Specify whether to launch the browser after starting the dashboard server").
 		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a dashboard session (comma-separated)").
 		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a dashboard session (comma-separated)").
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions", cmdconfig.FlagOptions.Hidden()).
 		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values").
 		AddBoolFlag(constants.ArgProgress, true, "Display dashboard execution progress respected when a dashboard name argument is passed").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -50,7 +50,7 @@ The current mod is the working directory, or the directory specified by the --mo
 		AddBoolFlag(constants.ArgBrowser, true, "Specify whether to launch the browser after starting the dashboard server").
 		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a dashboard session (comma-separated)").
 		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a dashboard session (comma-separated)").
-		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "the maximum number of database connections to open").
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of database connections to open").
 		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values").
 		AddBoolFlag(constants.ArgProgress, true, "Display dashboard execution progress respected when a dashboard name argument is passed").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -50,7 +50,7 @@ The current mod is the working directory, or the directory specified by the --mo
 		AddBoolFlag(constants.ArgBrowser, true, "Specify whether to launch the browser after starting the dashboard server").
 		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a dashboard session (comma-separated)").
 		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a dashboard session (comma-separated)").
-		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions").
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "the maximum number of database connections to open").
 		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values").
 		AddBoolFlag(constants.ArgProgress, true, "Display dashboard execution progress respected when a dashboard name argument is passed").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -50,7 +50,7 @@ The current mod is the working directory, or the directory specified by the --mo
 		AddBoolFlag(constants.ArgBrowser, true, "Specify whether to launch the browser after starting the dashboard server").
 		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a dashboard session (comma-separated)").
 		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a dashboard session (comma-separated)").
-		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of database connections to open").
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of concurrent database connections to open").
 		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values").
 		AddBoolFlag(constants.ArgProgress, true, "Display dashboard execution progress respected when a dashboard name argument is passed").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -50,7 +50,7 @@ The current mod is the working directory, or the directory specified by the --mo
 		AddBoolFlag(constants.ArgBrowser, true, "Specify whether to launch the browser after starting the dashboard server").
 		AddStringSliceFlag(constants.ArgSearchPath, nil, "Set a custom search_path for the steampipe user for a dashboard session (comma-separated)").
 		AddStringSliceFlag(constants.ArgSearchPathPrefix, nil, "Set a prefix to the current search path for a dashboard session (comma-separated)").
-		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions", cmdconfig.FlagOptions.Hidden()).
+		AddIntFlag(constants.ArgMaxParallel, constants.DefaultMaxConnections, "The maximum number of parallel executions").
 		AddStringSliceFlag(constants.ArgVarFile, nil, "Specify an .spvar file containing variable values").
 		AddBoolFlag(constants.ArgProgress, true, "Display dashboard execution progress respected when a dashboard name argument is passed").
 		// NOTE: use StringArrayFlag for ArgVariable, not StringSliceFlag

--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -26,7 +26,7 @@ const (
 	DatabaseUser                     = "steampipe"
 	DatabaseName                     = "steampipe"
 	DatabaseUsersRole                = "steampipe_users"
-	DefaultMaxConnections            = 5
+	DefaultMaxConnections            = 10
 )
 
 // constants for installing db and fdw images


### PR DESCRIPTION
This will enable the user to add  a `--max-parallel int` flag when issuing a `steampipe dashboard` session. 

`steampipe` will use the `--max-parallel` setting to set the size of the pool for database connections which is used during dashboard executions.
