### PR TITLE
Add a helpful error message when snapshot sharing fails because of a corrupted/invalid token. Closes #2944

### DIFF
--- a/pkg/cloud/workspace.go
+++ b/pkg/cloud/workspace.go
@@ -16,11 +16,8 @@ import (
 func GetUserWorkspaceHandle(ctx context.Context, token string) (string, error) {
 	client := newSteampipeCloudClient(token)
 	actor, _, err := client.Actors.Get(ctx).Execute()
-	if err.Error() == "400 Bad Request" {
-		return "", fmt.Errorf("Invalid token.\nPlease run %s or setup a token.", constants.Bold(fmt.Sprintf("steampipe login")))
-	}
 	if err != nil {
-		return "", sperr.Wrap(err)
+		return "", sperr.WrapWithMessage(err, fmt.Sprintf("Invalid token.\nPlease run %s or setup a token.", constants.Bold("steampipe login")))
 	}
 	userHandler := actor.Handle
 	workspacesResponse, _, err := client.UserWorkspaces.List(ctx, userHandler).Execute()

--- a/pkg/cloud/workspace.go
+++ b/pkg/cloud/workspace.go
@@ -17,7 +17,7 @@ func GetUserWorkspaceHandle(ctx context.Context, token string) (string, error) {
 	client := newSteampipeCloudClient(token)
 	actor, _, err := client.Actors.Get(ctx).Execute()
 	if err != nil {
-		return "", sperr.WrapWithMessage(err, fmt.Sprintf("Invalid token.\nPlease run %s or setup a token.", constants.Bold("steampipe login")))
+		return "", sperr.New(fmt.Sprintf("Invalid token.\nPlease run %s or setup a token.", constants.Bold("steampipe login")))
 	}
 	userHandler := actor.Handle
 	workspacesResponse, _, err := client.UserWorkspaces.List(ctx, userHandler).Execute()

--- a/pkg/cloud/workspace.go
+++ b/pkg/cloud/workspace.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/turbot/steampipe/pkg/constants"
 	"github.com/turbot/steampipe/sperr"
 )
 
@@ -15,6 +16,9 @@ import (
 func GetUserWorkspaceHandle(ctx context.Context, token string) (string, error) {
 	client := newSteampipeCloudClient(token)
 	actor, _, err := client.Actors.Get(ctx).Execute()
+	if err.Error() == "400 Bad Request" {
+		return "", fmt.Errorf("Invalid token.\nPlease run %s or setup a token.", constants.Bold(fmt.Sprintf("steampipe login")))
+	}
 	if err != nil {
 		return "", sperr.Wrap(err)
 	}

--- a/pkg/error_helpers/errors.go
+++ b/pkg/error_helpers/errors.go
@@ -1,5 +1,9 @@
 package error_helpers
 
-import "errors"
+import (
+	"fmt"
 
-var MissingCloudTokenError = errors.New("Not authenticated for Steampipe Cloud.\nPlease run 'steampipe login' or setup a token.")
+	"github.com/turbot/steampipe/pkg/constants"
+)
+
+var MissingCloudTokenError = fmt.Errorf("Not authenticated for Steampipe Cloud.\nPlease run %s or setup a token.", constants.Bold("steampipe login"))


### PR DESCRIPTION
![Screenshot 2023-01-25 at 6 14 24 PM](https://user-images.githubusercontent.com/45908484/214566521-dd240d71-be58-4791-a56a-eb2dd5927569.png)
