### PR TITLE
Allow overriding build output path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+OUTPUT_DIR?=/usr/local/bin
 
 steampipe:
-	go build -o  /usr/local/bin/steampipe
+	go build -o ${OUTPUT_DIR}/steampipe
 
 dashboard_assets:
 	$(MAKE) -C ui/dashboard
@@ -8,4 +9,4 @@ dashboard_assets:
 all:
 	$(MAKE) -C pluginmanager
 	$(MAKE) -C ui/dashboard
-	go build -o  /usr/local/bin/steampipe
+	go build -o ${OUTPUT_DIR}/steampipe


### PR DESCRIPTION
Usage example:

```sh
# make OUTPUT_DIR=~/go/bin/
```
