### PR TITLE
Further dashboard graph improvements #2708

### DIFF
--- a/ui/dashboard/src/components/dashboards/common/DashboardIcon.tsx
+++ b/ui/dashboard/src/components/dashboards/common/DashboardIcon.tsx
@@ -14,6 +14,11 @@ interface DashboardHeroIconProps extends DashboardIconProps {
   style?: any;
 }
 
+interface DashboardImageIconProps extends DashboardIconProps {
+  icon: string;
+  style?: any;
+}
+
 const useDashboardIconType = (icon) =>
   useMemo(() => {
     if (!icon) {
@@ -43,8 +48,12 @@ const useDashboardIconType = (icon) =>
     return "icon";
   }, [icon]);
 
-const DashboardImageIcon = ({ className, icon }) => (
-  <img className={className} src={icon} alt="" />
+const DashboardImageIcon = ({
+  className,
+  icon,
+  style,
+}: DashboardImageIconProps) => (
+  <img className={className} src={icon} alt="" style={style} />
 );
 
 const DashboardHeroIcon = ({
@@ -79,7 +88,9 @@ const DashboardIcon = ({ className, icon, style }: DashboardIconProps) => {
     case "text":
       return <DashboardTextIcon className={className} icon={icon} />;
     case "url":
-      return <DashboardImageIcon className={className} icon={icon} />;
+      return (
+        <DashboardImageIcon className={className} icon={icon} style={style} />
+      );
     default:
       return null;
   }

--- a/ui/dashboard/src/components/dashboards/common/useNodeAndEdgeData.ts
+++ b/ui/dashboard/src/components/dashboards/common/useNodeAndEdgeData.ts
@@ -1,5 +1,4 @@
 import has from "lodash/has";
-import set from "lodash/set";
 import {
   Category,
   CategoryMap,
@@ -139,18 +138,16 @@ const useNodeAndEdgeData = (
         continue;
       }
 
+      // Capture the status of this node resource
+      nodeAndEdgeStatus.nodes.push({
+        id: nodePanelName,
+        state: panelStateToCategoryState(panel.status || "ready"),
+      });
+
       const typedPanelData = (panel.data || {}) as NodeAndEdgeData;
       columns = addColumnsForResource(columns, typedPanelData);
       const nodeProperties = (panel.properties || {}) as NodeProperties;
       const nodeDataRows = typedPanelData.rows || [];
-
-      // Capture the status of this node resource
-      nodeAndEdgeStatus.nodes.push({
-        id: nodePanelName,
-        title: nodePanelName.split(".").pop(),
-        state: panelStateToCategoryState(panel.status || "ready"),
-        count: nodeDataRows.length,
-      });
 
       let nodeCategory: Category | null = null;
       let nodeCategoryId: string = "";
@@ -214,6 +211,12 @@ const useNodeAndEdgeData = (
         missingEdges[edgePanelName] = true;
         continue;
       }
+
+      // Capture the status of this edge resource
+      nodeAndEdgeStatus.edges.push({
+        id: edgePanelName,
+        state: panelStateToCategoryState(panel.status || "ready"),
+      });
 
       const typedPanelData = (panel.data || {}) as NodeAndEdgeData;
       columns = addColumnsForResource(columns, typedPanelData);

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -201,7 +201,7 @@ const AssetNode = ({
     <div
       className={classNames(
         renderedHref ? "text-link cursor-pointer" : null,
-        "absolute flex space-x-1 items-center justify-center -bottom-[20px] px-1 text-sm mt-1 bg-dashboard-panel text-foreground whitespace-nowrap min-w-[35px] max-w-[150px]"
+        "absolute flex space-x-1 items-center justify-center bottom-0 px-1 text-sm mt-1 bg-dashboard-panel text-foreground whitespace-nowrap min-w-[35px] max-w-[150px]"
       )}
       onClick={
         isFolded && foldedNodes
@@ -236,7 +236,7 @@ const AssetNode = ({
       {/*@ts-ignore*/}
       <Handle type="source" />
       {/*<div className="max-w-[50px]">{label}</div>*/}
-      <div className="relative flex flex-col items-center cursor-auto">
+      <div className="relative flex flex-col items-center cursor-auto h-[72px]">
         {nodeWithProperties}
         {nodeLabel}
       </div>

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -19,7 +19,7 @@ import { ThemeNames } from "../../../../hooks/useTheme";
 import { useDashboard } from "../../../../hooks/useDashboard";
 import { useGraph } from "../common/useGraph";
 
-interface AssetNodeProps {
+type AssetNodeProps = {
   data: {
     category?: Category;
     color?: string;
@@ -33,16 +33,20 @@ interface AssetNodeProps {
     row_data?: KeyValuePairs;
     themeColors;
   };
-}
+};
 
-interface FoldedNodeCountBadgeProps {
+type AssetNodePropertiesTitleProps = {
+  title: string;
+};
+
+type FoldedNodeCountBadgeProps = {
   foldedNodes: FoldedNode[] | undefined;
-}
+};
 
-interface FoldedNodeLabelProps {
+type FoldedNodeLabelProps = {
   category: Category | undefined;
   fold: CategoryFold | undefined;
-}
+};
 
 const FoldedNodeCountBadge = ({ foldedNodes }: FoldedNodeCountBadgeProps) => {
   if (!foldedNodes) {
@@ -84,6 +88,10 @@ const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
       </span>
     )}
   </div>
+);
+
+const AssetNodePropertiesTitle = ({ title }: AssetNodePropertiesTitleProps) => (
+  <>{title}</>
 );
 
 const AssetNode = ({
@@ -180,13 +188,14 @@ const AssetNode = ({
           <>
             {row_data && row_data.properties && (
               <RowProperties
+                category={category}
                 fields={fields || null}
                 properties={row_data.properties}
               />
             )}
           </>
         }
-        title={label}
+        title={<AssetNodePropertiesTitle title={label} />}
       >
         {node}
         {/*<div className="cursor-pointer text-black-scale-5">*/}

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -35,10 +35,6 @@ type AssetNodeProps = {
   };
 };
 
-type AssetNodePropertiesTitleProps = {
-  title: string;
-};
-
 type FoldedNodeCountBadgeProps = {
   foldedNodes: FoldedNode[] | undefined;
 };
@@ -184,7 +180,6 @@ const AssetNode = ({
           <>
             {row_data && row_data.properties && (
               <RowProperties
-                category={category}
                 fields={fields || null}
                 properties={row_data.properties}
               />

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -2,7 +2,7 @@ import DashboardIcon, {
   useDashboardIconType,
 } from "../../common/DashboardIcon";
 import IntegerDisplay from "../../../IntegerDisplay";
-import RowProperties from "./RowProperties";
+import RowProperties, { RowPropertiesTitle } from "./RowProperties";
 import Tooltip from "./Tooltip";
 import {
   Category,
@@ -88,10 +88,6 @@ const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
       </span>
     )}
   </div>
-);
-
-const AssetNodePropertiesTitle = ({ title }: AssetNodePropertiesTitleProps) => (
-  <>{title}</>
 );
 
 const AssetNode = ({
@@ -195,7 +191,7 @@ const AssetNode = ({
             )}
           </>
         }
-        title={<AssetNodePropertiesTitle title={label} />}
+        title={<RowPropertiesTitle category={category} title={label} />}
       >
         {node}
         {/*<div className="cursor-pointer text-black-scale-5">*/}

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/FloatingEdge.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/FloatingEdge.tsx
@@ -1,4 +1,4 @@
-import RowProperties from "./RowProperties";
+import RowProperties, { RowPropertiesTitle } from "./RowProperties";
 import Tooltip from "./Tooltip";
 import { circleGetBezierPath, getEdgeParams } from "./utils";
 import { classNames } from "../../../../utils/styles";
@@ -88,7 +88,7 @@ const FloatingEdge = ({
               properties={row_data.properties}
             />
           }
-          title={label}
+          title={<RowPropertiesTitle category={category} title={label} />}
         >
           {edgeLabel}
         </Tooltip>

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/FloatingEdge.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/FloatingEdge.tsx
@@ -14,6 +14,7 @@ const FloatingEdge = ({
   markerEnd,
   style,
   data: {
+    category,
     color,
     customColor,
     fields,
@@ -82,6 +83,7 @@ const FloatingEdge = ({
         <Tooltip
           overlay={
             <RowProperties
+              category={category}
               fields={fields || null}
               properties={row_data.properties}
             />

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/FloatingEdge.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/FloatingEdge.tsx
@@ -83,7 +83,6 @@ const FloatingEdge = ({
         <Tooltip
           overlay={
             <RowProperties
-              category={category}
               fields={fields || null}
               properties={row_data.properties}
             />

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
@@ -32,13 +32,16 @@ interface RowPropertyItemProps {
 
 const RowPropertiesTitle = ({ category, title }: RowPropertiesTitleProps) => {
   return (
-    <div className="flex flex-col space-y-2">
+    <div className="flex flex-col space-y-1">
       {category && (
-        <span className="block text-foreground-lighter text-xs">
+        <span
+          className="block text-foreground-lighter text-xs"
+          style={{ color: category.color }}
+        >
           {category.title || category.name}
         </span>
       )}
-      <span className="block">{title}</span>
+      <strong className="block">{title}</strong>
     </div>
   );
 };
@@ -153,6 +156,7 @@ const RowPropertyItem = ({
           "block text-sm text-foreground-lighter truncate",
           wrap ? "whitespace-normal" : "truncate"
         )}
+        title={name}
       >
         {name}
       </span>

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
@@ -1,9 +1,11 @@
 import isEmpty from "lodash/isEmpty";
+import useChartThemeColors from "../../../../hooks/useChartThemeColors";
 import useDeepCompareEffect from "use-deep-compare-effect";
 import { Category, CategoryFields, KeyValuePairs } from "../../common/types";
 import { classNames } from "../../../../utils/styles";
 import { DashboardDataModeLive } from "../../../../types";
 import { ErrorIcon } from "../../../../constants/icons";
+import { getColorOverride } from "../../common";
 import { isRelativeUrl } from "../../../../utils/url";
 import {
   renderInterpolatedTemplates,
@@ -18,7 +20,6 @@ interface RowPropertiesTitleProps {
 }
 
 interface RowPropertiesProps {
-  category: Category | undefined;
   fields: CategoryFields | null;
   properties: KeyValuePairs | null;
 }
@@ -31,12 +32,13 @@ interface RowPropertyItemProps {
 }
 
 const RowPropertiesTitle = ({ category, title }: RowPropertiesTitleProps) => {
+  const themeColors = useChartThemeColors();
   return (
     <div className="flex flex-col space-y-1">
       {category && (
         <span
           className="block text-foreground-lighter text-xs"
-          style={{ color: category.color }}
+          style={{ color: getColorOverride(category.color, themeColors) }}
         >
           {category.title || category.name}
         </span>
@@ -175,11 +177,7 @@ const RowPropertyItem = ({
   );
 };
 
-const RowProperties = ({
-  category,
-  properties = {},
-  fields,
-}: RowPropertiesProps) => {
+const RowProperties = ({ properties = {}, fields }: RowPropertiesProps) => {
   const [rowTemplateData, setRowTemplateData] =
     useState<RowRenderResult | null>(null);
 
@@ -216,13 +214,6 @@ const RowProperties = ({
 
   return (
     <div className="space-y-2">
-      {category && (
-        <RowPropertyItem
-          name="Category"
-          value={category.title || category.name}
-          wrap={true}
-        />
-      )}
       {Object.entries(properties || {}).map(([key, value]) => {
         const fieldDefinition = fields?.[key];
         if (fieldDefinition && fieldDefinition.display === "none") {

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
@@ -12,6 +12,11 @@ import {
 import { useDashboard } from "../../../../hooks/useDashboard";
 import { useEffect, useState } from "react";
 
+interface RowPropertiesTitleProps {
+  category: Category | undefined;
+  title: string;
+}
+
 interface RowPropertiesProps {
   category: Category | undefined;
   fields: CategoryFields | null;
@@ -24,6 +29,19 @@ interface RowPropertyItemProps {
   value: any;
   wrap: boolean;
 }
+
+const RowPropertiesTitle = ({ category, title }: RowPropertiesTitleProps) => {
+  return (
+    <div className="flex flex-col space-y-2">
+      {category && (
+        <span className="block text-foreground-lighter text-xs">
+          {category.title || category.name}
+        </span>
+      )}
+      <span className="block">{title}</span>
+    </div>
+  );
+};
 
 const RowPropertyItemValue = ({
   name,
@@ -221,3 +239,5 @@ const RowProperties = ({
 };
 
 export default RowProperties;
+
+export { RowPropertiesTitle };

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/RowProperties.tsx
@@ -1,6 +1,6 @@
 import isEmpty from "lodash/isEmpty";
 import useDeepCompareEffect from "use-deep-compare-effect";
-import { CategoryFields, KeyValuePairs } from "../../common/types";
+import { Category, CategoryFields, KeyValuePairs } from "../../common/types";
 import { classNames } from "../../../../utils/styles";
 import { DashboardDataModeLive } from "../../../../types";
 import { ErrorIcon } from "../../../../constants/icons";
@@ -13,13 +13,14 @@ import { useDashboard } from "../../../../hooks/useDashboard";
 import { useEffect, useState } from "react";
 
 interface RowPropertiesProps {
+  category: Category | undefined;
   fields: CategoryFields | null;
   properties: KeyValuePairs | null;
 }
 
 interface RowPropertyItemProps {
   name: string;
-  rowTemplateData: RowRenderResult | null;
+  rowTemplateData?: RowRenderResult | null;
   value: any;
   wrap: boolean;
 }
@@ -81,7 +82,7 @@ const RowPropertyItemValue = ({
       </span>
     );
   } else {
-    let renderValue: string = "";
+    let renderValue: string;
     switch (typeof value) {
       case "object":
         renderValue = JSON.stringify(value, null, 2);
@@ -152,7 +153,11 @@ const RowPropertyItem = ({
   );
 };
 
-const RowProperties = ({ properties = {}, fields }: RowPropertiesProps) => {
+const RowProperties = ({
+  category,
+  properties = {},
+  fields,
+}: RowPropertiesProps) => {
   const [rowTemplateData, setRowTemplateData] =
     useState<RowRenderResult | null>(null);
 
@@ -189,6 +194,13 @@ const RowProperties = ({ properties = {}, fields }: RowPropertiesProps) => {
 
   return (
     <div className="space-y-2">
+      {category && (
+        <RowPropertyItem
+          name="Category"
+          value={category.title || category.name}
+          wrap={true}
+        />
+      )}
       {Object.entries(properties || {}).map(([key, value]) => {
         const fieldDefinition = fields?.[key];
         if (fieldDefinition && fieldDefinition.display === "none") {

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/Tooltip.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/Tooltip.tsx
@@ -212,7 +212,7 @@ const Tooltip = ({
 };
 
 const Title = ({ title }) => {
-  return <strong className="block break-all">{title}</strong>;
+  return <div className="block break-all">{title}</div>;
 };
 
 export default Tooltip;

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/Tooltip.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/Tooltip.tsx
@@ -1,6 +1,7 @@
 import {
   cloneElement,
   createContext,
+  ReactNode,
   useContext,
   useEffect,
   useRef,
@@ -17,7 +18,7 @@ interface TooltipProps {
   overlay: JSX.Element;
   show?: boolean;
   showDelay?: number;
-  title: string;
+  title: ReactNode;
 }
 
 // Start: adapted from https://github.com/streamich/react-use

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -180,6 +180,10 @@ const buildGraphNodesAndEdges = (
         type: MarkerType.Arrow,
       },
       data: {
+        category:
+          edge.category && categories[edge.category]
+            ? categories[edge.category]
+            : null,
         color,
         customColor: !!categoryColor || !!targetNodeColor,
         fields: matchingCategory ? matchingCategory.fields : null,

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -106,6 +106,13 @@ const buildGraphNodesAndEdges = (
     const matchingCategory = node.category
       ? nodesAndEdges.categories[node.category]
       : null;
+    let categoryColor = getColorOverride(
+      matchingCategory ? matchingCategory.color : null,
+      themeColors
+    );
+    if (categoryColor === "auto") {
+      categoryColor = null;
+    }
     nodes.push({
       type: "asset",
       id: node.id,
@@ -115,7 +122,7 @@ const buildGraphNodesAndEdges = (
           node.category && categories[node.category]
             ? categories[node.category]
             : null,
-        color: matchingCategory ? matchingCategory.color : null,
+        color: categoryColor,
         fields: matchingCategory ? matchingCategory.fields : null,
         href: matchingCategory ? matchingCategory.href : null,
         icon: matchingCategory ? matchingCategory.icon : null,
@@ -159,9 +166,9 @@ const buildGraphNodesAndEdges = (
       }
     }
     const color = categoryColor
-      ? categoryColor
+      ? getColorOverride(categoryColor, themeColors)
       : targetNodeColor
-      ? targetNodeColor
+      ? getColorOverride(targetNodeColor, themeColors)
       : themeColors.blackScale4;
     const labelOpacity = categoryColor ? 1 : targetNodeColor ? 0.5 : 1;
     const lineOpacity = categoryColor ? 1 : targetNodeColor ? 0.7 : 1;

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -304,14 +304,7 @@ const ZoomOutControl = () => {
 };
 
 const ResetZoomControl = () => {
-  const { setFitView } = useGraph();
   const { fitView } = useReactFlow();
-
-  // We need to capture this fit view function and pass it into our graph provider,
-  // so that we can call it when the edges or nodes change to update the layout
-  useEffect(() => {
-    setFitView(fitView);
-  }, [fitView, setFitView]);
 
   return (
     <ControlButton
@@ -433,34 +426,32 @@ const Graph = (props) => {
   );
 
   return (
-    <ReactFlowProvider>
-      <div
-        style={{
-          height: graphOptions.height,
-          maxHeight: selectedPanel ? undefined : 600,
-          minHeight: 175,
+    <div
+      style={{
+        height: graphOptions.height,
+        maxHeight: selectedPanel ? undefined : 600,
+        minHeight: 175,
+      }}
+    >
+      <ReactFlow
+        // @ts-ignore
+        edgeTypes={edgeTypes}
+        edges={graphOptions.edges}
+        fitView
+        nodes={graphOptions.nodes}
+        nodeTypes={nodeTypes}
+        onEdgesChange={graphOptions.onEdgesChange}
+        onNodesChange={graphOptions.onNodesChange}
+        preventScrolling={false}
+        proOptions={{
+          account: "paid-pro",
+          hideAttribution: true,
         }}
+        zoomOnScroll={false}
       >
-        <ReactFlow
-          // @ts-ignore
-          edgeTypes={edgeTypes}
-          edges={graphOptions.edges}
-          fitView
-          nodes={graphOptions.nodes}
-          nodeTypes={nodeTypes}
-          onEdgesChange={graphOptions.onEdgesChange}
-          onNodesChange={graphOptions.onNodesChange}
-          preventScrolling={false}
-          proOptions={{
-            account: "paid-pro",
-            hideAttribution: true,
-          }}
-          zoomOnScroll={false}
-        >
-          <CustomControls />
-        </ReactFlow>
-      </div>
-    </ReactFlowProvider>
+        <CustomControls />
+      </ReactFlow>
+    </div>
   );
 };
 
@@ -481,16 +472,18 @@ const GraphWrapper = (props: GraphProps) => {
   }
 
   return (
-    <GraphProvider>
-      <Graph
-        {...props}
-        categories={nodeAndEdgeData.categories}
-        data={nodeAndEdgeData.data}
-        dataFormat={nodeAndEdgeData.dataFormat}
-        properties={nodeAndEdgeData.properties}
-        nodeAndEdgeStatus={nodeAndEdgeData.status}
-      />
-    </GraphProvider>
+    <ReactFlowProvider>
+      <GraphProvider>
+        <Graph
+          {...props}
+          categories={nodeAndEdgeData.categories}
+          data={nodeAndEdgeData.data}
+          dataFormat={nodeAndEdgeData.dataFormat}
+          properties={nodeAndEdgeData.properties}
+          nodeAndEdgeStatus={nodeAndEdgeData.status}
+        />
+      </GraphProvider>
+    </ReactFlowProvider>
   );
 };
 

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -24,6 +24,11 @@ import {
   LeafNodeData,
 } from "../../common";
 import {
+  CategoryMap,
+  KeyValueStringPairs,
+  Node as NodeType,
+} from "../../common/types";
+import {
   CategoryStatus,
   GraphProperties,
   GraphProps,
@@ -33,11 +38,6 @@ import {
 import { DashboardRunState } from "../../../../types";
 import { getGraphComponent } from "..";
 import { GraphProvider, useGraph } from "../common/useGraph";
-import {
-  CategoryMap,
-  KeyValueStringPairs,
-  Node as NodeType,
-} from "../../common/types";
 import { registerComponent } from "../../index";
 import {
   ResetLayoutIcon,

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -117,6 +117,7 @@ const buildGraphNodesAndEdges = (
       type: "asset",
       id: node.id,
       position: { x: matchingNode.x, y: matchingNode.y },
+      // height: 70,
       data: {
         category:
           node.category && categories[node.category]

--- a/ui/dashboard/src/components/dashboards/graphs/common/useGraph.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/common/useGraph.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import { Edge, Node } from "reactflow";
+import { Edge, Node, useReactFlow } from "reactflow";
 import { FoldedNode, KeyValueStringPairs } from "../../common/types";
 import { noop } from "../../../../utils/func";
 import { useDashboard } from "../../../../hooks/useDashboard";
@@ -10,7 +10,6 @@ interface IGraphContext {
   expandedNodes: KeyValueStringPairs;
   layoutId: string;
   recalcLayout: () => void;
-  setFitView: (fitView: typeof noop) => void;
   setGraphEdges: (edges: Edge[]) => void;
   setGraphNodes: (nodes: Node[]) => void;
 }
@@ -20,7 +19,6 @@ const GraphContext = createContext<IGraphContext>({
   expandedNodes: {},
   layoutId: "",
   recalcLayout: noop,
-  setFitView: noop,
   setGraphEdges: noop,
   setGraphNodes: noop,
 });
@@ -29,8 +27,8 @@ const GraphProvider = ({ children }) => {
   const {
     themeContext: { theme },
   } = useDashboard();
+  const { fitView } = useReactFlow();
   const [layoutId, setLayoutId] = useState(uuid());
-  const [fitView, setFitView] = useState<typeof noop>(noop);
   const [graphEdges, setGraphEdges] = useState<Edge[]>([]);
   const [graphNodes, setGraphNodes] = useState<Node[]>([]);
   const [expandedNodes, setExpandedNodes] = useState<KeyValueStringPairs>({});
@@ -69,7 +67,6 @@ const GraphProvider = ({ children }) => {
         expandedNodes,
         layoutId,
         recalcLayout,
-        setFitView: (newFitView) => setFitView(() => newFitView),
         setGraphEdges,
         setGraphNodes,
       }}

--- a/ui/dashboard/src/components/dashboards/graphs/types.ts
+++ b/ui/dashboard/src/components/dashboards/graphs/types.ts
@@ -53,20 +53,18 @@ export type NodeAndEdgeState = "pending" | "error" | "complete";
 
 type BaseNodeAndEdgeStatus = {
   id: string;
-  title?: string;
   state: NodeAndEdgeState;
 };
 
-export type CategoryStatus = BaseNodeAndEdgeStatus;
+export type CategoryStatus = BaseNodeAndEdgeStatus & {
+  title?: string;
+};
 
 type CategoryStatusMap = {
   [name: string]: CategoryStatus;
 };
 
-export type NodeStatus = BaseNodeAndEdgeStatus & {
-  count: number;
-};
-
+export type NodeStatus = BaseNodeAndEdgeStatus;
 export type EdgeStatus = BaseNodeAndEdgeStatus;
 
 export type NodeAndEdgeStatus = {

--- a/ui/dashboard/src/hooks/useDashboard.tsx
+++ b/ui/dashboard/src/hooks/useDashboard.tsx
@@ -624,12 +624,12 @@ const DashboardProvider = ({
 
   // Keep track of the previous selected dashboard and inputs
   const previousSelectedDashboardStates: SelectedDashboardStates | undefined =
-    usePrevious({
-      searchParams,
+    usePrevious<SelectedDashboardStates>({
       dashboard_name,
       dataMode: state.dataMode,
       refetchDashboard: state.refetchDashboard,
       search: state.search,
+      searchParams,
       selectedDashboard: state.selectedDashboard,
       selectedDashboardInputs: state.selectedDashboardInputs,
     });
@@ -671,10 +671,8 @@ const DashboardProvider = ({
     // If we've just popped or pushed from one dashboard to another, then we don't want to add the search to the URL
     // as that will show the dashboard list, but we want to see the dashboard that we came from / went to previously.
     const goneFromDashboardToDashboard =
-      // @ts-ignore
       previousSelectedDashboardStates?.dashboard_name &&
       dashboard_name &&
-      // @ts-ignore
       previousSelectedDashboardStates.dashboard_name !== dashboard_name;
 
     const search = searchParams.get("search") || "";
@@ -696,7 +694,6 @@ const DashboardProvider = ({
     });
     if (
       JSON.stringify(
-        // @ts-ignore
         previousSelectedDashboardStates?.selectedDashboardInputs
       ) !== JSON.stringify(inputs)
     ) {
@@ -724,19 +721,13 @@ const DashboardProvider = ({
       state.dataMode === DashboardDataModeCloudSnapshot ||
       state.dataMode === DashboardDataModeCLISnapshot ||
       (previousSelectedDashboardStates &&
-        // @ts-ignore
         previousSelectedDashboardStates?.dashboard_name === dashboard_name &&
-        // @ts-ignore
         previousSelectedDashboardStates.dataMode === state.dataMode &&
-        // @ts-ignore
         previousSelectedDashboardStates.search.value === state.search.value &&
-        // @ts-ignore
         previousSelectedDashboardStates.search.groupBy.value ===
           state.search.groupBy.value &&
-        // @ts-ignore
         previousSelectedDashboardStates.search.groupBy.tag ===
           state.search.groupBy.tag &&
-        // @ts-ignore
         previousSelectedDashboardStates.searchParams.toString() ===
           searchParams.toString())
     ) {
@@ -882,12 +873,9 @@ const DashboardProvider = ({
       (state.dataMode === DashboardDataModeLive ||
         state.dataMode === DashboardDataModeCLISnapshot) &&
       (!previousSelectedDashboardStates ||
-        // @ts-ignore
         !previousSelectedDashboardStates.selectedDashboard ||
         state.selectedDashboard.full_name !==
-          // @ts-ignore
           previousSelectedDashboardStates.selectedDashboard.full_name ||
-        // @ts-ignore
         (!previousSelectedDashboardStates.refetchDashboard &&
           state.refetchDashboard))
     ) {
@@ -913,10 +901,8 @@ const DashboardProvider = ({
     if (
       state.dataMode === DashboardDataModeLive &&
       previousSelectedDashboardStates &&
-      // @ts-ignore
       previousSelectedDashboardStates.selectedDashboard &&
       !isEqual(
-        // @ts-ignore
         previousSelectedDashboardStates.selectedDashboardInputs,
         state.selectedDashboardInputs
       )
@@ -952,7 +938,6 @@ const DashboardProvider = ({
     // If we've gone from having a report selected, to having nothing selected, clear the dashboard state
     if (
       previousSelectedDashboardStates &&
-      // @ts-ignore
       previousSelectedDashboardStates.selectedDashboard
     ) {
       sendSocketMessage({
@@ -979,7 +964,6 @@ const DashboardProvider = ({
     if (
       isEqual(
         state.selectedDashboardInputs,
-        // @ts-ignore
         previousSelectedDashboardStates.selectedDashboardInputs
       )
     ) {
@@ -989,10 +973,8 @@ const DashboardProvider = ({
     // Only record history when it's the same report before and after and the inputs have changed
     const shouldRecordHistory =
       state.recordInputsHistory &&
-      // @ts-ignore
       !!previousSelectedDashboardStates.selectedDashboard &&
       !!state.selectedDashboard &&
-      // @ts-ignore
       previousSelectedDashboardStates.selectedDashboard.full_name ===
         state.selectedDashboard.full_name;
 

--- a/ui/dashboard/src/hooks/usePrevious.ts
+++ b/ui/dashboard/src/hooks/usePrevious.ts
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
 
-const usePrevious = (value) => {
-  const ref = useRef();
+function usePrevious<T>(value: T): T {
+  const ref: any = useRef<T>();
   useEffect(() => {
     ref.current = value;
-  });
+  }, [value]);
   return ref.current;
-};
+}
 
 export default usePrevious;

--- a/ui/dashboard/src/types/index.ts
+++ b/ui/dashboard/src/types/index.ts
@@ -176,13 +176,13 @@ export interface DashboardTags {
 }
 
 export interface SelectedDashboardStates {
-  dashboard_name: string | null;
+  dashboard_name: string | undefined;
   dataMode: DashboardDataMode;
   refetchDashboard: boolean;
   search: DashboardSearch;
+  searchParams: URLSearchParams;
   selectedDashboard: AvailableDashboard | null;
   selectedDashboardInputs: DashboardInputs;
-  selectedSnapshot: DashboardSnapshot;
 }
 
 interface DashboardInputs {


### PR DESCRIPTION
- Add category info to node/edge properties tooltip
- Add typescript typing to usePrevious to remove need for tsignore hints
- Don't zoom out when expanding folded nodes
- Fix nodes moving / zoom resetting when you zoom in and try to click a node
- Fix bottom of nodes being cut off for certain default zoom levels