### PR TITLE
Fix duplicated text input on interactivve prompt during initialisation. Closes #3075

### DIFF
--- a/cmd/query.go
+++ b/cmd/query.go
@@ -121,7 +121,7 @@ func runQueryCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 
-	// enable spinner only in interactive mode
+	// enable paging only in interactive mode
 	interactiveMode := len(args) == 0
 	// set config to indicate whether we are running an interactive query
 	viper.Set(constants.ConfigKeyInteractive, interactiveMode)

--- a/pkg/interactive/interactive_client_init.go
+++ b/pkg/interactive/interactive_client_init.go
@@ -39,9 +39,16 @@ func (c *InteractiveClient) handleInitResult(ctx context.Context, initResult *db
 	}
 
 	if initResult.HasMessages() {
-		// hide the prompt in the next prompt render cycle
-		c.hidePrompt = true
+		// clear the prompt
+		// NOTE: this must be done BEFORE setting hidePrompt
+		// otherwise the cursor calculations in go-prompt do not work and multi-line test is not cleared
 		c.interactivePrompt.ClearLine()
+		// set the flag hide the prompt prefix in the next prompt render cycle
+		c.hidePrompt = true
+		// call ClearLine to render the empty prefix
+		c.interactivePrompt.ClearLine()
+
+		// display messages
 		initResult.DisplayMessages()
 		// show the prompt again
 		c.hidePrompt = false
@@ -90,11 +97,6 @@ func (c *InteractiveClient) readInitDataStream(ctx context.Context) {
 			c.initData.Result.Error = err
 		}
 	}
-
-	// Trigger a re-render of the prompt, so that the prompt actually shows up,
-	// since the prompt may have been removed by the installation spinner
-	c.interactivePrompt.Render()
-
 }
 
 func (c *InteractiveClient) workspaceWatcherErrorHandler(ctx context.Context, err error) {

--- a/pkg/query/init_data.go
+++ b/pkg/query/init_data.go
@@ -7,6 +7,7 @@ import (
 	"github.com/turbot/steampipe/pkg/constants"
 	"github.com/turbot/steampipe/pkg/export"
 	"github.com/turbot/steampipe/pkg/initialisation"
+	"github.com/turbot/steampipe/pkg/statushooks"
 	"github.com/turbot/steampipe/pkg/steampipeconfig/modconfig"
 	"github.com/turbot/steampipe/pkg/workspace"
 )
@@ -46,6 +47,10 @@ func NewInitData(ctx context.Context, args []string) *InitData {
 			i.Result.Error = err
 			return i
 		}
+	}
+	if len(args) == 0 {
+		// NOTE: disable any status updates - we do not want any intialisation spinners
+		ctx = statushooks.DisableStatusHooks(ctx)
 	}
 
 	go i.init(ctx, w, args)


### PR DESCRIPTION
fix interactivePrompt.ClearLine() before displaying messages