### PR TITLE
Adds an 'sperr' error package along with sample implementation with the login cmd

### DIFF
--- a/design/sperr.md
+++ b/design/sperr.md
@@ -1,0 +1,299 @@
+New package `sperr`
+
+# `sperr.Error`
+
+An `sperr.Error` is a stateful object with a `StackTrace` till the point of creation with a stack depth of `32` (`32` picked OTA)
+
+`sperr.Error` satisfies the standard `error` interface.
+
+## Create `sperr.Error`:
+
+> **Note:** All `sperr.Error` factory functions return an `error` interface.
+
+### `sperr.New(format string, args interface{}...)`
+
+This is to be used when we want to create new `error` instances. Always carries a `StackTrace`. It is recommended that this function be called from the actual place of the error and not to create error.
+
+### `sperr.Wrap(err error, options Option...)`
+
+If the given `err` is not an `sperr.Error`, this wraps around `err` and creates an `sperr.Error` along with a `StackTrace`.
+
+Returns `nil` if `err` is `nil`. `Wrap` tries to infer a friendly message for the error and if the inference succeeded, it will set the friendly message as it's own message.
+
+### `sperr.WrapWithMessage(err error, format string, args ...interface{})`
+
+Wrap an `error` to create an `sperr.Error` and sets a formatted message to the `wrapper`.
+
+`WrapWithMessage` is functionally equivalent to `Wrap(err, WithMessage(format,args...))` - but maintains the proper call stack.
+
+### `sperr.WrapWithRootMessage(err error, format string, args ...interface{})`
+
+Wrap an `error` to create an `sperr.Error` and sets a formatted message to the `wrapper` along with the `root` flag.
+
+`WrapWithRootMessage` is functionally equivalent to `Wrap(err, WithRootMessage(format,args...))` - but maintains the proper call stack.
+
+### `sperr.ToError(val interface{})`
+
+This creates an `error` object from any available value.
+
+If `val` is an instance of `error`, `ToError` creates a wrapper around `val` and returns it. Otherwise, it creates a new error using the value of `fmt.Sprintf("%v", val)` as the message. In both the cases, `ToError` creates and includes a `StackTrace`.
+
+## Adding Options
+
+### `WithMessage(format string, args ...interface())`
+
+Sets the formatted string to `error` if the `message` property is `empty`. Otherwise creates a new `error` by wrapping around this `error` and sets the message on the `wrapper`.
+
+### `WithDetail(format string, args ...interface())`
+
+Sets the formatted string to the `error` if the `detail` property is `empty`. Otherwise creates a new `error` by wrapping around this `error` and sets the detail on the `wrapper`.
+
+### `WithRootMessage(format string, args ...interface())`
+
+Sets the given formatted string as the error message and hides all error under this error from the UI. Setting the message follows the same rules as `WithMessage`. The `root` flag is set on the `error` returned by `WithMessage`.
+
+### Using Options
+
+```
+sperr.Wrap(
+  err,
+  sperr.WithMessage("operation '%s' failed", operation),
+  sperr.WithDetail("argument: %d", input),
+)
+```
+
+## Printing errors
+
+`sperr.Error` objects implement the `Formatter` interface to facilitate serializing errors to `io.Writer` interfaces.
+
+Formatting verbs supported are:
+| | |
+|-----|----------|
+|`%s` | Print the error string |
+|`%v` | See `%s` |
+|`%+v`| `%v` along with the `detail` and `message` values of all the errors |
+|`%#v`| `%+v` along the stacktrace of the underlying leaf error. Overrides `%+v`. |
+|`%q` | Print the error string - double quoted and safely escaped with Go syntax |
+
+### Example
+
+Let's write up a minimal example program:
+
+```
+func readFile() error {
+  path := "/imaginary/path"
+  _, err := os.Open(path)
+  if err != nil {
+    return sperr.WrapWithRootMessage(err, "could not open file at %s", path)
+  }
+  return nil
+}
+
+func wrapWithMessageAndDetail() error {
+  err := readFile()
+
+  return sperr.Wrap(
+    err,
+    sperr.WithMessage("message from wrapWithMessageAndDetail"),
+    sperr.WithDetail("detail from wrapWithMessageAndDetail"),
+  )
+}
+
+showCaseErr := sperr.Wrap(
+  err,
+  sperr.WithMessage("message from main"),
+  sperr.WithDetail("detail from main"),
+)
+
+```
+
+Outputs of the `showCaseErr` in preceeding program would be:
+
+#### `%q`
+
+`"message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path : open /imaginary/path"`
+
+#### `%s` and `%v`
+
+`message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path : open /imaginary/path`
+
+#### `%+v`
+
+```
+message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path
+
+Details:
+message from main :: detail from main
+|-- message from wrapWithMessageAndDetail :: detail from wrapWithMessageAndDetail
+|-- could not open file at /imaginary/path
+|-- open /imaginary/path: no such file or directory
+```
+
+#### `%#v`
+
+```
+message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path : open /imaginary/path
+
+Details:
+message from main :: detail from main
+|-- message from wrapWithMessageAndDetail :: detail from wrapWithMessageAndDetail
+|-- could not open file at /imaginary/path : open /imaginary/path: no such file or directory
+
+Stack:
+main.readFile
+        /home/user/sandbox/main.go:83
+main.wrapWithMessageAndDetail
+        /home/user/sandbox/main.go:63
+main.addMsgAndDetailToError
+        /home/user/sandbox/main.go:53
+main.wrapErrorAndSetRootMessage
+        /home/user/sandbox/main.go:39
+main.main
+        /home/user/sandbox/main.go:33
+runtime.main
+        /usr/local/go/src/runtime/proc.go:250
+runtime.goexit
+        /usr/local/go/src/runtime/asm_arm64.s:1165
+```
+
+> Note: `%+#v` is functionally equivalent to `%#v`
+
+## Examples:
+
+Snippets from Steampipe code base:
+
+### Create a new `error`
+
+```
+dbState, err := GetState()
+if err != nil {
+  log.Println("[TRACE] Error while loading database state", err)
+  return err
+}
+if dbState != nil {
+  return sperr.New("cannot install db - a previous version of the Steampipe service is still running. To stop running services, use %s ", constants.Bold("steampipe service stop"))
+}
+```
+
+### Create `error` with `message` and `detail`
+
+```
+func validateData(data int) error {
+  if data > 10 {
+    return sperr.Wrap(
+      sperr.New("invalid argument: %d", data),
+      sperr.WithDetail("error occurred with %d argument", data),
+    )
+  }
+  return nil
+}
+```
+
+### Wrap an `error`
+
+```
+if err := json.Unmarshal(bytContent, &data); err != nil {
+  return nil, sperr.Wrap(err)
+}
+```
+
+### Wrap an `error` with a `message`
+
+```
+if err := json.Unmarshal(byteContent, &data); err != nil {
+  return nil, sperr.WrapWithMessage(err, "error unmarshalling file content in %s", filePath)
+}
+```
+
+or
+
+```
+if err := json.Unmarshal(byteContent, &data); err != nil {
+  return nil, sperr.Wrap(err, sperr.WithMessage("error unmarshalling file content in %s", filePath))
+}
+```
+
+### Wrap an `error` with `detail`
+
+```
+err := validateData(userInput.numAttacks)
+if err!= nil {
+  return sperr.Wrap(err, sperr.WithDetail("error occurred with %d argument", userInput.numAttacks))
+}
+```
+
+### Wrap an `error` with a message replacing the message of the original `error`
+
+```
+if _, err := installFDW(ctx, false); err != nil {
+	log.Printf("[TRACE] installFDW failed: %v", err)
+	return sperr.WrapWithRootMessage(err, "Update steampipe-postgres-fdw... FAILED!")
+}
+```
+
+or
+
+```
+if _, err := installFDW(ctx, false); err != nil {
+	log.Printf("[TRACE] installFDW failed: %v", err)
+	return sperr.Wrap(err, sperr.WithRootMessage("Update steampipe-postgres-fdw... FAILED!"))
+}
+```
+
+> Setting an error as the `root` error hides all errors below it from the user interface. They are not purged - just hidden from display when displaying error messages. When enumerating error `details`, the details of all errors in the stack are shown - including errors under a `root` error.
+
+### Convert `panic` recovery to an `error`
+
+```
+defer func() {
+  if r := recover(); r != nil {
+    err = sperr.ToError(r)
+  }
+}()
+```
+
+## Technicalities
+
+### Wrapping as necessary
+
+#### `Wrap`
+
+The package function `Wrap` wraps around a given `error` instance if and only if it is not an instance of `sperr.Error`. This effectively ensures that the return of `Wrap` is always an instance of `sperr.Error`.
+
+#### `WrapWithMessage`
+
+The package function `WrapWithMessage` **always** wraps around the `error` given to it. This is because `WrapWithMessage` always sets it's own message with the arguments provided.
+
+#### `WithMessage`
+
+`WithMessage` sets the internal `message` if it is empty. Otherwise, it will create a `wrapper` around it's instance and set the `message` on the `wrapper` and returns the `wrapper`. This ensures that `WithMessage` is never lossy - but only creates wrappers when necessary.
+
+#### `WithDetail`
+
+`WithDetail` behaves just like `WithMessage`, but on the `detail` property.
+
+#### Example:
+
+> ```
+> sperr.WrapWithMessage(
+>   sperr.Wrap(
+>     err,
+>     sperr.WithDetail("added detail"),
+>     sperr.WithMessage("error occurred with %d argument", intArgument),
+>   ),
+>   "error occurred"
+> )
+> ```
+>
+> Result:
+>
+> ```
+> Error {
+>   Error {
+>     err
+>     Message : "error occurred with 10 argument"
+>     Detail  : "added detail"
+>   }
+>   Message : "error occurred"
+> }
+> ```

