### PR TITLE
Set minimum connection to 0, as thousands of connections are created if it is unset

### DIFF
--- a/pkg/db/db_client/db_client_connect.go
+++ b/pkg/db/db_client/db_client_connect.go
@@ -28,6 +28,8 @@ func (c *DbClient) establishConnectionPool(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// MinConns should default to 0, but when not set, it actually get very high values (e.g. 80217984)
+	config.MinConns = 0
 	config.MaxConns = int32(maxConnections)
 	config.MaxConnLifetime = connMaxLifetime
 	config.MaxConnIdleTime = connMaxIdleTime


### PR DESCRIPTION
Resolves an issue where thousands of connections are created when minimum connection count is undefined.

Related:
* https://github.com/turbot/steampipe/pull/3200#issuecomment-1464062176
* https://github.com/turbot/steampipe/pull/3199/files#diff-cd9dc2f303a3280bf101ef52708d0a761ff5c9cb5ff6352556c14b30ad7aab09L36
