### PR TITLE
Detect older versions of MacOS and warn that Steampipe does not support them. Closes #3256

### DIFF
--- a/main.go
+++ b/main.go
@@ -118,8 +118,7 @@ func checkWsl1(ctx context.Context) {
 
 func checkOSXVersion(ctx context.Context) {
 	// get the OS and return if not darwin
-	osname := runtime.GOOS
-	if !strings.Contains(strings.ToLower(string(osname)), "darwin") {
+	if !strings.Contains(runtime.GOOS, "darwin") {
 		return
 	}
 

--- a/main.go
+++ b/main.go
@@ -141,14 +141,14 @@ func checkOSXVersion(ctx context.Context) {
 		error_helpers.ShowErrorWithMessage(ctx, err, "failed to get version")
 		return
 	}
-	catalina, err := semver.NewVersion("19.0.0")
+	mojave, err := semver.NewVersion("18.0.0")
 	if err != nil {
 		error_helpers.ShowErrorWithMessage(ctx, err, "failed to get version")
 		return
 	}
 
-	// check if Darwin version is not less than Catalina(19.0.0)
-	if version.Compare(catalina) == -1 {
+	// check if Darwin version is not less than Mojave(Darwin version 18.0.0)
+	if version.Compare(mojave) == -1 {
 		error_helpers.ShowError(ctx, fmt.Errorf("Steampipe uses PostgreSQL 14, which requires MacOS version 10.14 or higher, please upgrade and try again."))
 		os.Exit(constants.ExitCodeInvalidExecutionEnvironment)
 	}

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/Masterminds/semver/v3"
@@ -116,14 +117,8 @@ func checkWsl1(ctx context.Context) {
 }
 
 func checkOSXVersion(ctx context.Context) {
-	// check if macOS
-	osname, err := exec.Command("uname").Output()
-	if err != nil {
-		error_helpers.ShowErrorWithMessage(ctx, err, "failed to check OS")
-		return
-	}
-
-	// return if OS is not darwin
+	// get the OS and return if not darwin
+	osname := runtime.GOOS
 	if !strings.Contains(strings.ToLower(string(osname)), "darwin") {
 		return
 	}

--- a/main.go
+++ b/main.go
@@ -141,15 +141,15 @@ func checkOSXVersion(ctx context.Context) {
 		error_helpers.ShowErrorWithMessage(ctx, err, "failed to get version")
 		return
 	}
-	mojave, err := semver.NewVersion("18.0.0")
+	catalina, err := semver.NewVersion("19.0.0")
 	if err != nil {
 		error_helpers.ShowErrorWithMessage(ctx, err, "failed to get version")
 		return
 	}
 
-	// check if Darwin version is not less than Mojave(Darwin version 18.0.0)
-	if version.Compare(mojave) == -1 {
-		error_helpers.ShowError(ctx, fmt.Errorf("Steampipe uses PostgreSQL 14, which requires MacOS version 10.14 or higher, please upgrade and try again."))
+	// check if Darwin version is not less than Catalina(Darwin version 19.0.0)
+	if version.Compare(catalina) == -1 {
+		error_helpers.ShowError(ctx, fmt.Errorf("Steampipe requires MacOS 10.15 (Catalina) and above, please upgrade and try again."))
 		os.Exit(constants.ExitCodeInvalidExecutionEnvironment)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -118,7 +118,7 @@ func checkWsl1(ctx context.Context) {
 
 func checkOSXVersion(ctx context.Context) {
 	// get the OS and return if not darwin
-	if !strings.Contains(runtime.GOOS, "darwin") {
+	if runtime.GOOS != "darwin" {
 		return
 	}
 

--- a/pkg/steampipeconfig/modconfig/attributes.go
+++ b/pkg/steampipeconfig/modconfig/attributes.go
@@ -3,7 +3,6 @@ package modconfig
 import (
 	"log"
 	"reflect"
-	"runtime/debug"
 
 	"github.com/hashicorp/hcl/v2/hcldec"
 	"github.com/hashicorp/terraform/configs/configschema"
@@ -18,7 +17,6 @@ func GetCtyTypes(item interface{}) map[string]cty.Type {
 	defer func() {
 		if r := recover(); r != nil {
 			log.Printf("[WARN] GetCtyTypes failed with panic: %v", r)
-			log.Printf("[WARN] stack: %s", debug.Stack())
 		}
 	}()
 	var res = make(map[string]cty.Type)

--- a/pkg/steampipeconfig/parse/mod_parse_context.go
+++ b/pkg/steampipeconfig/parse/mod_parse_context.go
@@ -2,13 +2,13 @@ package parse
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/hcl/v2"
 	filehelpers "github.com/turbot/go-kit/files"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/pkg/steampipeconfig/modconfig"
 	"github.com/turbot/steampipe/pkg/steampipeconfig/versionmap"
 	"github.com/zclconf/go-cty/cty"
-	"runtime/debug"
 )
 
 const rootDependencyNode = "rootDependencyNode"
@@ -420,7 +420,6 @@ func (m *ModParseContext) getResourceCtyValue(resource modconfig.HclResource) (c
 func (m *ModParseContext) mergeResourceCtyValue(resource modconfig.CtyValueProvider, valueMap map[string]cty.Value) (err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			fmt.Println(string(debug.Stack()))
 			err = fmt.Errorf("panic in mergeResourceCtyValue: %s", helpers.ToError(r).Error())
 		}
 	}()


### PR DESCRIPTION
Now running Steampipe on MacOS Mojave and other older versions throws the error message:

`Error: Steampipe requires MacOS 10.15 (Catalina) and above, please upgrade and try again.`