### PR TITLE
Fix Aggregator specs not being respected for static schema connections. Closes #3093

### DIFF
--- a/pkg/steampipeconfig/connection_data.go
+++ b/pkg/steampipeconfig/connection_data.go
@@ -51,6 +51,7 @@ func (d *ConnectionData) Equals(other *ConnectionData) bool {
 	}
 
 	return d.Plugin == other.Plugin &&
+		d.Connection.Equals(other.Connection) &&
 		d.ModTime.Equal(other.ModTime) &&
 		d.Connection.Equals(other.Connection)
 }

--- a/pkg/steampipeconfig/modconfig/connection.go
+++ b/pkg/steampipeconfig/modconfig/connection.go
@@ -5,10 +5,10 @@ import (
 	"log"
 	"path"
 	"reflect"
+	"strings"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/turbot/go-kit/helpers"
-	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe/pkg/steampipeconfig/options"
 	"golang.org/x/exp/maps"
 )
@@ -16,24 +16,6 @@ import (
 const (
 	ConnectionTypeAggregator = "aggregator"
 )
-
-type TableAggregationSpecs []*TableAggregationSpec
-
-func (s TableAggregationSpecs) ToProto() []*sdkproto.TableAggregationSpec {
-	res := make([]*sdkproto.TableAggregationSpec, len(s))
-	for i, t := range s {
-		res[i] = &sdkproto.TableAggregationSpec{
-			Match:       t.Match,
-			Connections: t.Connections,
-		}
-	}
-	return res
-}
-
-type TableAggregationSpec struct {
-	Match       string   `hcl:"match,optional"`
-	Connections []string `hcl:"connections"`
-}
 
 // Connection is a struct representing the partially parsed connection
 //
@@ -133,7 +115,11 @@ func (c *Connection) Equals(other *Connection) bool {
 		connectionOptionsEqual = c.Options.Equals(other.Options)
 	}
 	return c.Name == other.Name &&
+		c.Plugin == other.Plugin &&
+		c.Type == other.Type &&
+		strings.Join(c.ConnectionNames, ",") == strings.Join(other.ConnectionNames, ",") &&
 		connectionOptionsEqual &&
+		c.TableAggregationSpecs.Equals(other.TableAggregationSpecs) &&
 		c.Config == other.Config
 }
 

--- a/pkg/steampipeconfig/modconfig/table_aggregation_spec.go
+++ b/pkg/steampipeconfig/modconfig/table_aggregation_spec.go
@@ -1,0 +1,41 @@
+package modconfig
+
+import (
+	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"strings"
+)
+
+type TableAggregationSpecs []*TableAggregationSpec
+
+func (s TableAggregationSpecs) ToProto() []*sdkproto.TableAggregationSpec {
+	res := make([]*sdkproto.TableAggregationSpec, len(s))
+	for i, t := range s {
+		res[i] = &sdkproto.TableAggregationSpec{
+			Match:       t.Match,
+			Connections: t.Connections,
+		}
+	}
+	return res
+}
+
+func (s TableAggregationSpecs) Equals(other TableAggregationSpecs) bool {
+	if len(s) != len(other) {
+		return false
+	}
+	for i, s := range s {
+		if !s.Equals(other[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+type TableAggregationSpec struct {
+	Match       string   `hcl:"match,optional"`
+	Connections []string `hcl:"connections"`
+}
+
+func (s TableAggregationSpec) Equals(other *TableAggregationSpec) bool {
+	return s.Match == other.Match &&
+		strings.Join(s.Connections, ",") == strings.Join(other.Connections, ",")
+}


### PR DESCRIPTION
Always fetch schema for aggregator connections
Update ConnectionData.Equals
Update Connection.Equals
Add TableAggregationSpecs.Equals
Add type to ConnectionPluginData