### PR TITLE
Fix zsh completion instructions

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -61,8 +61,8 @@ func includeZshHelp(base string) string {
 	if runtime.GOOS == "darwin" {
 		buildUp = fmt.Sprintf(`%s
   Zsh:
-    # Load for every session (requires shell restart):
-    $ steampipe completion zsh > "${fpath[1]}/steampipe"
+    # Load for every session:
+    $ steampipe completion zsh > "${fpath[1]}/_steampipe" && compinit
 `, buildUp)
 	}
 


### PR DESCRIPTION
This MR fixes an inaccuracy in the `steampipe completion` command help text.

Instead of:

```shell
$ steampipe completion zsh > "${fpath[1]}/steampipe"
```

The command should be:

```shell
$ steampipe completion zsh > "${fpath[1]}/_steampipe" && compinit
```

As I'm not quite familiar with the steampipe codebase, if there are additional locations (documentation?) that should also be updated, please let me know and I can submit them as part of this PR. I just happened to see this by chance today and decided to fix it, for the other zsh users out there :)

Regarding _why_ this needs changing...

By convention, autoloadable zsh completion functions (specified using the `#compdef ...` pattern) _should_ start with an underscore (`_`). The zsh `compinit` completion initialization function will look in all `$fpath` directories for completion function definitions (files) starting with `_` and load them.

When the completion file `steampipe` (without the underscore) was placed into `$fpath` (e.g. before this commit), zsh treated this file as an autoloadable function _named_ `steampipe` (e.g. _not_ an autoloadable completion function definition). Since `steampipe` is already in the `$path` (or more specifically, the command hash table), the `${fpath[1]}/steampipe` "function" will be ignored and not used for completion. This results in the default zsh "file" completion popping up when someone types `steampipe <Tab>`, instead of the desired completion menu. 

A great place to see the different function naming conventions in practice is within the [zsh repo itself](https://github.com/zsh-users/zsh):

* [_Darwin_ Zsh Autoloadable Completion Functions](https://github.com/zsh-users/zsh/tree/master/Completion/Darwin/Command)
* [Miscellaneous Zsh-related functions](https://github.com/zsh-users/zsh/tree/master/Functions/Misc)

Reference: See [Zsh Documentation, _Completion System_, Section 20.2.2: Autoloaded files](https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Autoloaded-files)

<details>
<summary>20.2.2: Autoloaded files</summary>

**NOTE** This is just a _brief excerpt_ of the full Zsh completion system file/function autoloading reference documentation, available here: https://zsh.sourceforge.io/Doc/Release/Completion-System.html#Autoloaded-files

> The convention for autoloaded functions used in completion is that they start with an underscore; as already mentioned, the fpath/FPATH parameter must contain the directory in which they are stored. If zsh was properly installed on your system, then fpath/FPATH automatically contains the required directories for the standard functions.

> When compinit is run, it searches all such files accessible via fpath/FPATH and reads the first line of each of them. This line should contain one of the tags described below. Files whose first line does not start with one of these tags are not considered to be part of the completion system and will not be treated specially.

> #compdef name ... [ -{p|P} pattern ... [ -N name ... ] ]
> The file will be made autoloadable and the function defined in it will be called when completing names, each of which is either the name of a command whose arguments are to be completed or one of a number of special contexts in the form -context- described below.

</details>

