### PR TITLE
Show the exported file location when --progress flag is enabled

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -137,6 +137,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 	client := initData.Client
 	totalAlarms, totalErrors := 0, 0
 	var durations []time.Duration
+	var exportMsg []string
 
 	shouldShare := viper.GetBool(constants.ArgShare)
 	shouldUpload := viper.GetBool(constants.ArgSnapshot)
@@ -168,7 +169,7 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 		exportName := parsedName.ToFullNameWithMod(w.Mod.ShortName)
 
 		exportArgs := viper.GetStringSlice(constants.ArgExport)
-		err = initData.ExportManager.DoExport(ctx, exportName, executionTree, exportArgs)
+		exportMsg, err = initData.ExportManager.DoExport(ctx, exportName, executionTree, exportArgs)
 		error_helpers.FailOnError(err)
 
 		// if the share args are set, create a snapshot and share it
@@ -185,6 +186,13 @@ func runCheckCmd(cmd *cobra.Command, args []string) {
 
 	if shouldPrintTiming() {
 		printTiming(args, durations)
+	}
+
+	// print the location where the file is exported if progress=true
+	if len(exportMsg) > 0 && viper.GetBool(constants.ArgProgress) {
+		fmt.Printf("\n")
+		fmt.Println(strings.Join(exportMsg, "\n"))
+		fmt.Printf("\n")
 	}
 
 	// set the defined exit code after successful execution

--- a/cmd/dashboard.go
+++ b/cmd/dashboard.go
@@ -304,8 +304,15 @@ func runSingleDashboard(ctx context.Context, targetName string, inputs map[strin
 
 	// export the result (if needed)
 	exportArgs := viper.GetStringSlice(constants.ArgExport)
-	err = initData.ExportManager.DoExport(ctx, snap.FileNameRoot, snap, exportArgs)
+	exportMsg, err := initData.ExportManager.DoExport(ctx, snap.FileNameRoot, snap, exportArgs)
 	error_helpers.FailOnErrorWithMessage(err, "failed to export snapshot")
+
+	// print the location where the file is exported
+	if len(exportMsg) > 0 && viper.GetBool(constants.ArgProgress) {
+		fmt.Printf("\n")
+		fmt.Println(strings.Join(exportMsg, "\n"))
+		fmt.Printf("\n")
+	}
 
 	return nil
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -253,8 +253,14 @@ func executeSnapshotQuery(initData *query.InitData, ctx context.Context) int {
 
 			// export the result if necessary
 			exportArgs := viper.GetStringSlice(constants.ArgExport)
-			err = initData.ExportManager.DoExport(ctx, snap.FileNameRoot, snap, exportArgs)
+			exportMsg, err := initData.ExportManager.DoExport(ctx, snap.FileNameRoot, snap, exportArgs)
 			error_helpers.FailOnErrorWithMessage(err, "failed to export snapshot")
+			// print the location where the file is exported
+			if len(exportMsg) > 0 && viper.GetBool(constants.ArgProgress) {
+				fmt.Printf("\n")
+				fmt.Println(strings.Join(exportMsg, "\n"))
+				fmt.Printf("\n")
+			}
 		}
 	}
 	return 0

--- a/pkg/export/manager.go
+++ b/pkg/export/manager.go
@@ -132,23 +132,29 @@ func (m *Manager) getExportTarget(export, executionName string) (*Target, error)
 	return nil, fmt.Errorf("formatter satisfying '%s' not found", export)
 }
 
-func (m *Manager) DoExport(ctx context.Context, targetName string, source ExportSourceData, exports []string) error {
+func (m *Manager) DoExport(ctx context.Context, targetName string, source ExportSourceData, exports []string) ([]string, error) {
+	var errors []error
+	var msg string
+	var expLocation []string
+
 	if len(exports) == 0 {
-		return nil
+		return nil, nil
 	}
 
 	targets, err := m.resolveTargetsFromArgs(exports, targetName)
+
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	var errors []error
 	for _, target := range targets {
-		if err := target.Export(ctx, source); err != nil {
+		if msg, err = target.Export(ctx, source); err != nil {
 			errors = append(errors, err)
+		} else {
+			expLocation = append(expLocation, msg)
 		}
 	}
-	return error_helpers.CombineErrors(errors...)
+	return expLocation, error_helpers.CombineErrors(errors...)
 }
 
 func (m *Manager) ValidateExportFormat(exports []string) error {

--- a/pkg/export/target.go
+++ b/pkg/export/target.go
@@ -1,12 +1,22 @@
 package export
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"os"
+)
 
 type Target struct {
 	exporter Exporter
 	filePath string
 }
 
-func (t *Target) Export(ctx context.Context, input ExportSourceData) error {
-	return t.exporter.Export(ctx, input, t.filePath)
+func (t *Target) Export(ctx context.Context, input ExportSourceData) (string, error) {
+	err := t.exporter.Export(ctx, input, t.filePath)
+	if err != nil {
+		return "", err
+	} else {
+		pwd, _ := os.Getwd()
+		return fmt.Sprintf("File exported to %s/%s", pwd, t.filePath), nil
+	}
 }


### PR DESCRIPTION
`--progress=true`
```
➜  steampipe ✗ steampipe query query.query_1 --mod-location tests/acceptance/test_data/functionality_test_mod --export sps
+--------+-----------+------------------+
| status | resource  | reason           |
+--------+-----------+------------------+
| ok     | steampipe | acceptance tests |
+--------+-----------+------------------+

File exported to /Users/pskrbasu/dev/steampipe/functionality_test_mod.query.query_1.20230124T191545.sps
```

```
➜  steampipe ✗ steampipe check control.ok_1 --mod-location tests/acceptance/test_data/functionality_test_mod --export csv --export json

+ Control to verify the exit code when no controls are in error/alarm ...................................................................................................... HIGH 0 / 1 [==========]
  | 
  OK   : acceptance tests 
  
Summary

OK .................................................................................................................................................................................. 1 [==========]
SKIP ................................................................................................................................................................................ 0 [          ]
INFO ................................................................................................................................................................................ 0 [          ]
ALARM ............................................................................................................................................................................... 0 [          ]
ERROR ............................................................................................................................................................................... 0 [          ]

HIGH ............................................................................................................................................................................ 0 / 1 [==========]

TOTAL ........................................................................................................................................................................... 0 / 1 [==========]

File exported to /Users/pskrbasu/dev/steampipe/functionality_test_mod.control.ok_1.20230124T192225.csv
File exported to /Users/pskrbasu/dev/steampipe/functionality_test_mod.control.ok_1.20230124T192225.json
```

```
➜  steampipe ✗ steampipe dashboard dashboard.sibling_containers_report --mod-location tests/acceptance/test_data/dashboard_sibling_containers --export sps --output none

File exported to /Users/pskrbasu/dev/steampipe/sibling_containers_report.dashboard.sibling_containers_report.20230124T193422.sps
```

`-progress=false`
```
➜  steampipe ✗ steampipe check control.ok_1 --mod-location tests/acceptance/test_data/functionality_test_mod --export csv --export json --progress=false

+ Control to verify the exit code when no controls are in error/alarm ...................................................................................................... HIGH 0 / 1 [==========]
  | 
  OK   : acceptance tests 
  
Summary

OK .................................................................................................................................................................................. 1 [==========]
SKIP ................................................................................................................................................................................ 0 [          ]
INFO ................................................................................................................................................................................ 0 [          ]
ALARM ............................................................................................................................................................................... 0 [          ]
ERROR ............................................................................................................................................................................... 0 [          ]

HIGH ............................................................................................................................................................................ 0 / 1 [==========]

TOTAL ........................................................................................................................................................................... 0 / 1 [==========]
```