### PR TITLE
Further graph improvements #2708

### DIFF
--- a/ui/dashboard/src/components/Icon/index.tsx
+++ b/ui/dashboard/src/components/Icon/index.tsx
@@ -179,14 +179,15 @@ interface IconProps {
   className?: string;
   icon: string;
   style?: any;
+  title?: string;
 }
 
-const Icon = ({ className = "h-6 w-6", icon, style }: IconProps) => {
+const Icon = ({ className = "h-6 w-6", icon, style, title }: IconProps) => {
   const MatchingIcon = icons[getDashboardIconName(icon)];
   if (!MatchingIcon) {
     return null;
   }
-  return <MatchingIcon className={className} style={style} />;
+  return <MatchingIcon className={className} style={style} title={title} />;
 };
 
 export default Icon;

--- a/ui/dashboard/src/components/dashboards/common/DashboardIcon.tsx
+++ b/ui/dashboard/src/components/dashboards/common/DashboardIcon.tsx
@@ -7,6 +7,7 @@ interface DashboardIconProps {
   className?: string;
   icon?: string | null;
   style?: any;
+  title?: string;
 }
 
 interface DashboardHeroIconProps extends DashboardIconProps {
@@ -52,16 +53,18 @@ const DashboardImageIcon = ({
   className,
   icon,
   style,
+  title,
 }: DashboardImageIconProps) => (
-  <img className={className} src={icon} alt="" style={style} />
+  <img className={className} src={icon} alt="" style={style} title={title} />
 );
 
 const DashboardHeroIcon = ({
   className,
   icon,
   style,
+  title,
 }: DashboardHeroIconProps) => (
-  <Icon className={className} icon={icon} style={style} />
+  <Icon className={className} icon={icon} style={style} title={title} />
 );
 
 const DashboardTextIcon = ({ className, icon }: DashboardHeroIconProps) => (
@@ -72,7 +75,12 @@ const DashboardTextIcon = ({ className, icon }: DashboardHeroIconProps) => (
   </svg>
 );
 
-const DashboardIcon = ({ className, icon, style }: DashboardIconProps) => {
+const DashboardIcon = ({
+  className,
+  icon,
+  style,
+  title,
+}: DashboardIconProps) => {
   // First work out the type of the provided icon
   const iconType = useDashboardIconType(icon);
 
@@ -83,13 +91,25 @@ const DashboardIcon = ({ className, icon, style }: DashboardIconProps) => {
   switch (iconType) {
     case "icon":
       return (
-        <DashboardHeroIcon className={className} icon={icon} style={style} />
+        <DashboardHeroIcon
+          className={className}
+          icon={icon}
+          style={style}
+          title={title}
+        />
       );
     case "text":
-      return <DashboardTextIcon className={className} icon={icon} />;
+      return (
+        <DashboardTextIcon className={className} icon={icon} title={title} />
+      );
     case "url":
       return (
-        <DashboardImageIcon className={className} icon={icon} style={style} />
+        <DashboardImageIcon
+          className={className}
+          icon={icon}
+          style={style}
+          title={title}
+        />
       );
     default:
       return null;

--- a/ui/dashboard/src/components/dashboards/common/index.ts
+++ b/ui/dashboard/src/components/dashboards/common/index.ts
@@ -6,7 +6,6 @@ import {
   Edge,
   EdgeMap,
   KeyValuePairs,
-  KeyValueStringPairs,
   Node,
   NodeAndEdgeProperties,
   NodeCategoryMap,
@@ -15,6 +14,7 @@ import {
 } from "./types";
 import { ChartProperties, ChartTransform, ChartType } from "../charts/types";
 import { DashboardRunState, PanelsMap } from "../../../types";
+import { ExpandedNodes } from "../graphs/common/useGraph";
 import { FlowProperties, FlowType } from "../flows/types";
 import { getColumn } from "../../../utils/data";
 import { getNodeAndEdgeDataFormat } from "./useNodeAndEdgeData";
@@ -341,7 +341,7 @@ const getCategoriesWithFold = (categories: CategoryMap): CategoryMap => {
 
 const foldNodesAndEdges = (
   nodesAndEdges: NodesAndEdges,
-  expandedNodes: KeyValueStringPairs = {}
+  expandedNodes: ExpandedNodes = {}
 ): NodesAndEdges => {
   const categoriesWithFold = getCategoriesWithFold(nodesAndEdges.categories);
 

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -62,6 +62,7 @@ type NodeControlProps = {
   action?: () => void;
   className?: string;
   icon: string;
+  iconClassName?: string;
   title?: string;
 };
 
@@ -147,7 +148,13 @@ const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
   </>
 );
 
-const NodeControl = ({ action, className, icon, title }: NodeControlProps) => {
+const NodeControl = ({
+  action,
+  className,
+  icon,
+  iconClassName,
+  title,
+}: NodeControlProps) => {
   return (
     <div
       onClick={(e) => {
@@ -157,14 +164,14 @@ const NodeControl = ({ action, className, icon, title }: NodeControlProps) => {
       className={classNames(className, "p-1")}
       title={title}
     >
-      <Icon className="w-4 h-4" icon={icon} />
+      <Icon className={classNames(iconClassName, "w-3 h-3")} icon={icon} />
     </div>
   );
 };
 
 const NodeControls = ({ children }: NodeControlsProps) => {
   return (
-    <div className="invisible group-hover:visible absolute -left-[10%] -bottom-[10%] flex flex-col space-y-px bg-dashboard text-foreground">
+    <div className="invisible group-hover:visible absolute -left-[17%] -bottom-[4%] flex flex-col space-y-px bg-dashboard text-foreground">
       {children}
     </div>
   );
@@ -173,7 +180,8 @@ const NodeControls = ({ children }: NodeControlsProps) => {
 const NodeGrabHandleControl = () => (
   <NodeControl
     className="custom-drag-handle cursor-grab"
-    icon="cursor-arrow-ripple"
+    icon="arrows-pointing-out"
+    iconClassName="rotate-45"
     title="Move node"
   />
 );
@@ -266,7 +274,6 @@ const AssetNode = ({
       <DashboardIcon
         className={classNames(
           "max-w-full",
-          isFolded ? "group-hover:hidden" : null,
           iconType === "icon" && !color ? "text-foreground-lighter" : null,
           theme.name === ThemeNames.STEAMPIPE_DARK ? "brightness-[1.75]" : null
         )}
@@ -275,21 +282,6 @@ const AssetNode = ({
         }}
         icon={isFolded ? fold?.icon : icon}
       />
-      {isFolded && (
-        <DashboardIcon
-          className={classNames(
-            "hidden group-hover:block max-w-full",
-            iconType === "icon" && !color ? "text-foreground-lighter" : null
-            // theme.name === ThemeNames.STEAMPIPE_DARK
-            //   ? "brightness-[1.75]"
-            //   : null
-          )}
-          style={{
-            color: color ? color : undefined,
-          }}
-          icon="plus"
-        />
-      )}
       {isFolded && <FoldedNodeCountBadge foldedNodes={foldedNodes} />}
       <NodeControls>
         {isExpandedNode && (

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -385,7 +385,6 @@ const AssetNode = ({
       <Handle type="target" />
       {/*@ts-ignore*/}
       <Handle type="source" />
-      {/*<div className="max-w-[50px]">{label}</div>*/}
       {!hasProperties && !isFolded && wrappedNode}
       {hasProperties && !isFolded && (
         <Tooltip

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -158,21 +158,18 @@ const FoldNodeIcon = ({
 };
 
 const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
-  <div className="flex space-x-1 items-center">
+  <>
     {fold?.title && (
-      <span className="cursor-pointer truncate" title={fold?.title}>
+      <span className="truncate" title={fold?.title}>
         {fold?.title}
       </span>
     )}
     {!fold?.title && (
-      <span
-        className="text-link cursor-pointer truncate"
-        title={category?.name}
-      >
+      <span className="text-link truncate" title={category?.name}>
         {category?.name}
       </span>
     )}
-  </div>
+  </>
 );
 
 const NodeControls = () => {
@@ -239,7 +236,7 @@ const AssetNode = ({
     </div>
   );
 
-  const node = (
+  const nodeIcon = (
     <div
       className={classNames(
         "relative p-3 rounded-full w-[50px] h-[50px] leading-[50px] my-0 mx-auto border"
@@ -265,12 +262,12 @@ const AssetNode = ({
       {isFolded && (
         <FoldedNodeCountBadge category={category} foldedNodes={foldedNodes} />
       )}
-      {isExpandedNode && (
-        <FoldNodeIcon
-          collapseNodes={collapseNodes}
-          expandedNodeInfo={expandedNodes[id]}
-        />
-      )}
+      {/*{isExpandedNode && (*/}
+      {/*  <FoldNodeIcon*/}
+      {/*    collapseNodes={collapseNodes}*/}
+      {/*    expandedNodeInfo={expandedNodes[id]}*/}
+      {/*  />*/}
+      {/*)}*/}
       {/*{nodeGrabHandle}*/}
     </div>
   );
@@ -289,35 +286,35 @@ const AssetNode = ({
   //     node
   //   );
 
-  const nodeWithProperties =
-    row_data && row_data.properties && !isFolded ? (
-      <Tooltip
-        overlay={
-          <>
-            {row_data && row_data.properties && (
-              <RowProperties
-                fields={fields || null}
-                properties={row_data.properties}
-              />
-            )}
-          </>
-        }
-        title={<RowPropertiesTitle category={category} title={label} />}
-      >
-        {node}
-        {/*<div className="cursor-pointer text-black-scale-5">*/}
-        {/*  <Icon className="w-4 h-4" icon="queue-list" />*/}
-        {/*</div>*/}
-      </Tooltip>
-    ) : (
-      node
-    );
+  // const nodeWithProperties =
+  //   row_data && row_data.properties && !isFolded ? (
+  //     <Tooltip
+  //       overlay={
+  //         <>
+  //           {row_data && row_data.properties && (
+  //             <RowProperties
+  //               fields={fields || null}
+  //               properties={row_data.properties}
+  //             />
+  //           )}
+  //         </>
+  //       }
+  //       title={<RowPropertiesTitle category={category} title={label} />}
+  //     >
+  //       {icon}
+  //       {/*<div className="cursor-pointer text-black-scale-5">*/}
+  //       {/*  <Icon className="w-4 h-4" icon="queue-list" />*/}
+  //       {/*</div>*/}
+  //     </Tooltip>
+  //   ) : (
+  //     icon
+  //   );
 
   const nodeLabel = (
     <div
       className={classNames(
         renderedHref ? "text-link cursor-pointer" : null,
-        "absolute flex space-x-1 items-center justify-center bottom-0 px-1 text-sm mt-1 bg-dashboard-panel text-foreground whitespace-nowrap min-w-[35px] max-w-[150px]"
+        "absolute flex space-x-1 truncate items-center bottom-0 px-1 text-sm mt-1 bg-dashboard-panel text-foreground whitespace-nowrap min-w-[35px] max-w-[150px]"
       )}
       onClick={
         isFolded && foldedNodes
@@ -325,21 +322,27 @@ const AssetNode = ({
           : undefined
       }
     >
-      {!isFolded && renderedHref && (
-        <ExternalLink className="truncate" to={renderedHref}>
+      {isFolded && (
+        <span className="truncate" title={label}>
           {label}
-        </ExternalLink>
+        </span>
       )}
-      {!renderedHref && (
-        <>
-          {!isFolded && (
-            <span className="truncate" title={label}>
-              {label}
-            </span>
-          )}
-          {isFolded && <FoldedNodeLabel category={category} fold={fold} />}
-        </>
-      )}
+      {!isFolded && <FoldedNodeLabel category={category} fold={fold} />}
+      {/*{!isFolded && renderedHref && (*/}
+      {/*  <ExternalLink className="truncate" to={renderedHref}>*/}
+      {/*    {label}*/}
+      {/*  </ExternalLink>*/}
+      {/*)}*/}
+      {/*{!renderedHref && (*/}
+      {/*  <>*/}
+      {/*    {!isFolded && (*/}
+      {/*      <span className="truncate" title={label}>*/}
+      {/*        {label}*/}
+      {/*      </span>*/}
+      {/*    )}*/}
+      {/*    {isFolded && <FoldedNodeLabel category={category} fold={fold} />}*/}
+      {/*  </>*/}
+      {/*)}*/}
     </div>
   );
 
@@ -353,10 +356,21 @@ const AssetNode = ({
       <Handle type="source" />
       {/*<div className="max-w-[50px]">{label}</div>*/}
       <div className="relative cursor-auto h-[72px]">
-        <div className="peer flex flex-col group items-center">
-          {nodeWithProperties}
-          {nodeLabel}
-        </div>
+        {renderedHref && (
+          <ExternalLink
+            className="block flex flex-col items-center"
+            to={renderedHref}
+          >
+            {nodeIcon}
+            {nodeLabel}
+          </ExternalLink>
+        )}
+        {!renderedHref && (
+          <div className="flex flex-col items-center">
+            {nodeIcon}
+            {nodeLabel}
+          </div>
+        )}
         <NodeControls />
       </div>
     </>

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -44,11 +44,6 @@ type FoldedNodeCountBadgeProps = {
   foldedNodes: FoldedNode[] | undefined;
 };
 
-type FoldNodeIconProps = {
-  collapseNodes: (foldedNodes: FoldedNode[]) => void;
-  expandedNodeInfo: ExpandedNodeInfo | undefined;
-};
-
 type FoldedNodeLabelProps = {
   category: Category | undefined;
   fold: CategoryFold | undefined;
@@ -67,10 +62,16 @@ type NodeControlProps = {
   action?: () => void;
   className?: string;
   icon: string;
+  title?: string;
 };
 
 type NodeControlsProps = {
   children: ReactNode | ReactNode[];
+};
+
+type RefoldNodeControlProps = {
+  collapseNodes: (foldedNodes: FoldedNode[]) => void;
+  expandedNodeInfo: ExpandedNodeInfo | undefined;
 };
 
 const FoldedNodeTooltipTitle = ({
@@ -131,24 +132,6 @@ const FoldedNodeCountBadge = ({ foldedNodes }: FoldedNodeCountBadgeProps) => {
   );
 };
 
-const FoldNodeIcon = ({
-  collapseNodes,
-  expandedNodeInfo,
-}: FoldNodeIconProps) => {
-  if (!expandedNodeInfo) {
-    return null;
-  }
-  return (
-    <div
-      className="absolute -right-[4%] -top-[4%] items-center bg-foreground-lightest text-foreground-light rounded-full p-0.5 text-sm font-medium cursor-pointer"
-      title="Collapse"
-      onClick={() => collapseNodes(expandedNodeInfo.foldedNodes)}
-    >
-      <Icon className="w-4 h-4" icon="arrows-pointing-in" />
-    </div>
-  );
-};
-
 const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
   <>
     {fold?.title && (
@@ -164,7 +147,7 @@ const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
   </>
 );
 
-const NodeControl = ({ action, className, icon }: NodeControlProps) => {
+const NodeControl = ({ action, className, icon, title }: NodeControlProps) => {
   return (
     <div
       onClick={(e) => {
@@ -172,6 +155,7 @@ const NodeControl = ({ action, className, icon }: NodeControlProps) => {
         action && action();
       }}
       className={classNames(className, "p-1")}
+      title={title}
     >
       <Icon className="w-4 h-4" icon={icon} />
     </div>
@@ -186,12 +170,30 @@ const NodeControls = ({ children }: NodeControlsProps) => {
   );
 };
 
-const NodeGrabHandle = () => (
+const NodeGrabHandleControl = () => (
   <NodeControl
     className="custom-drag-handle cursor-grab"
     icon="cursor-arrow-ripple"
+    title="Move node"
   />
 );
+
+const RefoldNodeControl = ({
+  collapseNodes,
+  expandedNodeInfo,
+}: RefoldNodeControlProps) => {
+  if (!expandedNodeInfo) {
+    return null;
+  }
+  return (
+    <NodeControl
+      action={() => collapseNodes(expandedNodeInfo.foldedNodes)}
+      className="cursor-pointer"
+      icon="arrows-pointing-in"
+      title="Collapse node"
+    />
+  );
+};
 
 // <div className="custom-drag-handle absolute -left-[4%] -bottom-[4%] items-center bg-black-scale-2 p-1 rounded-full cursor-grab">
 //   <Icon className="w-4 h-4" icon="cursor-arrow-ripple" />
@@ -286,19 +288,17 @@ const AssetNode = ({
             color: color ? color : undefined,
           }}
           icon="plus"
-          title="Expand nodes"
         />
       )}
       {isFolded && <FoldedNodeCountBadge foldedNodes={foldedNodes} />}
-      {/*{isExpandedNode && (*/}
-      {/*  <FoldNodeIcon*/}
-      {/*    collapseNodes={collapseNodes}*/}
-      {/*    expandedNodeInfo={expandedNodes[id]}*/}
-      {/*  />*/}
-      {/*)}*/}
-      {/*{nodeGrabHandle}*/}
       <NodeControls>
-        <NodeGrabHandle />
+        {isExpandedNode && (
+          <RefoldNodeControl
+            collapseNodes={collapseNodes}
+            expandedNodeInfo={expandedNodes[id]}
+          />
+        )}
+        <NodeGrabHandleControl />
       </NodeControls>
     </div>
   );
@@ -354,6 +354,7 @@ const AssetNode = ({
           ? () => expandNode(foldedNodes, category?.name as string)
           : undefined
       }
+      title={isFolded ? "Expand nodes" : undefined}
     >
       {renderedHref && (
         <ExternalLink

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -6,6 +6,7 @@ import IntegerDisplay from "../../../IntegerDisplay";
 import RowProperties, { RowPropertiesTitle } from "./RowProperties";
 import Tooltip from "./Tooltip";
 import useChartThemeColors from "../../../../hooks/useChartThemeColors";
+import usePaginatedList from "../../../../hooks/usePaginatedList";
 import {
   Category,
   CategoryFields,
@@ -21,7 +22,6 @@ import { memo, useEffect, useMemo, useState } from "react";
 import { renderInterpolatedTemplates } from "../../../../utils/template";
 import { ThemeNames } from "../../../../hooks/useTheme";
 import { useDashboard } from "../../../../hooks/useDashboard";
-import usePaginatedList from "../../../../hooks/usePaginatedList";
 
 type AssetNodeProps = {
   id: string;
@@ -115,6 +115,7 @@ const FoldedNodeCountBadge = ({
   category,
   foldedNodes,
 }: FoldedNodeCountBadgeProps) => {
+  const { expandNode } = useGraph();
   if (!foldedNodes) {
     return null;
   }
@@ -128,7 +129,10 @@ const FoldedNodeCountBadge = ({
         />
       }
     >
-      <div className="absolute -right-[4%] -top-[4%] items-center bg-info text-white rounded-full px-1.5 text-sm font-medium cursor-pointer">
+      <div
+        className="absolute -right-[4%] -top-[4%] items-center bg-info text-white rounded-full px-1.5 text-sm font-medium cursor-pointer"
+        onClick={() => expandNode(foldedNodes, category?.name as string)}
+      >
         <IntegerDisplay num={foldedNodes?.length || null} />
       </div>
     </Tooltip>
@@ -153,23 +157,33 @@ const FoldNodeIcon = ({
   );
 };
 
-const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
-  <div className="flex space-x-1 items-center">
-    {fold?.title && (
-      <span className="text-link cursor-pointer truncate" title={fold?.title}>
-        {fold?.title}
-      </span>
-    )}
-    {!fold?.title && (
-      <span
-        className="text-link cursor-pointer truncate"
-        title={category?.name}
-      >
-        {category?.name}
-      </span>
-    )}
-  </div>
-);
+const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => {
+  const themeColors = useChartThemeColors();
+  return (
+    <div
+      className="flex space-x-1 items-center"
+      style={{
+        color: category?.color
+          ? getColorOverride(category.color, themeColors)
+          : null,
+      }}
+    >
+      {fold?.title && (
+        <span className="cursor-pointer truncate" title={fold?.title}>
+          {fold?.title}
+        </span>
+      )}
+      {!fold?.title && (
+        <span
+          className="text-link cursor-pointer truncate"
+          title={category?.name}
+        >
+          {category?.name}
+        </span>
+      )}
+    </div>
+  );
+};
 
 const AssetNode = ({
   id,

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -327,14 +327,6 @@ const AssetNode = ({
 
   const hasProperties = row_data && row_data.properties;
 
-  // 4 possible node states
-  // HREF  |  Folded  |  Properties  |  Controls
-  // ----------------------------------------
-  // false |  false   |  false       |  true
-  // false |  true    |  true        |  true
-  // true  |  false   |  false       |  true
-  // true  |  false   |  true        |  true
-
   const wrappedNode = (
     <div
       className={classNames(
@@ -365,6 +357,14 @@ const AssetNode = ({
       )}
     </div>
   );
+
+  // 4 possible node states
+  // HREF  |  Folded  |  Properties  |  Controls
+  // ----------------------------------------
+  // false |  false   |  false       |  true
+  // false |  true    |  true        |  true
+  // true  |  false   |  false       |  true
+  // true  |  false   |  true        |  true
 
   // Notes:
   // * The Handle elements seem to be required to allow the connectors to work.

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -203,10 +203,6 @@ const RefoldNodeControl = ({
   );
 };
 
-// <div className="custom-drag-handle absolute -left-[4%] -bottom-[4%] items-center bg-black-scale-2 p-1 rounded-full cursor-grab">
-//   <Icon className="w-4 h-4" icon="cursor-arrow-ripple" />
-// </div>
-
 const AssetNode = ({
   id,
   data: {
@@ -259,10 +255,10 @@ const AssetNode = ({
     doRender();
   }, [isFolded, href, row_data, setRenderedHref]);
 
-  const nodeIcon = (
+  const innerIcon = (
     <div
       className={classNames(
-        "relative p-3 rounded-full w-[50px] h-[50px] leading-[50px] my-0 mx-auto border"
+        "p-3 rounded-full w-[50px] h-[50px] leading-[50px] my-0 mx-auto border"
       )}
       style={{
         // backgroundColor: color,
@@ -283,6 +279,20 @@ const AssetNode = ({
         icon={isFolded ? fold?.icon : icon}
       />
       {isFolded && <FoldedNodeCountBadge foldedNodes={foldedNodes} />}
+    </div>
+  );
+
+  const nodeIcon = (
+    <div className="relative">
+      {!renderedHref && innerIcon}
+      {renderedHref && (
+        <ExternalLink
+          className="block flex flex-col items-center"
+          to={renderedHref}
+        >
+          {innerIcon}
+        </ExternalLink>
+      )}
       <NodeControls>
         {isExpandedNode && (
           <RefoldNodeControl
@@ -309,7 +319,7 @@ const AssetNode = ({
   //     node
   //   );
 
-  const nodeLabel = (
+  const innerNodeLabel = (
     <div
       className={classNames(
         renderedHref ? "text-link" : null,
@@ -325,12 +335,26 @@ const AssetNode = ({
     </div>
   );
 
+  const nodeLabel = (
+    <>
+      {!renderedHref && innerNodeLabel}
+      {renderedHref && (
+        <ExternalLink
+          className="block flex flex-col items-center"
+          to={renderedHref}
+        >
+          {innerNodeLabel}
+        </ExternalLink>
+      )}
+    </>
+  );
+
   const hasProperties = row_data && row_data.properties;
 
   const wrappedNode = (
     <div
       className={classNames(
-        "group relative h-[72px]",
+        "group relative h-[72px] flex flex-col items-center",
         renderedHref || isFolded ? "cursor-pointer" : "cursor-auto"
       )}
       onClick={
@@ -340,21 +364,8 @@ const AssetNode = ({
       }
       title={isFolded ? "Expand nodes" : undefined}
     >
-      {renderedHref && (
-        <ExternalLink
-          className="block flex flex-col items-center"
-          to={renderedHref}
-        >
-          {nodeIcon}
-          {nodeLabel}
-        </ExternalLink>
-      )}
-      {!renderedHref && (
-        <div className="flex flex-col items-center">
-          {nodeIcon}
-          {nodeLabel}
-        </div>
-      )}
+      {nodeIcon}
+      {nodeLabel}
     </div>
   );
 

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -18,7 +18,7 @@ import { classNames } from "../../../../utils/styles";
 import { ExpandedNodeInfo, useGraph } from "../common/useGraph";
 import { getColorOverride } from "../../common";
 import { Handle } from "reactflow";
-import { memo, useEffect, useMemo, useState } from "react";
+import { memo, ReactNode, useEffect, useMemo, useState } from "react";
 import { renderInterpolatedTemplates } from "../../../../utils/template";
 import { ThemeNames } from "../../../../hooks/useTheme";
 import { useDashboard } from "../../../../hooks/useDashboard";
@@ -41,7 +41,6 @@ type AssetNodeProps = {
 };
 
 type FoldedNodeCountBadgeProps = {
-  category: Category | undefined;
   foldedNodes: FoldedNode[] | undefined;
 };
 
@@ -62,6 +61,16 @@ type FoldedNodeTooltipTitleProps = {
 
 type FolderNodeTooltipNodesProps = {
   foldedNodes: FoldedNode[] | undefined;
+};
+
+type NodeControlProps = {
+  action?: () => void;
+  className?: string;
+  icon: string;
+};
+
+type NodeControlsProps = {
+  children: ReactNode | ReactNode[];
 };
 
 const FoldedNodeTooltipTitle = ({
@@ -111,31 +120,14 @@ const FolderNodeTooltipNodes = ({
   );
 };
 
-const FoldedNodeCountBadge = ({
-  category,
-  foldedNodes,
-}: FoldedNodeCountBadgeProps) => {
-  const { expandNode } = useGraph();
+const FoldedNodeCountBadge = ({ foldedNodes }: FoldedNodeCountBadgeProps) => {
   if (!foldedNodes) {
     return null;
   }
   return (
-    // <Tooltip
-    //   overlay={<FolderNodeTooltipNodes foldedNodes={foldedNodes} />}
-    //   title={
-    //     <FoldedNodeTooltipTitle
-    //       category={category}
-    //       foldedNodesCount={foldedNodes.length}
-    //     />
-    //   }
-    // >
-    <div
-      className="absolute -right-[4%] -top-[4%] items-center bg-info text-white rounded-full px-1.5 text-sm font-medium cursor-pointer"
-      onClick={() => expandNode(foldedNodes, category?.name as string)}
-    >
+    <div className="absolute -right-[4%] -top-[4%] items-center bg-info text-white rounded-full px-1.5 text-sm font-medium cursor-pointer">
       <IntegerDisplay num={foldedNodes?.length || null} />
     </div>
-    // </Tooltip>
   );
 };
 
@@ -172,11 +164,38 @@ const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
   </>
 );
 
-const NodeControls = () => {
+const NodeControl = ({ action, className, icon }: NodeControlProps) => {
   return (
-    <div className="invisible peer-hover:visible absolute -left-[4%] -bottom-[4%] items-center bg-black-scale-2 p-1 rounded-full cursor-grab"></div>
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        action && action();
+      }}
+      className={classNames(className, "p-1")}
+    >
+      <Icon className="w-4 h-4" icon={icon} />
+    </div>
   );
 };
+
+const NodeControls = ({ children }: NodeControlsProps) => {
+  return (
+    <div className="invisible group-hover:visible absolute -left-[10%] -bottom-[10%] flex flex-col space-y-px bg-dashboard text-foreground">
+      {children}
+    </div>
+  );
+};
+
+const NodeGrabHandle = () => (
+  <NodeControl
+    className="custom-drag-handle cursor-grab"
+    icon="cursor-arrow-ripple"
+  />
+);
+
+// <div className="custom-drag-handle absolute -left-[4%] -bottom-[4%] items-center bg-black-scale-2 p-1 rounded-full cursor-grab">
+//   <Icon className="w-4 h-4" icon="cursor-arrow-ripple" />
+// </div>
 
 const AssetNode = ({
   id,
@@ -230,12 +249,6 @@ const AssetNode = ({
     doRender();
   }, [isFolded, href, row_data, setRenderedHref]);
 
-  const nodeGrabHandle = (
-    <div className="custom-drag-handle absolute -left-[4%] -bottom-[4%] items-center bg-black-scale-2 p-1 rounded-full cursor-grab">
-      <Icon className="w-4 h-4" icon="cursor-arrow-ripple" />
-    </div>
-  );
-
   const nodeIcon = (
     <div
       className={classNames(
@@ -276,9 +289,7 @@ const AssetNode = ({
           title="Expand nodes"
         />
       )}
-      {isFolded && (
-        <FoldedNodeCountBadge category={category} foldedNodes={foldedNodes} />
-      )}
+      {isFolded && <FoldedNodeCountBadge foldedNodes={foldedNodes} />}
       {/*{isExpandedNode && (*/}
       {/*  <FoldNodeIcon*/}
       {/*    collapseNodes={collapseNodes}*/}
@@ -286,6 +297,9 @@ const AssetNode = ({
       {/*  />*/}
       {/*)}*/}
       {/*{nodeGrabHandle}*/}
+      <NodeControls>
+        <NodeGrabHandle />
+      </NodeControls>
     </div>
   );
 
@@ -301,30 +315,6 @@ const AssetNode = ({
   //     </div>
   //   ) : (
   //     node
-  //   );
-
-  // const nodeWithProperties =
-  //   row_data && row_data.properties && !isFolded ? (
-  //     <Tooltip
-  //       overlay={
-  //         <>
-  //           {row_data && row_data.properties && (
-  //             <RowProperties
-  //               fields={fields || null}
-  //               properties={row_data.properties}
-  //             />
-  //           )}
-  //         </>
-  //       }
-  //       title={<RowPropertiesTitle category={category} title={label} />}
-  //     >
-  //       {icon}
-  //       {/*<div className="cursor-pointer text-black-scale-5">*/}
-  //       {/*  <Icon className="w-4 h-4" icon="queue-list" />*/}
-  //       {/*</div>*/}
-  //     </Tooltip>
-  //   ) : (
-  //     icon
   //   );
 
   const nodeLabel = (
@@ -380,7 +370,6 @@ const AssetNode = ({
           {nodeLabel}
         </div>
       )}
-      <NodeControls />
     </div>
   );
 

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -120,22 +120,22 @@ const FoldedNodeCountBadge = ({
     return null;
   }
   return (
-    <Tooltip
-      overlay={<FolderNodeTooltipNodes foldedNodes={foldedNodes} />}
-      title={
-        <FoldedNodeTooltipTitle
-          category={category}
-          foldedNodesCount={foldedNodes.length}
-        />
-      }
+    // <Tooltip
+    //   overlay={<FolderNodeTooltipNodes foldedNodes={foldedNodes} />}
+    //   title={
+    //     <FoldedNodeTooltipTitle
+    //       category={category}
+    //       foldedNodesCount={foldedNodes.length}
+    //     />
+    //   }
+    // >
+    <div
+      className="absolute -right-[4%] -top-[4%] items-center bg-info text-white rounded-full px-1.5 text-sm font-medium cursor-pointer"
+      onClick={() => expandNode(foldedNodes, category?.name as string)}
     >
-      <div
-        className="absolute -right-[4%] -top-[4%] items-center bg-info text-white rounded-full px-1.5 text-sm font-medium cursor-pointer"
-        onClick={() => expandNode(foldedNodes, category?.name as string)}
-      >
-        <IntegerDisplay num={foldedNodes?.length || null} />
-      </div>
-    </Tooltip>
+      <IntegerDisplay num={foldedNodes?.length || null} />
+    </div>
+    // </Tooltip>
   );
 };
 
@@ -322,27 +322,43 @@ const AssetNode = ({
           : undefined
       }
     >
-      {isFolded && (
+      {!isFolded && (
         <span className="truncate" title={label}>
           {label}
         </span>
       )}
-      {!isFolded && <FoldedNodeLabel category={category} fold={fold} />}
-      {/*{!isFolded && renderedHref && (*/}
-      {/*  <ExternalLink className="truncate" to={renderedHref}>*/}
-      {/*    {label}*/}
-      {/*  </ExternalLink>*/}
-      {/*)}*/}
-      {/*{!renderedHref && (*/}
-      {/*  <>*/}
-      {/*    {!isFolded && (*/}
-      {/*      <span className="truncate" title={label}>*/}
-      {/*        {label}*/}
-      {/*      </span>*/}
-      {/*    )}*/}
-      {/*    {isFolded && <FoldedNodeLabel category={category} fold={fold} />}*/}
-      {/*  </>*/}
-      {/*)}*/}
+      {isFolded && <FoldedNodeLabel category={category} fold={fold} />}
+    </div>
+  );
+
+  const hasProperties = row_data && row_data.properties;
+
+  // 4 possible node states
+  // HREF  |  Folded  |  Properties  |  Controls
+  // ----------------------------------------
+  // false |  false   |  false       |  true
+  // false |  true    |  true        |  true
+  // true  |  false   |  false       |  true
+  // true  |  false   |  true        |  true
+
+  const wrappedNode = (
+    <div className="relative cursor-auto h-[72px]">
+      {renderedHref && (
+        <ExternalLink
+          className="block flex flex-col items-center"
+          to={renderedHref}
+        >
+          {nodeIcon}
+          {nodeLabel}
+        </ExternalLink>
+      )}
+      {!renderedHref && (
+        <div className="flex flex-col items-center">
+          {nodeIcon}
+          {nodeLabel}
+        </div>
+      )}
+      <NodeControls />
     </div>
   );
 
@@ -355,24 +371,34 @@ const AssetNode = ({
       {/*@ts-ignore*/}
       <Handle type="source" />
       {/*<div className="max-w-[50px]">{label}</div>*/}
-      <div className="relative cursor-auto h-[72px]">
-        {renderedHref && (
-          <ExternalLink
-            className="block flex flex-col items-center"
-            to={renderedHref}
-          >
-            {nodeIcon}
-            {nodeLabel}
-          </ExternalLink>
-        )}
-        {!renderedHref && (
-          <div className="flex flex-col items-center">
-            {nodeIcon}
-            {nodeLabel}
-          </div>
-        )}
-        <NodeControls />
-      </div>
+      {!hasProperties && !isFolded && wrappedNode}
+      {hasProperties && !isFolded && (
+        <Tooltip
+          overlay={
+            <RowProperties
+              fields={fields || null}
+              properties={row_data.properties}
+            />
+          }
+          title={<RowPropertiesTitle category={category} title={label} />}
+        >
+          {wrappedNode}
+        </Tooltip>
+      )}
+      {isFolded && (
+        <Tooltip
+          overlay={<FolderNodeTooltipNodes foldedNodes={foldedNodes} />}
+          title={
+            <FoldedNodeTooltipTitle
+              category={category}
+              // @ts-ignore
+              foldedNodesCount={foldedNodes.length}
+            />
+          }
+        >
+          {wrappedNode}
+        </Tooltip>
+      )}
     </>
   );
 };

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -251,6 +251,7 @@ const AssetNode = ({
       <DashboardIcon
         className={classNames(
           "max-w-full",
+          isFolded ? "group-hover:hidden" : null,
           iconType === "icon" && !color ? "text-foreground-lighter" : null,
           theme.name === ThemeNames.STEAMPIPE_DARK ? "brightness-[1.75]" : null
         )}
@@ -259,6 +260,22 @@ const AssetNode = ({
         }}
         icon={isFolded ? fold?.icon : icon}
       />
+      {isFolded && (
+        <DashboardIcon
+          className={classNames(
+            "hidden group-hover:block max-w-full",
+            iconType === "icon" && !color ? "text-foreground-lighter" : null
+            // theme.name === ThemeNames.STEAMPIPE_DARK
+            //   ? "brightness-[1.75]"
+            //   : null
+          )}
+          style={{
+            color: color ? color : undefined,
+          }}
+          icon="plus"
+          title="Expand nodes"
+        />
+      )}
       {isFolded && (
         <FoldedNodeCountBadge category={category} foldedNodes={foldedNodes} />
       )}
@@ -313,14 +330,9 @@ const AssetNode = ({
   const nodeLabel = (
     <div
       className={classNames(
-        renderedHref ? "text-link cursor-pointer" : null,
+        renderedHref ? "text-link" : null,
         "absolute flex space-x-1 truncate items-center bottom-0 px-1 text-sm mt-1 bg-dashboard-panel text-foreground whitespace-nowrap min-w-[35px] max-w-[150px]"
       )}
-      onClick={
-        isFolded && foldedNodes
-          ? () => expandNode(foldedNodes, category?.name as string)
-          : undefined
-      }
     >
       {!isFolded && (
         <span className="truncate" title={label}>
@@ -342,7 +354,17 @@ const AssetNode = ({
   // true  |  false   |  true        |  true
 
   const wrappedNode = (
-    <div className="relative cursor-auto h-[72px]">
+    <div
+      className={classNames(
+        "group relative h-[72px]",
+        renderedHref || isFolded ? "cursor-pointer" : "cursor-auto"
+      )}
+      onClick={
+        isFolded && foldedNodes
+          ? () => expandNode(foldedNodes, category?.name as string)
+          : undefined
+      }
+    >
       {renderedHref && (
         <ExternalLink
           className="block flex flex-col items-center"

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/AssetNode.tsx
@@ -157,31 +157,27 @@ const FoldNodeIcon = ({
   );
 };
 
-const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => {
-  const themeColors = useChartThemeColors();
+const FoldedNodeLabel = ({ category, fold }: FoldedNodeLabelProps) => (
+  <div className="flex space-x-1 items-center">
+    {fold?.title && (
+      <span className="cursor-pointer truncate" title={fold?.title}>
+        {fold?.title}
+      </span>
+    )}
+    {!fold?.title && (
+      <span
+        className="text-link cursor-pointer truncate"
+        title={category?.name}
+      >
+        {category?.name}
+      </span>
+    )}
+  </div>
+);
+
+const NodeControls = () => {
   return (
-    <div
-      className="flex space-x-1 items-center"
-      style={{
-        color: category?.color
-          ? getColorOverride(category.color, themeColors)
-          : null,
-      }}
-    >
-      {fold?.title && (
-        <span className="cursor-pointer truncate" title={fold?.title}>
-          {fold?.title}
-        </span>
-      )}
-      {!fold?.title && (
-        <span
-          className="text-link cursor-pointer truncate"
-          title={category?.name}
-        >
-          {category?.name}
-        </span>
-      )}
-    </div>
+    <div className="invisible peer-hover:visible absolute -left-[4%] -bottom-[4%] items-center bg-black-scale-2 p-1 rounded-full cursor-grab"></div>
   );
 };
 
@@ -237,10 +233,16 @@ const AssetNode = ({
     doRender();
   }, [isFolded, href, row_data, setRenderedHref]);
 
+  const nodeGrabHandle = (
+    <div className="custom-drag-handle absolute -left-[4%] -bottom-[4%] items-center bg-black-scale-2 p-1 rounded-full cursor-grab">
+      <Icon className="w-4 h-4" icon="cursor-arrow-ripple" />
+    </div>
+  );
+
   const node = (
     <div
       className={classNames(
-        "relative p-3 rounded-full w-[50px] h-[50px] leading-[50px] my-0 mx-auto border cursor-grab"
+        "relative p-3 rounded-full w-[50px] h-[50px] leading-[50px] my-0 mx-auto border"
       )}
       style={{
         // backgroundColor: color,
@@ -269,6 +271,7 @@ const AssetNode = ({
           expandedNodeInfo={expandedNodes[id]}
         />
       )}
+      {/*{nodeGrabHandle}*/}
     </div>
   );
 
@@ -322,7 +325,7 @@ const AssetNode = ({
           : undefined
       }
     >
-      {renderedHref && (
+      {!isFolded && renderedHref && (
         <ExternalLink className="truncate" to={renderedHref}>
           {label}
         </ExternalLink>
@@ -349,9 +352,12 @@ const AssetNode = ({
       {/*@ts-ignore*/}
       <Handle type="source" />
       {/*<div className="max-w-[50px]">{label}</div>*/}
-      <div className="relative flex flex-col items-center cursor-auto h-[72px]">
-        {nodeWithProperties}
-        {nodeLabel}
+      <div className="relative cursor-auto h-[72px]">
+        <div className="peer flex flex-col group items-center">
+          {nodeWithProperties}
+          {nodeLabel}
+        </div>
+        <NodeControls />
       </div>
     </>
   );

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -23,11 +23,7 @@ import {
   getColorOverride,
   LeafNodeData,
 } from "../../common";
-import {
-  CategoryMap,
-  KeyValueStringPairs,
-  Node as NodeType,
-} from "../../common/types";
+import { CategoryMap, Node as NodeType } from "../../common/types";
 import {
   CategoryStatus,
   GraphProperties,
@@ -36,8 +32,8 @@ import {
   NodeAndEdgeStatus,
 } from "../types";
 import { DashboardRunState } from "../../../../types";
+import { ExpandedNodes, GraphProvider, useGraph } from "../common/useGraph";
 import { getGraphComponent } from "..";
-import { GraphProvider, useGraph } from "../common/useGraph";
 import { registerComponent } from "../../index";
 import {
   ResetLayoutIcon,
@@ -58,7 +54,7 @@ const buildGraphNodesAndEdges = (
   data: LeafNodeData | undefined,
   properties: GraphProperties | undefined,
   themeColors: any,
-  expandedNodes: KeyValueStringPairs,
+  expandedNodes: ExpandedNodes,
   status: DashboardRunState
 ) => {
   if (!data) {

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -279,7 +279,7 @@ const useGraphNodesAndEdges = (
         expandedNodes,
         status
       ),
-    [data, expandedNodes, properties, status, themeColors]
+    [categories, data, expandedNodes, properties, status, themeColors]
   );
   return {
     nodesAndEdges,

--- a/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
+++ b/ui/dashboard/src/components/dashboards/graphs/Graph/index.tsx
@@ -111,6 +111,7 @@ const buildGraphNodesAndEdges = (
     }
     nodes.push({
       type: "asset",
+      dragHandle: ".custom-drag-handle",
       id: node.id,
       position: { x: matchingNode.x, y: matchingNode.y },
       // height: 70,

--- a/ui/dashboard/src/hooks/usePaginatedList.ts
+++ b/ui/dashboard/src/hooks/usePaginatedList.ts
@@ -1,10 +1,10 @@
 import { useEffect, useState } from "react";
 
-const usePaginatedList = (
-  items: any[] = [],
+function usePaginatedList<T>(
+  items: T[] = [],
   pageSize = 10,
   doubleOnExpand = true
-) => {
+) {
   const [allItems, setAllItems] = useState(items);
   const [visibleItems, setVisibleItems] = useState(items.slice(0, pageSize));
   const [nextPageSize, setNextPageSize] = useState(
@@ -32,6 +32,6 @@ const usePaginatedList = (
   };
 
   return { visibleItems, hasMore, loadMore };
-};
+}
 
 export default usePaginatedList;

--- a/ui/dashboard/src/hooks/usePaginatedList.ts
+++ b/ui/dashboard/src/hooks/usePaginatedList.ts
@@ -15,7 +15,7 @@ function usePaginatedList<T>(
     setAllItems(items);
     setVisibleItems(items.slice(0, pageSize));
     setNextPageSize(doubleOnExpand ? pageSize * 2 : pageSize);
-  }, [items]);
+  }, [doubleOnExpand, items, pageSize]);
 
   const hasMore = visibleItems.length < allItems.length;
 


### PR DESCRIPTION
- Clicking folded node label or icon will expand
- Show node control panel on hover
- Nodes are now only moveable from the controls shown on hover
- Show re-fold icon in node controls