### PR TITLE
Show plugin name with stream in the progress bar during plugin update

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -413,7 +413,7 @@ func runPluginUpdateCmd(cmd *cobra.Command, args []string) {
 	for _, key := range sorted {
 		report := reports[key]
 		updateWaitGroup.Add(1)
-		bar := createProgressBar(report.ShortName(), progressBars)
+		bar := createProgressBar(report.ShortNameWithStream(), progressBars)
 		go doPluginUpdate(ctx, bar, report, updateWaitGroup, dataChannel)
 	}
 	go func() {
@@ -470,7 +470,7 @@ func doPluginUpdate(ctx context.Context, bar *uiprogress.Bar, pvr plugin.Version
 func createProgressBar(plugin string, parentProgressBars *uiprogress.Progress) *uiprogress.Bar {
 	bar := parentProgressBars.AddBar(len(pluginInstallSteps))
 	bar.PrependFunc(func(b *uiprogress.Bar) string {
-		return helpers.Resize(plugin, 20)
+		return helpers.Resize(plugin, 30)
 	})
 	return bar
 }

--- a/pkg/plugin/version_checker.go
+++ b/pkg/plugin/version_checker.go
@@ -26,6 +26,10 @@ func (vr *VersionCheckReport) ShortName() string {
 	return fmt.Sprintf("%s/%s", vr.CheckResponse.Org, vr.CheckResponse.Name)
 }
 
+func (vr *VersionCheckReport) ShortNameWithStream() string {
+	return fmt.Sprintf("%s/%s@%s", vr.CheckResponse.Org, vr.CheckResponse.Name, vr.CheckResponse.Stream)
+}
+
 // VersionChecker :: wrapper struct over the plugin version check utilities
 type VersionChecker struct {
 	pluginsToCheck []*versionfile.InstalledVersion


### PR DESCRIPTION
steampipe plugin update --all
![Screenshot 2023-04-10 at 6 51 09 PM](https://user-images.githubusercontent.com/45908484/230909012-1ebc5eff-380b-47fa-bfa1-6302fe8b207e.png)

steampipe plugin update aws
![Screenshot 2023-04-10 at 6 52 28 PM](https://user-images.githubusercontent.com/45908484/230909203-87cb9173-f9ee-4563-b987-e9aa22f2b3df.png)

steampipe plugin update aws@0.97.0
![Screenshot 2023-04-10 at 6 53 23 PM](https://user-images.githubusercontent.com/45908484/230909364-c7dbcbc8-237d-46a3-b672-979cab7441e0.png)


