### PR TITLE
Tweaks to service startup

### DIFF
--- a/pkg/cmdconfig/diagnostics.go
+++ b/pkg/cmdconfig/diagnostics.go
@@ -3,13 +3,14 @@ package cmdconfig
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"sort"
+	"strings"
+
 	"github.com/spf13/viper"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/pkg/constants"
 	"github.com/turbot/steampipe/pkg/error_helpers"
-	"os"
-	"sort"
-	"strings"
 )
 
 // DisplayConfig prints all config set via WorkspaceProfile or HCL options
@@ -42,6 +43,8 @@ func DisplayConfig() {
 		constants.ArgListenAddress,
 		constants.ArgSearchPath,
 		constants.ArgDatabaseQueryTimeout,
+		constants.ArgServiceRecoveryTimeout,
+		constants.ArgServiceConnectionTimeout,
 		// general
 		constants.ArgUpdateCheck,
 		constants.ArgMaxParallel,

--- a/pkg/cmdconfig/diagnostics.go
+++ b/pkg/cmdconfig/diagnostics.go
@@ -43,7 +43,7 @@ func DisplayConfig() {
 		constants.ArgListenAddress,
 		constants.ArgSearchPath,
 		constants.ArgDatabaseQueryTimeout,
-		constants.ArgServiceStartTimeout,
+		constants.ArgDatabaseStartTimeout,
 		// general
 		constants.ArgUpdateCheck,
 		constants.ArgMaxParallel,

--- a/pkg/cmdconfig/diagnostics.go
+++ b/pkg/cmdconfig/diagnostics.go
@@ -43,8 +43,7 @@ func DisplayConfig() {
 		constants.ArgListenAddress,
 		constants.ArgSearchPath,
 		constants.ArgDatabaseQueryTimeout,
-		constants.ArgServiceRecoveryTimeout,
-		constants.ArgServiceConnectionTimeout,
+		constants.ArgServiceStartTimeout,
 		// general
 		constants.ArgUpdateCheck,
 		constants.ArgMaxParallel,

--- a/pkg/cmdconfig/viper.go
+++ b/pkg/cmdconfig/viper.go
@@ -84,13 +84,12 @@ func SetDefaultsFromConfig(configMap map[string]interface{}) {
 // for keys which do not have a corresponding command flag, we need a separate defaulting mechanism
 func setBaseDefaults() {
 	defaults := map[string]interface{}{
-		constants.ArgUpdateCheck:              true,
-		constants.ArgTelemetry:                constants.TelemetryInfo,
-		constants.ArgDatabasePort:             constants.DatabaseDefaultPort,
-		constants.ArgMaxCacheSizeMb:           constants.DefaultMaxCacheSizeMb,
-		constants.ArgAutoComplete:             true,
-		constants.ArgServiceRecoveryTimeout:   constants.DBRecoveryTimeout.Seconds(),
-		constants.ArgServiceConnectionTimeout: constants.DBConnectionTimeout.Seconds(),
+		constants.ArgUpdateCheck:         true,
+		constants.ArgTelemetry:           constants.TelemetryInfo,
+		constants.ArgDatabasePort:        constants.DatabaseDefaultPort,
+		constants.ArgMaxCacheSizeMb:      constants.DefaultMaxCacheSizeMb,
+		constants.ArgAutoComplete:        true,
+		constants.ArgServiceStartTimeout: constants.DBConnectionTimeout.Seconds(),
 	}
 
 	for k, v := range defaults {
@@ -124,22 +123,21 @@ func SetDefaultsFromEnv() {
 
 	// a map of known environment variables to map to viper keys
 	envMappings := map[string]envMapping{
-		constants.EnvInstallDir:        {constants.ArgInstallDir, "string"},
-		constants.EnvWorkspaceChDir:    {constants.ArgModLocation, "string"},
-		constants.EnvModLocation:       {constants.ArgModLocation, "string"},
-		constants.EnvIntrospection:     {constants.ArgIntrospection, "string"},
-		constants.EnvTelemetry:         {constants.ArgTelemetry, "string"},
-		constants.EnvUpdateCheck:       {constants.ArgUpdateCheck, "bool"},
-		constants.EnvCloudHost:         {constants.ArgCloudHost, "string"},
-		constants.EnvCloudToken:        {constants.ArgCloudToken, "string"},
-		constants.EnvSnapshotLocation:  {constants.ArgSnapshotLocation, "string"},
-		constants.EnvWorkspaceDatabase: {constants.ArgWorkspaceDatabase, "string"},
-		constants.EnvServicePassword:   {constants.ArgServicePassword, "string"},
-		constants.EnvCheckDisplayWidth: {constants.ArgCheckDisplayWidth, "int"},
-		constants.EnvMaxParallel:       {constants.ArgMaxParallel, "int"},
-		constants.EnvQueryTimeout:      {constants.ArgDatabaseQueryTimeout, "int"},
-		constants.EnvConnectionTimeout: {constants.ArgServiceConnectionTimeout, "int"},
-		constants.EnvRecoveryTimeout:   {constants.ArgServiceRecoveryTimeout, "int"},
+		constants.EnvInstallDir:          {constants.ArgInstallDir, "string"},
+		constants.EnvWorkspaceChDir:      {constants.ArgModLocation, "string"},
+		constants.EnvModLocation:         {constants.ArgModLocation, "string"},
+		constants.EnvIntrospection:       {constants.ArgIntrospection, "string"},
+		constants.EnvTelemetry:           {constants.ArgTelemetry, "string"},
+		constants.EnvUpdateCheck:         {constants.ArgUpdateCheck, "bool"},
+		constants.EnvCloudHost:           {constants.ArgCloudHost, "string"},
+		constants.EnvCloudToken:          {constants.ArgCloudToken, "string"},
+		constants.EnvSnapshotLocation:    {constants.ArgSnapshotLocation, "string"},
+		constants.EnvWorkspaceDatabase:   {constants.ArgWorkspaceDatabase, "string"},
+		constants.EnvServicePassword:     {constants.ArgServicePassword, "string"},
+		constants.EnvCheckDisplayWidth:   {constants.ArgCheckDisplayWidth, "int"},
+		constants.EnvMaxParallel:         {constants.ArgMaxParallel, "int"},
+		constants.EnvQueryTimeout:        {constants.ArgDatabaseQueryTimeout, "int"},
+		constants.EnvServiceStartTimeout: {constants.ArgServiceStartTimeout, "int"},
 	}
 
 	for k, v := range envMappings {

--- a/pkg/cmdconfig/viper.go
+++ b/pkg/cmdconfig/viper.go
@@ -84,12 +84,12 @@ func SetDefaultsFromConfig(configMap map[string]interface{}) {
 // for keys which do not have a corresponding command flag, we need a separate defaulting mechanism
 func setBaseDefaults() {
 	defaults := map[string]interface{}{
-		constants.ArgUpdateCheck:         true,
-		constants.ArgTelemetry:           constants.TelemetryInfo,
-		constants.ArgDatabasePort:        constants.DatabaseDefaultPort,
-		constants.ArgMaxCacheSizeMb:      constants.DefaultMaxCacheSizeMb,
-		constants.ArgAutoComplete:        true,
-		constants.ArgServiceStartTimeout: constants.DBConnectionTimeout.Seconds(),
+		constants.ArgUpdateCheck:          true,
+		constants.ArgTelemetry:            constants.TelemetryInfo,
+		constants.ArgDatabasePort:         constants.DatabaseDefaultPort,
+		constants.ArgMaxCacheSizeMb:       constants.DefaultMaxCacheSizeMb,
+		constants.ArgAutoComplete:         true,
+		constants.ArgDatabaseStartTimeout: constants.DBStartTimeout.Seconds(),
 	}
 
 	for k, v := range defaults {
@@ -123,21 +123,21 @@ func SetDefaultsFromEnv() {
 
 	// a map of known environment variables to map to viper keys
 	envMappings := map[string]envMapping{
-		constants.EnvInstallDir:          {constants.ArgInstallDir, "string"},
-		constants.EnvWorkspaceChDir:      {constants.ArgModLocation, "string"},
-		constants.EnvModLocation:         {constants.ArgModLocation, "string"},
-		constants.EnvIntrospection:       {constants.ArgIntrospection, "string"},
-		constants.EnvTelemetry:           {constants.ArgTelemetry, "string"},
-		constants.EnvUpdateCheck:         {constants.ArgUpdateCheck, "bool"},
-		constants.EnvCloudHost:           {constants.ArgCloudHost, "string"},
-		constants.EnvCloudToken:          {constants.ArgCloudToken, "string"},
-		constants.EnvSnapshotLocation:    {constants.ArgSnapshotLocation, "string"},
-		constants.EnvWorkspaceDatabase:   {constants.ArgWorkspaceDatabase, "string"},
-		constants.EnvServicePassword:     {constants.ArgServicePassword, "string"},
-		constants.EnvCheckDisplayWidth:   {constants.ArgCheckDisplayWidth, "int"},
-		constants.EnvMaxParallel:         {constants.ArgMaxParallel, "int"},
-		constants.EnvQueryTimeout:        {constants.ArgDatabaseQueryTimeout, "int"},
-		constants.EnvServiceStartTimeout: {constants.ArgServiceStartTimeout, "int"},
+		constants.EnvInstallDir:           {constants.ArgInstallDir, "string"},
+		constants.EnvWorkspaceChDir:       {constants.ArgModLocation, "string"},
+		constants.EnvModLocation:          {constants.ArgModLocation, "string"},
+		constants.EnvIntrospection:        {constants.ArgIntrospection, "string"},
+		constants.EnvTelemetry:            {constants.ArgTelemetry, "string"},
+		constants.EnvUpdateCheck:          {constants.ArgUpdateCheck, "bool"},
+		constants.EnvCloudHost:            {constants.ArgCloudHost, "string"},
+		constants.EnvCloudToken:           {constants.ArgCloudToken, "string"},
+		constants.EnvSnapshotLocation:     {constants.ArgSnapshotLocation, "string"},
+		constants.EnvWorkspaceDatabase:    {constants.ArgWorkspaceDatabase, "string"},
+		constants.EnvServicePassword:      {constants.ArgServicePassword, "string"},
+		constants.EnvCheckDisplayWidth:    {constants.ArgCheckDisplayWidth, "int"},
+		constants.EnvMaxParallel:          {constants.ArgMaxParallel, "int"},
+		constants.EnvQueryTimeout:         {constants.ArgDatabaseQueryTimeout, "int"},
+		constants.EnvDatabaseStartTimeout: {constants.ArgDatabaseStartTimeout, "int"},
 	}
 
 	for k, v := range envMappings {

--- a/pkg/cmdconfig/viper.go
+++ b/pkg/cmdconfig/viper.go
@@ -89,8 +89,8 @@ func setBaseDefaults() {
 		constants.ArgDatabasePort:             constants.DatabaseDefaultPort,
 		constants.ArgMaxCacheSizeMb:           constants.DefaultMaxCacheSizeMb,
 		constants.ArgAutoComplete:             true,
-		constants.ArgServiceRecoveryTimeout:   constants.DBRecoveryTimeout,
-		constants.ArgServiceConnectionTimeout: constants.DBConnectionTimeout,
+		constants.ArgServiceRecoveryTimeout:   constants.DBRecoveryTimeout.Seconds(),
+		constants.ArgServiceConnectionTimeout: constants.DBConnectionTimeout.Seconds(),
 	}
 
 	for k, v := range defaults {

--- a/pkg/cmdconfig/viper.go
+++ b/pkg/cmdconfig/viper.go
@@ -84,11 +84,13 @@ func SetDefaultsFromConfig(configMap map[string]interface{}) {
 // for keys which do not have a corresponding command flag, we need a separate defaulting mechanism
 func setBaseDefaults() {
 	defaults := map[string]interface{}{
-		constants.ArgUpdateCheck:    true,
-		constants.ArgTelemetry:      constants.TelemetryInfo,
-		constants.ArgDatabasePort:   constants.DatabaseDefaultPort,
-		constants.ArgMaxCacheSizeMb: constants.DefaultMaxCacheSizeMb,
-		constants.ArgAutoComplete:   true,
+		constants.ArgUpdateCheck:              true,
+		constants.ArgTelemetry:                constants.TelemetryInfo,
+		constants.ArgDatabasePort:             constants.DatabaseDefaultPort,
+		constants.ArgMaxCacheSizeMb:           constants.DefaultMaxCacheSizeMb,
+		constants.ArgAutoComplete:             true,
+		constants.ArgServiceRecoveryTimeout:   constants.DBRecoveryTimeout,
+		constants.ArgServiceConnectionTimeout: constants.DBConnectionTimeout,
 	}
 
 	for k, v := range defaults {
@@ -136,6 +138,8 @@ func SetDefaultsFromEnv() {
 		constants.EnvCheckDisplayWidth: {constants.ArgCheckDisplayWidth, "int"},
 		constants.EnvMaxParallel:       {constants.ArgMaxParallel, "int"},
 		constants.EnvQueryTimeout:      {constants.ArgDatabaseQueryTimeout, "int"},
+		constants.EnvConnectionTimeout: {constants.ArgServiceConnectionTimeout, "int"},
+		constants.EnvRecoveryTimeout:   {constants.ArgServiceRecoveryTimeout, "int"},
 	}
 
 	for k, v := range envMappings {

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -58,7 +58,7 @@ const (
 	ArgSnapshotLocation     = "snapshot-location"
 	ArgSnapshotTitle        = "snapshot-title"
 
-	ArgServiceStartTimeout = "service-start-timeout"
+	ArgDatabaseStartTimeout = "database-start-timeout"
 )
 
 // metaquery mode arguments

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -57,6 +57,9 @@ const (
 	ArgModLocation          = "mod-location"
 	ArgSnapshotLocation     = "snapshot-location"
 	ArgSnapshotTitle        = "snapshot-title"
+
+	ArgServiceRecoveryTimeout   = "recovery-timeout"
+	ArgServiceConnectionTimeout = "connection-timeout"
 )
 
 // metaquery mode arguments

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -58,8 +58,7 @@ const (
 	ArgSnapshotLocation     = "snapshot-location"
 	ArgSnapshotTitle        = "snapshot-title"
 
-	ArgServiceRecoveryTimeout   = "recovery-timeout"
-	ArgServiceConnectionTimeout = "connection-timeout"
+	ArgServiceStartTimeout = "service-start-timeout"
 )
 
 // metaquery mode arguments

--- a/pkg/constants/default_options.go
+++ b/pkg/constants/default_options.go
@@ -14,9 +14,10 @@ const DefaultConnectionConfigContent = `
 # }
 
 # options "database" {
-#   port          = 9193    # any valid, open port number
-#   listen        = "local" # local, network
-#   search_path   =  ""     # comma-separated string
+#   port                  = 9193    # any valid, open port number
+#   listen                = "local" # local, network
+#   search_path           =  ""     # comma-separated string
+#   service_start_timeout = 30      # maximum time it should take for service to start up (in seconds)
 # }
 
 # options "terminal" {
@@ -27,8 +28,8 @@ const DefaultConnectionConfigContent = `
 #   timing              = false   # true, false
 #   search_path         =  ""     # comma-separated string
 #   search_path_prefix  =  ""     # comma-separated string
-#   watch  			    =  true   # true, false
-#   autocomplete       =  true   # true, false
+#   watch  			        =  true   # true, false
+#   autocomplete        =  true   # true, false
 # }
 
 # options "general" {

--- a/pkg/constants/duration.go
+++ b/pkg/constants/duration.go
@@ -5,7 +5,8 @@ import "time"
 var (
 	DashboardServiceStartTimeout = 30 * time.Second
 	DBConnectionTimeout          = 30 * time.Second
-	DBRecoveryWaitTimeout        = 5 * time.Minute
 	DBConnectionRetryBackoff     = 200 * time.Millisecond
+	DBRecoveryTimeout            = 5 * time.Minute
+	DBRecoveryRetryBackoff       = 200 * time.Millisecond
 	ServicePingInterval          = 50 * time.Millisecond
 )

--- a/pkg/constants/duration.go
+++ b/pkg/constants/duration.go
@@ -4,7 +4,7 @@ import "time"
 
 var (
 	DashboardServiceStartTimeout = 30 * time.Second
-	DBConnectionTimeout          = 30 * time.Second
+	DBStartTimeout               = 30 * time.Second
 	DBConnectionRetryBackoff     = 200 * time.Millisecond
 	DBRecoveryTimeout            = 24 * time.Hour
 	DBRecoveryRetryBackoff       = 200 * time.Millisecond

--- a/pkg/constants/duration.go
+++ b/pkg/constants/duration.go
@@ -6,7 +6,7 @@ var (
 	DashboardServiceStartTimeout = 30 * time.Second
 	DBConnectionTimeout          = 30 * time.Second
 	DBConnectionRetryBackoff     = 200 * time.Millisecond
-	DBRecoveryTimeout            = 5 * time.Minute
+	DBRecoveryTimeout            = 24 * time.Hour
 	DBRecoveryRetryBackoff       = 200 * time.Millisecond
 	ServicePingInterval          = 50 * time.Millisecond
 )

--- a/pkg/constants/duration.go
+++ b/pkg/constants/duration.go
@@ -5,6 +5,7 @@ import "time"
 var (
 	DashboardServiceStartTimeout = 30 * time.Second
 	DBConnectionTimeout          = 30 * time.Second
+	DBRecoveryWaitTimeout        = 5 * time.Minute
 	DBConnectionRetryBackoff     = 200 * time.Millisecond
 	ServicePingInterval          = 50 * time.Millisecond
 )

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -8,8 +8,8 @@ const (
 	EnvServicePassword = "STEAMPIPE_DATABASE_PASSWORD"
 	EnvMaxParallel     = "STEAMPIPE_MAX_PARALLEL"
 
-	EnvConnectionTimeout = "STEAMPIPE_CONNECTION_WAIT"
-	EnvRecoveryTimeout   = "STEAMPIPE_RECOVERY_WAIT"
+	EnvConnectionTimeout = "STEAMPIPE_CONNECTION_TIMEOUT"
+	EnvRecoveryTimeout   = "STEAMPIPE_RECOVERY_TIMEOUT"
 
 	EnvSnapshotLocation  = "STEAMPIPE_SNAPSHOT_LOCATION"
 	EnvWorkspaceDatabase = "STEAMPIPE_WORKSPACE_DATABASE"

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -8,8 +8,7 @@ const (
 	EnvServicePassword = "STEAMPIPE_DATABASE_PASSWORD"
 	EnvMaxParallel     = "STEAMPIPE_MAX_PARALLEL"
 
-	EnvConnectionTimeout = "STEAMPIPE_CONNECTION_TIMEOUT"
-	EnvRecoveryTimeout   = "STEAMPIPE_RECOVERY_TIMEOUT"
+	EnvServiceStartTimeout = "STEAMPIPE_SERVICE_START_TIMEOUT"
 
 	EnvSnapshotLocation  = "STEAMPIPE_SNAPSHOT_LOCATION"
 	EnvWorkspaceDatabase = "STEAMPIPE_WORKSPACE_DATABASE"

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -8,7 +8,7 @@ const (
 	EnvServicePassword = "STEAMPIPE_DATABASE_PASSWORD"
 	EnvMaxParallel     = "STEAMPIPE_MAX_PARALLEL"
 
-	EnvServiceStartTimeout = "STEAMPIPE_SERVICE_START_TIMEOUT"
+	EnvDatabaseStartTimeout = "STEAMPIPE_DATABASE_START_TIMEOUT"
 
 	EnvSnapshotLocation  = "STEAMPIPE_SNAPSHOT_LOCATION"
 	EnvWorkspaceDatabase = "STEAMPIPE_WORKSPACE_DATABASE"

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -8,6 +8,9 @@ const (
 	EnvServicePassword = "STEAMPIPE_DATABASE_PASSWORD"
 	EnvMaxParallel     = "STEAMPIPE_MAX_PARALLEL"
 
+	EnvConnectionTimeout = "STEAMPIPE_CONNECTION_WAIT"
+	EnvRecoveryTimeout   = "STEAMPIPE_RECOVERY_WAIT"
+
 	EnvSnapshotLocation  = "STEAMPIPE_SNAPSHOT_LOCATION"
 	EnvWorkspaceDatabase = "STEAMPIPE_WORKSPACE_DATABASE"
 	EnvWorkspaceProfile  = "STEAMPIPE_WORKSPACE"

--- a/pkg/db/db_client/db_client_connect.go
+++ b/pkg/db/db_client/db_client_connect.go
@@ -55,7 +55,7 @@ func (c *DbClient) establishConnectionPool(ctx context.Context) error {
 		ctx,
 		dbPool,
 		db_common.WithRetryInterval(constants.DBConnectionRetryBackoff),
-		db_common.WithTimeout(time.Duration(viper.GetInt(constants.ArgServiceStartTimeout))*time.Second),
+		db_common.WithTimeout(time.Duration(viper.GetInt(constants.ArgDatabaseStartTimeout))*time.Second),
 	)
 	if err != nil {
 		return err

--- a/pkg/db/db_client/db_client_connect.go
+++ b/pkg/db/db_client/db_client_connect.go
@@ -55,7 +55,7 @@ func (c *DbClient) establishConnectionPool(ctx context.Context) error {
 		ctx,
 		dbPool,
 		db_common.WithRetryInterval(constants.DBConnectionRetryBackoff),
-		db_common.WithTimeout(viper.GetDuration(constants.ArgServiceConnectionTimeout)),
+		db_common.WithTimeout(time.Duration(viper.GetInt(constants.ArgServiceStartTimeout))*time.Second),
 	)
 	if err != nil {
 		return err

--- a/pkg/db/db_client/db_client_connect.go
+++ b/pkg/db/db_client/db_client_connect.go
@@ -51,7 +51,13 @@ func (c *DbClient) establishConnectionPool(ctx context.Context) error {
 		return err
 	}
 
-	if err := db_common.WaitForPool(ctx, dbPool); err != nil {
+	err = db_common.WaitForPool(
+		ctx,
+		dbPool,
+		db_common.WithRetryInterval(constants.DBConnectionRetryBackoff),
+		db_common.WithTimeout(viper.GetDuration(constants.ArgServiceConnectionTimeout)),
+	)
+	if err != nil {
 		return err
 	}
 	c.pool = dbPool

--- a/pkg/db/db_common/wait_connection.go
+++ b/pkg/db/db_common/wait_connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sethvargo/go-retry"
 	"github.com/turbot/steampipe/pkg/constants"
+	"github.com/turbot/steampipe/pkg/error_helpers"
 	"github.com/turbot/steampipe/pkg/utils"
 )
 
@@ -145,6 +146,9 @@ func WaitForRecovery(ctx context.Context, connection *pgx.Conn, waitOptions ...W
 		row := connection.QueryRow(ctx, "select pg_is_in_recovery();")
 		var isInRecovery bool
 		if scanErr := row.Scan(&isInRecovery); scanErr != nil {
+			if error_helpers.IsContextCancelledError(scanErr) {
+				return scanErr
+			}
 			log.Println("[ERROR] checking for recover mode", scanErr)
 			return retry.RetryableError(scanErr)
 		}

--- a/pkg/db/db_common/wait_connection.go
+++ b/pkg/db/db_common/wait_connection.go
@@ -15,50 +15,95 @@ import (
 
 var ErrRecoveryMode = errors.New("service is in recovery mode")
 
+type waitConfig struct {
+	retryInterval time.Duration
+	timeout       time.Duration
+}
+
+type WaitOption func(w *waitConfig)
+
+func WithRetryInterval(d time.Duration) WaitOption {
+	return func(w *waitConfig) {
+		w.retryInterval = d
+	}
+}
+func WithTimeout(d time.Duration) WaitOption {
+	return func(w *waitConfig) {
+		w.timeout = d
+	}
+}
+
+func WaitForConnection(ctx context.Context, connStr string, options ...WaitOption) (conn *pgx.Conn, err error) {
+	utils.LogTime("db_common.waitForConnection start")
+	defer utils.LogTime("db.waitForConnection end")
+
+	config := &waitConfig{
+		retryInterval: constants.DBConnectionRetryBackoff,
+		timeout:       constants.DBConnectionTimeout,
+	}
+
+	for _, o := range options {
+		o(config)
+	}
+
+	backoff := retry.WithMaxDuration(
+		config.timeout,
+		retry.NewConstant(config.retryInterval),
+	)
+
+	// create a connection to the service.
+	// Retry after a backoff, but only upto a maximum duration.
+	err = retry.Do(ctx, backoff, func(rCtx context.Context) error {
+		log.Println("[TRACE] Trying to create client with: ", connStr)
+		dbConnection, err := pgx.Connect(rCtx, connStr)
+		if err != nil {
+			log.Println("[TRACE] could not connect:", err)
+			return retry.RetryableError(err)
+		}
+		log.Println("[TRACE] connected to database")
+		conn = dbConnection
+		return nil
+	})
+
+	return conn, err
+}
+
 // WaitForPool waits for the db to start accepting connections and returns true
 // returns false if the dbClient does not start within a stipulated time,
-func WaitForPool(ctx context.Context, db *pgxpool.Pool) (err error) {
+func WaitForPool(ctx context.Context, db *pgxpool.Pool, waitOptions ...WaitOption) (err error) {
 	utils.LogTime("db.waitForConnection start")
 	defer utils.LogTime("db.waitForConnection end")
 
-	pingTimer := time.NewTicker(constants.ServicePingInterval)
-	timeoutAt := time.After(constants.DBConnectionTimeout)
-	defer pingTimer.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-pingTimer.C:
-			err = db.Ping(ctx)
-			if err == nil {
-				return
-			}
-		case <-timeoutAt:
-			return
-		}
+	connection, err := db.Acquire(ctx)
+	if err != nil {
+		return err
 	}
+	return WaitForConnectionPing(ctx, connection.Conn(), waitOptions...)
 }
 
 // WaitForConnectionPing PINGs the DB - retrying after a backoff of constants.ServicePingInterval - but only for constants.DBConnectionTimeout
 // returns the error from the database if the dbClient does not respond successfully after a timeout
-func WaitForConnectionPing(ctx context.Context, connection *pgx.Conn) (err error) {
-	utils.LogTime("db.waitForConnection start")
+func WaitForConnectionPing(ctx context.Context, connection *pgx.Conn, waitOptions ...WaitOption) (err error) {
+	utils.LogTime("db_common.waitForConnection start")
 	defer utils.LogTime("db.waitForConnection end")
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, constants.DBConnectionTimeout)
-	defer func() {
-		cancel()
-	}()
+	config := &waitConfig{
+		retryInterval: constants.ServicePingInterval,
+		timeout:       constants.DBConnectionTimeout,
+	}
+
+	for _, o := range waitOptions {
+		o(config)
+	}
 
 	retryBackoff := retry.WithMaxDuration(
-		constants.DBConnectionTimeout,
-		retry.NewConstant(constants.ServicePingInterval),
+		config.timeout,
+		retry.NewConstant(config.retryInterval),
 	)
 
 	retryErr := retry.Do(ctx, retryBackoff, func(ctx context.Context) error {
 		log.Println("[TRACE] Pinging")
-		pingErr := connection.Ping(timeoutCtx)
+		pingErr := connection.Ping(ctx)
 		if pingErr != nil {
 			log.Println("[TRACE] Pinging failed -> trying again")
 			return retry.RetryableError(pingErr)
@@ -71,21 +116,25 @@ func WaitForConnectionPing(ctx context.Context, connection *pgx.Conn) (err error
 
 // WaitForRecovery returns an error (ErrRecoveryMode) if the service stays in recovery
 // mode for more than constants.DBRecoveryWaitTimeout
-func WaitForRecovery(ctx context.Context, connection *pgx.Conn) (err error) {
+func WaitForRecovery(ctx context.Context, connection *pgx.Conn, waitOptions ...WaitOption) (err error) {
 	utils.LogTime("db_common.WaitForRecovery start")
 	defer utils.LogTime("db_common.WaitForRecovery end")
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, constants.DBRecoveryWaitTimeout)
-	defer func() {
-		cancel()
-	}()
+	config := &waitConfig{
+		retryInterval: constants.ServicePingInterval,
+		timeout:       constants.DBRecoveryTimeout,
+	}
+
+	for _, o := range waitOptions {
+		o(config)
+	}
 
 	retryBackoff := retry.WithMaxDuration(
-		constants.DBRecoveryWaitTimeout,
-		retry.NewConstant(constants.ServicePingInterval),
+		config.timeout,
+		retry.NewConstant(config.retryInterval),
 	)
 
-	retryErr := retry.Do(timeoutCtx, retryBackoff, func(ctx context.Context) error {
+	retryErr := retry.Do(ctx, retryBackoff, func(ctx context.Context) error {
 		log.Println("[TRACE] checking for recovery mode")
 		row := connection.QueryRow(ctx, "select pg_is_in_recovery();")
 		var isInRecovery bool
@@ -93,6 +142,7 @@ func WaitForRecovery(ctx context.Context, connection *pgx.Conn) (err error) {
 			return retry.RetryableError(scanErr)
 		}
 		if isInRecovery {
+			log.Println("[TRACE] service is in recovery")
 			return retry.RetryableError(ErrRecoveryMode)
 		}
 		return nil

--- a/pkg/db/db_common/wait_connection.go
+++ b/pkg/db/db_common/wait_connection.go
@@ -13,7 +13,7 @@ import (
 	"github.com/turbot/steampipe/pkg/utils"
 )
 
-var ErrRecoveryMode = errors.New("service is in recovery mode")
+var ErrServiceInRecoveryMode = errors.New("service is in recovery mode")
 
 type waitConfig struct {
 	retryInterval time.Duration
@@ -140,11 +140,12 @@ func WaitForRecovery(ctx context.Context, connection *pgx.Conn, waitOptions ...W
 		row := connection.QueryRow(ctx, "select pg_is_in_recovery();")
 		var isInRecovery bool
 		if scanErr := row.Scan(&isInRecovery); scanErr != nil {
+			log.Println("[ERROR] checking for recover mode", scanErr)
 			return retry.RetryableError(scanErr)
 		}
 		if isInRecovery {
 			log.Println("[TRACE] service is in recovery")
-			return retry.RetryableError(ErrRecoveryMode)
+			return retry.RetryableError(ErrServiceInRecoveryMode)
 		}
 		return nil
 	})

--- a/pkg/db/db_common/wait_connection.go
+++ b/pkg/db/db_common/wait_connection.go
@@ -39,7 +39,7 @@ func WaitForConnection(ctx context.Context, connStr string, options ...WaitOptio
 
 	config := &waitConfig{
 		retryInterval: constants.DBConnectionRetryBackoff,
-		timeout:       constants.DBConnectionTimeout,
+		timeout:       constants.DBStartTimeout,
 	}
 
 	for _, o := range options {
@@ -90,7 +90,7 @@ func WaitForConnectionPing(ctx context.Context, connection *pgx.Conn, waitOption
 
 	config := &waitConfig{
 		retryInterval: constants.ServicePingInterval,
-		timeout:       constants.DBConnectionTimeout,
+		timeout:       constants.DBStartTimeout,
 	}
 
 	for _, o := range waitOptions {

--- a/pkg/db/db_common/wait_connection.go
+++ b/pkg/db/db_common/wait_connection.go
@@ -7,10 +7,13 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/pkg/errors"
 	"github.com/sethvargo/go-retry"
 	"github.com/turbot/steampipe/pkg/constants"
 	"github.com/turbot/steampipe/pkg/utils"
 )
+
+var ErrRecoveryMode = errors.New("service is in recovery mode")
 
 // WaitForPool waits for the db to start accepting connections and returns true
 // returns false if the dbClient does not start within a stipulated time,
@@ -19,7 +22,7 @@ func WaitForPool(ctx context.Context, db *pgxpool.Pool) (err error) {
 	defer utils.LogTime("db.waitForConnection end")
 
 	pingTimer := time.NewTicker(constants.ServicePingInterval)
-	timeoutAt := time.After(constants.DashboardServiceStartTimeout)
+	timeoutAt := time.After(constants.DBConnectionTimeout)
 	defer pingTimer.Stop()
 
 	for {
@@ -37,9 +40,9 @@ func WaitForPool(ctx context.Context, db *pgxpool.Pool) (err error) {
 	}
 }
 
-// WaitForConnection PINGs the DB - retrying after a backoff of constants.ServicePingInterval - but only for constants.DBConnectionTimeout
+// WaitForConnectionPing PINGs the DB - retrying after a backoff of constants.ServicePingInterval - but only for constants.DBConnectionTimeout
 // returns the error from the database if the dbClient does not respond successfully after a timeout
-func WaitForConnection(ctx context.Context, connection *pgx.Conn) (err error) {
+func WaitForConnectionPing(ctx context.Context, connection *pgx.Conn) (err error) {
 	utils.LogTime("db.waitForConnection start")
 	defer utils.LogTime("db.waitForConnection end")
 
@@ -59,6 +62,38 @@ func WaitForConnection(ctx context.Context, connection *pgx.Conn) (err error) {
 		if pingErr != nil {
 			log.Println("[TRACE] Pinging failed -> trying again")
 			return retry.RetryableError(pingErr)
+		}
+		return nil
+	})
+
+	return retryErr
+}
+
+// WaitForRecovery returns an error (ErrRecoveryMode) if the service stays in recovery
+// mode for more than constants.DBRecoveryWaitTimeout
+func WaitForRecovery(ctx context.Context, connection *pgx.Conn) (err error) {
+	utils.LogTime("db_common.WaitForRecovery start")
+	defer utils.LogTime("db_common.WaitForRecovery end")
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, constants.DBRecoveryWaitTimeout)
+	defer func() {
+		cancel()
+	}()
+
+	retryBackoff := retry.WithMaxDuration(
+		constants.DBRecoveryWaitTimeout,
+		retry.NewConstant(constants.ServicePingInterval),
+	)
+
+	retryErr := retry.Do(timeoutCtx, retryBackoff, func(ctx context.Context) error {
+		log.Println("[TRACE] checking for recovery mode")
+		row := connection.QueryRow(ctx, "select pg_is_in_recovery();")
+		var isInRecovery bool
+		if scanErr := row.Scan(&isInRecovery); scanErr != nil {
+			return retry.RetryableError(scanErr)
+		}
+		if isInRecovery {
+			return retry.RetryableError(ErrRecoveryMode)
 		}
 		return nil
 	})

--- a/pkg/db/db_common/wait_connection.go
+++ b/pkg/db/db_common/wait_connection.go
@@ -78,6 +78,7 @@ func WaitForPool(ctx context.Context, db *pgxpool.Pool, waitOptions ...WaitOptio
 	if err != nil {
 		return err
 	}
+	defer connection.Release()
 	return WaitForConnectionPing(ctx, connection.Conn(), waitOptions...)
 }
 

--- a/pkg/db/db_local/create_client.go
+++ b/pkg/db/db_local/create_client.go
@@ -120,7 +120,7 @@ func createMaintenanceClient(ctx context.Context, port int) (*pgx.Conn, error) {
 	utils.LogTime("db_local.createMaintenanceClient start")
 	defer utils.LogTime("db_local.createMaintenanceClient end")
 
-	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(viper.GetInt(constants.ArgServiceStartTimeout))*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, time.Duration(viper.GetInt(constants.ArgDatabaseStartTimeout))*time.Second)
 	defer cancel()
 
 	connStr := fmt.Sprintf("host=localhost port=%d user=%s dbname=postgres sslmode=disable", port, constants.DatabaseSuperUser)
@@ -128,7 +128,7 @@ func createMaintenanceClient(ctx context.Context, port int) (*pgx.Conn, error) {
 		timeoutCtx,
 		connStr,
 		db_common.WithRetryInterval(constants.DBRecoveryRetryBackoff),
-		db_common.WithTimeout(time.Duration(viper.GetInt(constants.ArgServiceStartTimeout))*time.Second),
+		db_common.WithTimeout(time.Duration(viper.GetInt(constants.ArgDatabaseStartTimeout))*time.Second),
 	)
 	if err != nil {
 		log.Println("[TRACE] could not connect to service")
@@ -140,7 +140,7 @@ func createMaintenanceClient(ctx context.Context, port int) (*pgx.Conn, error) {
 		timeoutCtx,
 		conn,
 		db_common.WithRetryInterval(constants.DBConnectionRetryBackoff),
-		db_common.WithTimeout(viper.GetDuration(constants.ArgServiceStartTimeout)*time.Second),
+		db_common.WithTimeout(viper.GetDuration(constants.ArgDatabaseStartTimeout)*time.Second),
 	)
 	if err != nil {
 		conn.Close(ctx)

--- a/pkg/db/db_local/create_client.go
+++ b/pkg/db/db_local/create_client.go
@@ -159,7 +159,6 @@ func createMaintenanceClient(ctx context.Context, port int) (*pgx.Conn, error) {
 		ctx,
 		conn,
 		db_common.WithRetryInterval(constants.DBRecoveryRetryBackoff),
-		db_common.WithTimeout(constants.DBRecoveryTimeout),
 	)
 	if err != nil {
 		conn.Close(ctx)

--- a/pkg/db/db_local/create_client.go
+++ b/pkg/db/db_local/create_client.go
@@ -125,7 +125,7 @@ func createMaintenanceClient(ctx context.Context, port int) (*pgx.Conn, error) {
 		ctx,
 		connStr,
 		db_common.WithRetryInterval(constants.DBRecoveryRetryBackoff),
-		db_common.WithTimeout(viper.GetDuration(constants.ArgServiceConnectionTimeout)*time.Second),
+		db_common.WithTimeout(time.Duration(viper.GetInt(constants.ArgServiceConnectionTimeout))*time.Second),
 	)
 	if err != nil {
 		log.Println("[TRACE] could not connect to service")

--- a/pkg/steampipeconfig/options/database.go
+++ b/pkg/steampipeconfig/options/database.go
@@ -9,9 +9,11 @@ import (
 
 // Database
 type Database struct {
-	Port       *int    `hcl:"port"`
-	Listen     *string `hcl:"listen"`
-	SearchPath *string `hcl:"search_path"`
+	Port           *int    `hcl:"port"`
+	Listen         *string `hcl:"listen"`
+	SearchPath     *string `hcl:"search_path"`
+	RecoveryWait   *int    `hcl:"recovery_wait"`
+	ConnectionWait *int    `hcl:"connection_wait"`
 }
 
 // ConfigMap :: create a config map to pass to viper
@@ -27,6 +29,12 @@ func (d *Database) ConfigMap() map[string]interface{} {
 	if d.SearchPath != nil {
 		// convert from string to array
 		res[constants.ArgSearchPath] = searchPathToArray(*d.SearchPath)
+	}
+	if d.ConnectionWait != nil {
+		res[constants.ArgServiceConnectionTimeout] = d.ConnectionWait
+	}
+	if d.RecoveryWait != nil {
+		res[constants.ArgServiceRecoveryTimeout] = d.RecoveryWait
 	}
 	return res
 }

--- a/pkg/steampipeconfig/options/database.go
+++ b/pkg/steampipeconfig/options/database.go
@@ -30,9 +30,9 @@ func (d *Database) ConfigMap() map[string]interface{} {
 		res[constants.ArgSearchPath] = searchPathToArray(*d.SearchPath)
 	}
 	if d.ServiceStartTimeout != nil {
-		res[constants.ArgServiceStartTimeout] = d.ServiceStartTimeout
+		res[constants.ArgDatabaseStartTimeout] = d.ServiceStartTimeout
 	} else {
-		res[constants.ArgServiceStartTimeout] = constants.DBConnectionTimeout.Seconds()
+		res[constants.ArgDatabaseStartTimeout] = constants.DBStartTimeout.Seconds()
 	}
 	return res
 }

--- a/pkg/steampipeconfig/options/database.go
+++ b/pkg/steampipeconfig/options/database.go
@@ -76,5 +76,15 @@ func (d *Database) String() string {
 	} else {
 		str = append(str, fmt.Sprintf("  SearchPath: %s", *d.SearchPath))
 	}
+	if d.ConnectionTimeout == nil {
+		str = append(str, "  ConnectionTimeout: nil")
+	} else {
+		str = append(str, fmt.Sprintf("  ConnectionTimeout: %d", *d.ConnectionTimeout))
+	}
+	if d.RecoveryTimeout == nil {
+		str = append(str, "  RecoveryTimeout: nil")
+	} else {
+		str = append(str, fmt.Sprintf("  RecoveryTimeout: %d", *d.RecoveryTimeout))
+	}
 	return strings.Join(str, "\n")
 }

--- a/pkg/steampipeconfig/options/database.go
+++ b/pkg/steampipeconfig/options/database.go
@@ -9,11 +9,11 @@ import (
 
 // Database
 type Database struct {
-	Port           *int    `hcl:"port"`
-	Listen         *string `hcl:"listen"`
-	SearchPath     *string `hcl:"search_path"`
-	RecoveryWait   *int    `hcl:"recovery_wait"`
-	ConnectionWait *int    `hcl:"connection_wait"`
+	Port              *int    `hcl:"port"`
+	Listen            *string `hcl:"listen"`
+	SearchPath        *string `hcl:"search_path"`
+	RecoveryTimeout   *int    `hcl:"recovery_timeout"`
+	ConnectionTimeout *int    `hcl:"connection_timeout"`
 }
 
 // ConfigMap :: create a config map to pass to viper
@@ -30,11 +30,11 @@ func (d *Database) ConfigMap() map[string]interface{} {
 		// convert from string to array
 		res[constants.ArgSearchPath] = searchPathToArray(*d.SearchPath)
 	}
-	if d.ConnectionWait != nil {
-		res[constants.ArgServiceConnectionTimeout] = d.ConnectionWait
+	if d.ConnectionTimeout != nil {
+		res[constants.ArgServiceConnectionTimeout] = d.ConnectionTimeout
 	}
-	if d.RecoveryWait != nil {
-		res[constants.ArgServiceRecoveryTimeout] = d.RecoveryWait
+	if d.RecoveryTimeout != nil {
+		res[constants.ArgServiceRecoveryTimeout] = d.RecoveryTimeout
 	}
 	return res
 }

--- a/pkg/steampipeconfig/options/database.go
+++ b/pkg/steampipeconfig/options/database.go
@@ -9,10 +9,10 @@ import (
 
 // Database
 type Database struct {
-	Port                *int    `hcl:"port"`
-	Listen              *string `hcl:"listen"`
-	SearchPath          *string `hcl:"search_path"`
-	ServiceStartTimeout *int    `hcl:"service_start_timeout"`
+	Port         *int    `hcl:"port"`
+	Listen       *string `hcl:"listen"`
+	SearchPath   *string `hcl:"search_path"`
+	StartTimeout *int    `hcl:"start_timeout"`
 }
 
 // ConfigMap :: create a config map to pass to viper
@@ -29,8 +29,8 @@ func (d *Database) ConfigMap() map[string]interface{} {
 		// convert from string to array
 		res[constants.ArgSearchPath] = searchPathToArray(*d.SearchPath)
 	}
-	if d.ServiceStartTimeout != nil {
-		res[constants.ArgDatabaseStartTimeout] = d.ServiceStartTimeout
+	if d.StartTimeout != nil {
+		res[constants.ArgDatabaseStartTimeout] = d.StartTimeout
 	} else {
 		res[constants.ArgDatabaseStartTimeout] = constants.DBStartTimeout.Seconds()
 	}
@@ -74,10 +74,10 @@ func (d *Database) String() string {
 	} else {
 		str = append(str, fmt.Sprintf("  SearchPath: %s", *d.SearchPath))
 	}
-	if d.ServiceStartTimeout == nil {
+	if d.StartTimeout == nil {
 		str = append(str, "  ServiceStartTimeout: nil")
 	} else {
-		str = append(str, fmt.Sprintf("  ServiceStartTimeout: %d", *d.ServiceStartTimeout))
+		str = append(str, fmt.Sprintf("  ServiceStartTimeout: %d", *d.StartTimeout))
 	}
 	return strings.Join(str, "\n")
 }

--- a/pkg/steampipeconfig/options/database.go
+++ b/pkg/steampipeconfig/options/database.go
@@ -9,11 +9,10 @@ import (
 
 // Database
 type Database struct {
-	Port              *int    `hcl:"port"`
-	Listen            *string `hcl:"listen"`
-	SearchPath        *string `hcl:"search_path"`
-	RecoveryTimeout   *int    `hcl:"recovery_timeout"`
-	ConnectionTimeout *int    `hcl:"connection_timeout"`
+	Port                *int    `hcl:"port"`
+	Listen              *string `hcl:"listen"`
+	SearchPath          *string `hcl:"search_path"`
+	ServiceStartTimeout *int    `hcl:"service_start_timeout"`
 }
 
 // ConfigMap :: create a config map to pass to viper
@@ -30,11 +29,10 @@ func (d *Database) ConfigMap() map[string]interface{} {
 		// convert from string to array
 		res[constants.ArgSearchPath] = searchPathToArray(*d.SearchPath)
 	}
-	if d.ConnectionTimeout != nil {
-		res[constants.ArgServiceConnectionTimeout] = d.ConnectionTimeout
-	}
-	if d.RecoveryTimeout != nil {
-		res[constants.ArgServiceRecoveryTimeout] = d.RecoveryTimeout
+	if d.ServiceStartTimeout != nil {
+		res[constants.ArgServiceStartTimeout] = d.ServiceStartTimeout
+	} else {
+		res[constants.ArgServiceStartTimeout] = constants.DBConnectionTimeout.Seconds()
 	}
 	return res
 }
@@ -76,15 +74,10 @@ func (d *Database) String() string {
 	} else {
 		str = append(str, fmt.Sprintf("  SearchPath: %s", *d.SearchPath))
 	}
-	if d.ConnectionTimeout == nil {
-		str = append(str, "  ConnectionTimeout: nil")
+	if d.ServiceStartTimeout == nil {
+		str = append(str, "  ServiceStartTimeout: nil")
 	} else {
-		str = append(str, fmt.Sprintf("  ConnectionTimeout: %d", *d.ConnectionTimeout))
-	}
-	if d.RecoveryTimeout == nil {
-		str = append(str, "  RecoveryTimeout: nil")
-	} else {
-		str = append(str, fmt.Sprintf("  RecoveryTimeout: %d", *d.RecoveryTimeout))
+		str = append(str, fmt.Sprintf("  ServiceStartTimeout: %d", *d.ServiceStartTimeout))
 	}
 	return strings.Join(str, "\n")
 }


### PR DESCRIPTION
This PR adds a mechanism to specify the maximum time `Steampipe` will wait for the database to start accepting queries after it has started the `postgres` process. 

This can be configured in one of two ways:
1. Using `start_timeout` in the `database` options block.
1. Using the `STEAMPIPE_DATABASE_START_TIMEOUT` environment variable.
> Both are defined in seconds.

> Note: If steampipe detects that the database is in recovery after starting it up, it ignores the `start_timeout` parameter and waits for the database to complete recovery. If it gets stuck in `recovery` for some reason, `Ctrl+C` can be used to cancel the recovery.