### PR TITLE
fix: trim protocol in url for mod commands

### DIFF
--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -90,6 +91,7 @@ func runModInstallCmd(cmd *cobra.Command, args []string) {
 
 	// if any mod names were passed as args, convert into formed mod names
 	opts := newInstallOpts(cmd, args...)
+	trimGitUrls(opts)
 	installData, err := modinstaller.InstallWorkspaceDependencies(ctx, opts)
 	error_helpers.FailOnError(err)
 
@@ -125,6 +127,7 @@ func runModUninstallCmd(cmd *cobra.Command, args []string) {
 	}()
 
 	opts := newInstallOpts(cmd, args...)
+	trimGitUrls(opts)
 	installData, err := modinstaller.UninstallWorkspaceDependencies(ctx, opts)
 	error_helpers.FailOnError(err)
 
@@ -160,7 +163,7 @@ func runModUpdateCmd(cmd *cobra.Command, args []string) {
 	}()
 
 	opts := newInstallOpts(cmd, args...)
-
+	trimGitUrls(opts)
 	installData, err := modinstaller.InstallWorkspaceDependencies(ctx, opts)
 	error_helpers.FailOnError(err)
 
@@ -255,4 +258,15 @@ func newInstallOpts(cmd *cobra.Command, args ...string) *modinstaller.InstallOpt
 		Command:       cmd.Name(),
 	}
 	return opts
+}
+
+// Modifies(trims) the URL if contains http ot https in arguments
+
+func trimGitUrls(opts *modinstaller.InstallOpts) {
+	re := regexp.MustCompile(`^(https?://)`)
+	for i, url := range opts.ModArgs {
+		if re.MatchString(url) {
+			opts.ModArgs[i] = re.ReplaceAllString(url, "")
+		}
+	}
 }

--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -263,10 +262,11 @@ func newInstallOpts(cmd *cobra.Command, args ...string) *modinstaller.InstallOpt
 // Modifies(trims) the URL if contains http ot https in arguments
 
 func trimGitUrls(opts *modinstaller.InstallOpts) {
-	re := regexp.MustCompile(`^(https?://)`)
-	for i, url := range opts.ModArgs {
-		if re.MatchString(url) {
-			opts.ModArgs[i] = re.ReplaceAllString(url, "")
-		}
-	}
+    for i, url := range opts.ModArgs {
+        if strings.HasPrefix(url, "http://") {
+            opts.ModArgs[i] = strings.TrimPrefix(url, "http://")
+        } else if strings.HasPrefix(url, "https://") {
+            opts.ModArgs[i] = strings.TrimPrefix(url, "https://")
+        }
+    }
 }

--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -263,10 +263,7 @@ func newInstallOpts(cmd *cobra.Command, args ...string) *modinstaller.InstallOpt
 
 func trimGitUrls(opts *modinstaller.InstallOpts) {
     for i, url := range opts.ModArgs {
-        if strings.HasPrefix(url, "http://") {
-            opts.ModArgs[i] = strings.TrimPrefix(url, "http://")
-        } else if strings.HasPrefix(url, "https://") {
-            opts.ModArgs[i] = strings.TrimPrefix(url, "https://")
-        }
+        opts.ModArgs[i] = strings.TrimPrefix(url, "http://")
+        opts.ModArgs[i] = strings.TrimPrefix(url, "https://")
     }
 }

--- a/tests/acceptance/test_files/mod_install.bats
+++ b/tests/acceptance/test_files/mod_install.bats
@@ -75,7 +75,7 @@ local
 }
 
 @test "install a mod with protocal in url" {
-  steampipe mod install https://github.com/turbot/steampipe-mod-hackernews-insights@0.3.0
+  run steampipe mod install https://github.com/turbot/steampipe-mod-hackernews-insights@0.3.0
   # should install with the protocol in the url prefix
   assert_output '
 Installed 1 mod:

--- a/tests/acceptance/test_files/mod_install.bats
+++ b/tests/acceptance/test_files/mod_install.bats
@@ -74,6 +74,16 @@ local
   assert_output --partial 'does not satisfy mod.m4 which requires version 10.99.99'
 }
 
+@test "install a mod with protocal in url" {
+  steampipe mod install https://github.com/turbot/steampipe-mod-hackernews-insights@0.3.0
+  # should install with the protocol in the url prefix
+  assert_output '
+Installed 1 mod:
+
+local
+└── github.com/turbot/steampipe-mod-hackernews-insights@v0.3.0'
+}
+
 function teardown() {
   rm -rf .steampipe/
   rm -rf .mod.cache.json


### PR DESCRIPTION
Remove `https` or `http` protocol in the URL as args in the mod commands
- Install
- Uninstall
- Update

Fix for #3257 

Fixes the error:
From
```bash
$ steampipe mod install https://github.com/turbot/steampipe-mod-hackernews-insights
Error: 1 dependency failed to install - could not retrieve version data from Git URL 'https://github.com/turbot/steampipe-mod-hackernews-insights'
```
To this;

```bash
$ steampipe mod install https://github.com/turbot/steampipe-mod-hackernews-insights

Installed 1 mod:

local
└── github.com/turbot/steampipe-mod-hackernews-insights@v0.3.0

```

It can also be done with simple string trimming like `opts.ModArgs[i] = opts.ModArgs[i][8:]` ,
but regex might be better for handling other protocols if needed.

Let me know if it's a valid fix or for any changes are required.
 