### PR TITLE
When running a dashboard from a dependent mod, default var vals are not included in the snapshot. Closes #2730

### DIFF
--- a/pkg/dashboard/dashboardexecute/referenced_variables.go
+++ b/pkg/dashboard/dashboardexecute/referenced_variables.go
@@ -16,6 +16,11 @@ func GetReferencedVariables(root dashboardtypes.DashboardTreeRun, w *workspace.W
 			parts := strings.Split(ref.To, ".")
 			if len(parts) == 2 && parts[0] == "var" {
 				varName := parts[1]
+				// NOTE: if the ref is NOT for the workspace mod, then use the fully qualifed name
+				if refMod := ref.GetMetadata().ModName; refMod != w.Mod.Name() {
+					// NOTE: for variables we use "var" in the full name, not the block name "variable
+					varName = modconfig.BuildFullResourceName(refMod, "var", varName)
+				}
 				referencedVariables[varName] = w.VariableValues[varName]
 			}
 		}


### PR DESCRIPTION
…ot included in the snapshot. Closes #2730