### PR TITLE
Changes the serialization of NULL values in a CSV

### DIFF
--- a/pkg/display/column.go
+++ b/pkg/display/column.go
@@ -84,3 +84,11 @@ func ParseJSONOutputColumnValue(val interface{}, col *queryresult.ColumnDef) (in
 		return ColumnValueAsString(val, col)
 	}
 }
+
+func ParseCSVOutputColumnValue(val interface{}, col *queryresult.ColumnDef) (string, error) {
+	if val == nil {
+		return "", nil
+	}
+
+	return ColumnValueAsString(val, col)
+}

--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -278,7 +278,12 @@ func displayCSV(ctx context.Context, result *queryresult.Result) {
 	// print the data as it comes
 	// define function display each csv row
 	rowFunc := func(row []interface{}, result *queryresult.Result) {
-		rowAsString, _ := ColumnValuesAsString(row, result.Cols)
+		columns := result.Cols
+		rowAsString := make([]string, len(columns))
+		for idx, val := range row {
+			val, _ := ParseCSVOutputColumnValue(val, columns[idx])
+			rowAsString[idx] = val
+		}
 		_ = csvWriter.Write(rowAsString)
 	}
 


### PR DESCRIPTION
Fixes #2847

As discussed in the related issue, this PR offers the simplest change so that the CSV output of a query matches `psql`.
It fixes the general situation of NULL values, which used to be serialized as `<null>` and, with this PR, are now `` (empty string).