--- a/pkg/cloud/api.go
+++ b/pkg/cloud/api.go
@@ -2,6 +2,8 @@ package cloud
 
 import (
 	"fmt"
+	"net/url"
+
 	"github.com/spf13/viper"
 	steampipecloud "github.com/turbot/steampipe-cloud-sdk-go"
 	"github.com/turbot/steampipe/pkg/constants"
@@ -22,6 +24,10 @@ func newSteampipeCloudClient(token string) *steampipecloud.APIClient {
 }
 
 func getLoginTokenConfirmUIUrl() string {
-	return fmt.Sprintf("https://%s/login/token", viper.GetString(constants.ArgCloudHost))
-
+	url := url.URL{
+		Scheme: "https",
+		Host:   viper.GetString(constants.ArgCloudHost),
+		Path:   "/login/token",
+	}
+	return url.String()
 }

--- a/pkg/cloud/cloud_metadata.go
+++ b/pkg/cloud/cloud_metadata.go
@@ -7,6 +7,7 @@ import (
 
 	steampipecloud "github.com/turbot/steampipe-cloud-sdk-go"
 	"github.com/turbot/steampipe/pkg/steampipeconfig"
+	"github.com/turbot/steampipe/sperr"
 )
 
 func GetCloudMetadata(ctx context.Context, workspaceDatabaseString, token string) (*steampipeconfig.CloudMetadata, error) {
@@ -14,7 +15,7 @@ func GetCloudMetadata(ctx context.Context, workspaceDatabaseString, token string
 
 	parts := strings.Split(workspaceDatabaseString, "/")
 	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid 'workspace-database' argument '%s' - must be either a connection string or in format <identity>/<workspace>", workspaceDatabaseString)
+		return nil, sperr.New("invalid 'workspace-database' argument '%s' - must be either a connection string or in format <identity>/<workspace>", workspaceDatabaseString)
 	}
 	identityHandle := parts[0]
 	workspaceHandle := parts[1]
@@ -22,7 +23,7 @@ func GetCloudMetadata(ctx context.Context, workspaceDatabaseString, token string
 	// get the identity
 	identity, _, err := client.Identities.Get(ctx, identityHandle).Execute()
 	if err != nil {
-		return nil, err
+		return nil, sperr.Wrap(err)
 	}
 
 	// get the workspace
@@ -34,7 +35,7 @@ func GetCloudMetadata(ctx context.Context, workspaceDatabaseString, token string
 	}
 
 	if err != nil {
-		return nil, err
+		return nil, sperr.Wrap(err)
 	}
 
 	workspaceHost := cloudWorkspace.GetHost()
@@ -42,12 +43,12 @@ func GetCloudMetadata(ctx context.Context, workspaceDatabaseString, token string
 
 	actor, _, err := client.Actors.Get(ctx).Execute()
 	if err != nil {
-		return nil, err
+		return nil, sperr.Wrap(err)
 	}
 
 	password, _, err := client.Users.GetDBPassword(ctx, actor.GetHandle()).Execute()
 	if err != nil {
-		return nil, err
+		return nil, sperr.Wrap(err)
 	}
 
 	connectionString := fmt.Sprintf("postgresql://%s:%s@%s-%s.%s:9193/%s", actor.Handle, password.Password, identityHandle, workspaceHandle, workspaceHost, databaseName)

--- a/pkg/cloud/workspace.go
+++ b/pkg/cloud/workspace.go
@@ -3,6 +3,8 @@ package cloud
 import (
 	"context"
 	"fmt"
+
+	"github.com/turbot/steampipe/sperr"
 )
 
 // GetUserWorkspaceHandle returns the handle of the user workspace
@@ -14,20 +16,20 @@ func GetUserWorkspaceHandle(ctx context.Context, token string) (string, error) {
 	client := newSteampipeCloudClient(token)
 	actor, _, err := client.Actors.Get(ctx).Execute()
 	if err != nil {
-		return "", err
+		return "", sperr.Wrap(err)
 	}
 	userHandler := actor.Handle
 	workspacesResponse, _, err := client.UserWorkspaces.List(ctx, userHandler).Execute()
 	if err != nil {
-		return "", err
+		return "", sperr.Wrap(err)
 	}
 	workspaces := workspacesResponse.GetItems()
 
 	if len(workspaces) == 0 {
-		return "", fmt.Errorf("snapshot-location is not specified and no workspaces exist for user %s", getActorName(actor))
+		return "", sperr.New("snapshot-location is not specified and no workspaces exist for user %s", getActorName(actor))
 	}
 	if len(workspaces) > 1 {
-		return "", fmt.Errorf("more than one workspace found for user %s", getActorName(actor))
+		return "", sperr.New("more than one workspace found for user %s", getActorName(actor))
 	}
 
 	workspaceHandle := fmt.Sprintf("%s/%s", actor.GetHandle(), workspaces[0].GetHandle())

--- a/sperr/doc.go
+++ b/sperr/doc.go
@@ -1,0 +1,12 @@
+package sperr
+
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively.
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.

--- a/sperr/error.go
+++ b/sperr/error.go
@@ -1,0 +1,151 @@
+package sperr
+
+import (
+	"fmt"
+	"io"
+	"strings"
+)
+
+type Error struct {
+	stack         *stack
+	cause         error
+	detail        string
+	message       string
+	isRootMessage bool
+}
+
+// RootCause will retrieves the underlying root error in the error stack
+// RootCause will recursively retrieve
+// the topmost error that does not have a cause, which is assumed to be
+// the original cause.
+func (e *Error) RootCause() error {
+	if e == nil {
+		return nil
+	}
+	type hasCause interface {
+		Cause() error
+	}
+	if e.cause == nil {
+		// return self if we don't have a cause
+		// I was created with New
+		return e
+	}
+	if cause, ok := e.cause.(hasCause); ok {
+		return cause.Cause()
+	}
+	return e.cause
+}
+
+// Cause returns the underlying cause of this error. Maybe <nil> if this was created with New
+func (e *Error) Cause() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+// Stack retrieves the stack trace of the absolute underlying sperr.Error
+func (e *Error) Stack() StackTrace {
+	if e == nil {
+		return nil
+	}
+	type hasStack interface {
+		Stack() StackTrace
+	}
+	if cause, ok := e.cause.(hasStack); ok {
+		return cause.Stack()
+	}
+	if e.stack == nil {
+		return StackTrace{}
+	}
+	return e.stack.StackTrace()
+}
+
+// Unwrap returns the immediately underlying error
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.cause
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	res := []string{}
+	if len(e.message) > 0 {
+		res = append(res, e.message)
+	}
+	if e.isRootMessage || e.cause == nil {
+		return e.message
+	}
+	if e.cause != nil && len(e.cause.Error()) > 0 {
+		res = append(res, e.cause.Error())
+	}
+	return strings.Join(res, ": ")
+}
+
+func (e *Error) Detail() string {
+	if e == nil {
+		return ""
+	}
+	res := []string{}
+	if len(e.detail) > 0 {
+		// if this is available - the underlying error will always be a sperr
+		res = append(res, fmt.Sprintf("%s :: %s", e.message, e.detail))
+	}
+	type hasDetail interface {
+		Detail() string
+	}
+	if e.cause != nil {
+		if asD, ok := e.cause.(hasDetail); ok {
+			res = append(res, asD.Detail())
+		} else {
+			res = append(res, e.Error(), e.cause.Error())
+		}
+	}
+	return strings.Join(res, "\n|-- ")
+}
+
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported:
+//
+//			%s    print the error. If the error has a Cause it will be
+//			      printed recursively.
+//			%v    see %s
+//			%+v   detailed format - includes messages and detail.
+//	    %#v   Each Frame of the error's StackTrace will be printed in detail.
+//		  %q		a double-quoted string safely escaped with Go syntax
+//
+// TODO: add Details for +
+func (e *Error) Format(s fmt.State, verb rune) {
+	if e == nil {
+		return
+	}
+	switch verb {
+	case 'v':
+		io.WriteString(s, e.Error())
+		io.WriteString(s, "\n")
+
+		printStack := s.Flag('#')
+		printDetail := printStack || s.Flag('+')
+
+		if printDetail {
+			io.WriteString(s, "\nDetails:\n")
+			io.WriteString(s, e.Detail())
+			io.WriteString(s, "\n")
+		}
+
+		if printStack {
+			io.WriteString(s, "\nStack:")
+			io.WriteString(s, fmt.Sprintf("%+v", e.Stack()))
+			io.WriteString(s, "\n")
+		}
+	case 's':
+		io.WriteString(s, e.Error())
+	case 'q':
+		// fallback to the standard %q for consistent escaping
+		fmt.Fprintf(s, "%q", e.Error())
+	}
+}

--- a/sperr/factory.go
+++ b/sperr/factory.go
@@ -1,0 +1,142 @@
+package sperr
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/turbot/go-kit/helpers"
+)
+
+// New creates a new sperr.Error with a stack
+// It is recommended that `New` be called from the place where the actual
+// error occurs and not do define errors.
+// This is because sperr.Error is a stateful construct which also
+// encapsulates the stacktrace at the time of creation.
+//
+// For converting generic errors to sperr.Error the recommended usage pattern
+// is sperr.Wrap or sperr.Wrapf
+func New(format string, args ...interface{}) error {
+	sperr := &Error{
+		message: fmt.Sprintf(format, args...),
+		stack:   callers(), // always has a stack
+	}
+	return sperr
+}
+
+// Wrap creates a new sperr.Error if the `error` that is being wrapped
+// is not an sperr.Error
+//
+// When wrapping an error this also adds a stacktrace into the new `Error` object
+func Wrap(err error, options ...Option) error {
+	if err == nil {
+		return nil
+	}
+	res := wrap(err, options...)
+	// if the error we wrapped was not an sperr,
+	// we need to set the stack
+	if _, ok := err.(*Error); !ok {
+		res.stack = callers()
+	}
+	return res
+}
+
+func WrapWithMessage(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	res := wrap(err, WithMessage(format, args...))
+	// if the error we wrapped was not an sperr,
+	// we need to set the stack
+	if _, ok := err.(*Error); !ok {
+		res.stack = callers()
+	}
+	return res
+}
+
+func WrapWithRootMessage(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	res := wrap(err, WithRootMessage(format, args...))
+	// if the error we wrapped was not an sperr,
+	// we need to set the stack
+	if _, ok := err.(*Error); !ok {
+		res.stack = callers()
+	}
+	return res
+}
+
+func ToError(val interface{}, options ...Option) error {
+	// we need to do a IsNil, since the value of the interface may be nil
+	// and not the interface itself
+	if helpers.IsNil(val) {
+		return nil
+	}
+	var res *Error
+
+	if e, ok := val.(error); ok {
+		res = Wrap(e, options...).(*Error)
+	} else {
+		res = New("%v", val).(*Error)
+	}
+	for _, opt := range options {
+		res = opt(res)
+	}
+	// if the error we wrapped was not an sperr,
+	// we need to set the stack
+	if _, ok := val.(*Error); !ok {
+		res.stack = callers()
+	}
+	return res
+}
+
+// err MUST be non-nil
+func wrap(err error, options ...Option) *Error {
+	// we know err will always be non-nil - callers need to make sure of that
+	var e *Error
+	if x, ok := err.(*Error); ok {
+		e = x
+	} else {
+		msg := inferMessageFromError(err)
+		// hide the child error if we could infer a message from the error
+		isRoot := len(msg) > 0
+		return &Error{
+			cause:         err,
+			message:       msg,
+			isRootMessage: isRoot,
+			// do not set the stack here. We need rely on the calling function
+			// to set the stack so that the call stack remains clean
+		}
+	}
+	for _, opt := range options {
+		e = opt(e)
+	}
+	return e
+}
+
+func inferMessageFromError(err error) string {
+	constructedMsg := ""
+	// if this is one of the errors from the SQL stdlib
+	if errors.Is(err, sql.ErrConnDone) ||
+		errors.Is(err, sql.ErrNoRows) ||
+		errors.Is(err, sql.ErrTxDone) {
+		// all of these errors are errors.New with a string argument all prefixed with 'sql: '
+		constructedMsg = strings.TrimPrefix(err.Error(), "sql:")
+	}
+
+	// Errors we need to wrap around and produce beautiful messages
+	// context.DeadlineExceeded
+	// context.TimeoutExceeded
+	// sql.ErrConnDone
+	// sql.ErrNoRows
+	// sql.ErrTxDone
+	// plugin.ErrChecksumsDoNotMatch
+	// plugin.ErrProcessNotFound
+	// plugin.ErrSecureConfigAndReattach
+	// plugin.ErrSecureConfigNoChecksum
+	// plugin.ErrSecureConfigNoHash
+
+	return strings.TrimSpace(constructedMsg)
+}

--- a/sperr/option.go
+++ b/sperr/option.go
@@ -1,0 +1,47 @@
+package sperr
+
+import "fmt"
+
+type Option func(e *Error) *Error
+
+func WithDetail(format string, args ...interface{}) Option {
+	return func(e *Error) *Error {
+		if e == nil {
+			return nil
+		}
+		res := e
+		// if there's a detail, wrap this error and set the detail the new error
+		if len(e.detail) > 0 {
+			res = &Error{
+				cause: e,
+			}
+		}
+		res.detail = fmt.Sprintf(format, args...)
+		return res
+	}
+}
+
+func WithMessage(format string, args ...interface{}) Option {
+	return func(e *Error) *Error {
+		if e == nil {
+			return nil
+		}
+		res := e
+		// if there's a message, wrap this error and set the message on the new error
+		if len(e.message) > 0 {
+			res = &Error{
+				cause: e,
+			}
+		}
+		res.message = fmt.Sprintf(format, args...)
+		return res
+	}
+}
+
+func WithRootMessage(format string, args ...interface{}) Option {
+	return func(e *Error) *Error {
+		e = WithMessage(format, args...)(e)
+		e.isRootMessage = true
+		return e
+	}
+}

--- a/sperr/stack.go
+++ b/sperr/stack.go
@@ -1,0 +1,177 @@
+package sperr
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+// For historical reasons if Frame is interpreted as a uintptr
+// its value represents the program counter + 1.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// name returns the name of this function, if known.
+func (f Frame) name() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	return fn.Name()
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//	%s    source file
+//	%d    source line
+//	%n    function name
+//	%v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//	%+s   function name and path of source file relative to the compile time
+//	      GOPATH separated by \n\t (<funcname>\n\t<path>)
+//	%+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			io.WriteString(s, f.name())
+			io.WriteString(s, "\n\t")
+			io.WriteString(s, f.file())
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		io.WriteString(s, strconv.Itoa(f.line()))
+	case 'n':
+		io.WriteString(s, funcname(f.name()))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// MarshalText formats a stacktrace Frame as a text string. The output is the
+// same as that of fmt.Sprintf("%+v", f), but without newlines or tabs.
+func (f Frame) MarshalText() ([]byte, error) {
+	name := f.name()
+	if name == "unknown" {
+		return []byte(name), nil
+	}
+	return []byte(fmt.Sprintf("%s %s:%d", name, f.file(), f.line())), nil
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+// Format formats the stack of Frames according to the fmt.Formatter interface.
+//
+//	%s	lists source files for each Frame in the stack
+//	%v	lists the source file and line number for each Frame in the stack
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//	%+v   Prints filename, function, and line number for each Frame in the stack.
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				io.WriteString(s, "\n")
+				f.Format(s, verb)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			st.formatSlice(s, verb)
+		}
+	case 's':
+		st.formatSlice(s, verb)
+	}
+}
+
+// formatSlice will format this StackTrace into the given buffer as a slice of
+// Frame, only valid when called with '%s' or '%v'.
+func (st StackTrace) formatSlice(s fmt.State, verb rune) {
+	io.WriteString(s, "[")
+	for i, f := range st {
+		if i > 0 {
+			io.WriteString(s, " ")
+		}
+		f.Format(s, verb)
+	}
+	io.WriteString(s, "]")
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}


### PR DESCRIPTION
New package `sperr`

# `sperr.Error`

An `sperr.Error` is a stateful object with a `StackTrace` till the point of creation with a stack depth of `32` (`32` picked OTA)

`sperr.Error` satisfies the standard `error` interface.

## Create `sperr.Error`:

> **Note:** All `sperr.Error` factory functions return an `error` interface.

### `sperr.New(format string, args interface{}...)`

This is to be used when we want to create new `error` instances. Always carries a `StackTrace`. It is recommended that this function be called from the actual place of the error and not to create error.

### `sperr.Wrap(err error, options Option...)`

If the given `err` is not an `sperr.Error`, this wraps around `err` and creates an `sperr.Error` along with a `StackTrace`.

Returns `nil` if `err` is `nil`. `Wrap` tries to infer a friendly message for the error and if the inference succeeded, it will set the friendly message as it's own message.

### `sperr.WrapWithMessage(err error, format string, args ...interface{})`

Wrap an `error` to create an `sperr.Error` and sets a formatted message to the `wrapper`.

`WrapWithMessage` is functionally equivalent to `Wrap(err, WithMessage(format,args...))` - but maintains the proper call stack.

### `sperr.WrapWithRootMessage(err error, format string, args ...interface{})`

Wrap an `error` to create an `sperr.Error` and sets a formatted message to the `wrapper` along with the `root` flag.

`WrapWithRootMessage` is functionally equivalent to `Wrap(err, WithRootMessage(format,args...))` - but maintains the proper call stack.

### `sperr.ToError(val interface{})`

This creates an `error` object from any available value.

If `val` is an instance of `error`, `ToError` creates a wrapper around `val` and returns it. Otherwise, it creates a new error using the value of `fmt.Sprintf("%v", val)` as the message. In both the cases, `ToError` creates and includes a `StackTrace`.

## Adding Options

### `WithMessage(format string, args ...interface())`

Sets the formatted string to `error` if the `message` property is `empty`. Otherwise creates a new `error` by wrapping around this `error` and sets the message on the `wrapper`.

### `WithDetail(format string, args ...interface())`

Sets the formatted string to the `error` if the `detail` property is `empty`. Otherwise creates a new `error` by wrapping around this `error` and sets the detail on the `wrapper`.

### `WithRootMessage(format string, args ...interface())`

Sets the given formatted string as the error message and hides all error under this error from the UI. Setting the message follows the same rules as `WithMessage`. The `root` flag is set on the `error` returned by `WithMessage`.

### Using Options

```
sperr.Wrap(
  err,
  sperr.WithMessage("operation '%s' failed", operation),
  sperr.WithDetail("argument: %d", input),
)
```

## Printing errors

`sperr.Error` objects implement the `Formatter` interface to facilitate serializing errors to `io.Writer` interfaces.

Formatting verbs supported are:
| | |
|-----|----------|
|`%s` | Print the error string |
|`%v` | See `%s` |
|`%+v`| `%v` along with the `detail` and `message` values of all the errors |
|`%#v`| `%+v` along the stacktrace of the underlying leaf error. Overrides `%+v`. |
|`%q` | Print the error string - double quoted and safely escaped with Go syntax |

### Example

Let's write up a minimal example program:

```
func readFile() error {
  path := "/imaginary/path"
  _, err := os.Open(path)
  if err != nil {
    return sperr.WrapWithRootMessage(err, "could not open file at %s", path)
  }
  return nil
}

func wrapWithMessageAndDetail() error {
  err := readFile()

  return sperr.Wrap(
    err,
    sperr.WithMessage("message from wrapWithMessageAndDetail"),
    sperr.WithDetail("detail from wrapWithMessageAndDetail"),
  )
}

showCaseErr := sperr.Wrap(
  err,
  sperr.WithMessage("message from main"),
  sperr.WithDetail("detail from main"),
)

```

Outputs of the `showCaseErr` in preceeding program would be:

#### `%q`

`"message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path : open /imaginary/path"`

#### `%s` and `%v`

`message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path : open /imaginary/path`

#### `%+v`

```
message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path

Details:
message from main :: detail from main
|-- message from wrapWithMessageAndDetail :: detail from wrapWithMessageAndDetail
|-- could not open file at /imaginary/path
|-- open /imaginary/path: no such file or directory
```

#### `%#v`

```
message from main : message from wrapWithMessageAndDetail : could not open file at /imaginary/path : open /imaginary/path

Details:
message from main :: detail from main
|-- message from wrapWithMessageAndDetail :: detail from wrapWithMessageAndDetail
|-- could not open file at /imaginary/path : open /imaginary/path: no such file or directory

Stack:
main.readFile
        /home/user/sandbox/main.go:83
main.wrapWithMessageAndDetail
        /home/user/sandbox/main.go:63
main.addMsgAndDetailToError
        /home/user/sandbox/main.go:53
main.wrapErrorAndSetRootMessage
        /home/user/sandbox/main.go:39
main.main
        /home/user/sandbox/main.go:33
runtime.main
        /usr/local/go/src/runtime/proc.go:250
runtime.goexit
        /usr/local/go/src/runtime/asm_arm64.s:1165
```

> Note: `%+#v` is functionally equivalent to `%#v`

## Examples:

Snippets from Steampipe code base:

### Create a new `error`

```
dbState, err := GetState()
if err != nil {
  log.Println("[TRACE] Error while loading database state", err)
  return err
}
if dbState != nil {
  return sperr.New("cannot install db - a previous version of the Steampipe service is still running. To stop running services, use %s ", constants.Bold("steampipe service stop"))
}
```

### Create `error` with `message` and `detail`

```
func validateData(data int) error {
  if data > 10 {
    return sperr.Wrap(
      sperr.New("invalid argument: %d", data),
      sperr.WithDetail("error occurred with %d argument", data),
    )
  }
  return nil
}
```

### Wrap an `error`

```
if err := json.Unmarshal(bytContent, &data); err != nil {
  return nil, sperr.Wrap(err)
}
```

### Wrap an `error` with a `message`

```
if err := json.Unmarshal(byteContent, &data); err != nil {
  return nil, sperr.WrapWithMessage(err, "error unmarshalling file content in %s", filePath)
}
```

or

```
if err := json.Unmarshal(byteContent, &data); err != nil {
  return nil, sperr.Wrap(err, sperr.WithMessage("error unmarshalling file content in %s", filePath))
}
```

### Wrap an `error` with `detail`

```
err := validateData(userInput.numAttacks)
if err!= nil {
  return sperr.Wrap(err, sperr.WithDetail("error occurred with %d argument", userInput.numAttacks))
}
```

### Wrap an `error` with a message replacing the message of the original `error`

```
if _, err := installFDW(ctx, false); err != nil {
	log.Printf("[TRACE] installFDW failed: %v", err)
	return sperr.WrapWithRootMessage(err, "Update steampipe-postgres-fdw... FAILED!")
}
```

or

```
if _, err := installFDW(ctx, false); err != nil {
	log.Printf("[TRACE] installFDW failed: %v", err)
	return sperr.Wrap(err, sperr.WithRootMessage("Update steampipe-postgres-fdw... FAILED!"))
}
```

> Setting an error as the `root` error hides all errors below it from the user interface. They are not purged - just hidden from display when displaying error messages. When enumerating error `details`, the details of all errors in the stack are shown - including errors under a `root` error.

### Convert `panic` recovery to an `error`

```
defer func() {
  if r := recover(); r != nil {
    err = sperr.ToError(r)
  }
}()
```

## Technicalities

### Wrapping as necessary

#### `Wrap`

The package function `Wrap` wraps around a given `error` instance if and only if it is not an instance of `sperr.Error`. This effectively ensures that the return of `Wrap` is always an instance of `sperr.Error`.

#### `WrapWithMessage`

The package function `WrapWithMessage` **always** wraps around the `error` given to it. This is because `WrapWithMessage` always sets it's own message with the arguments provided.

#### `WithMessage`

`WithMessage` sets the internal `message` if it is empty. Otherwise, it will create a `wrapper` around it's instance and set the `message` on the `wrapper` and returns the `wrapper`. This ensures that `WithMessage` is never lossy - but only creates wrappers when necessary.

#### `WithDetail`

`WithDetail` behaves just like `WithMessage`, but on the `detail` property.

#### Example:

> ```
> sperr.WrapWithMessage(
>   sperr.Wrap(
>     err,
>     sperr.WithDetail("added detail"),
>     sperr.WithMessage("error occurred with %d argument", intArgument),
>   ),
>   "error occurred"
> )
> ```
>
> Result:
>
> ```
> Error {
>   Error {
>     err
>     Message : "error occurred with 10 argument"
>     Detail  : "added detail"
>   }
>   Message : "error occurred"
> }
> ```
