### PR TITLE
Show stream name only for non-latest streams in plugin update output. Closes #3330

### DIFF
--- a/pkg/plugin/version_checker.go
+++ b/pkg/plugin/version_checker.go
@@ -27,7 +27,11 @@ func (vr *VersionCheckReport) ShortName() string {
 }
 
 func (vr *VersionCheckReport) ShortNameWithStream() string {
-	return fmt.Sprintf("%s/%s@%s", vr.CheckResponse.Org, vr.CheckResponse.Name, vr.CheckResponse.Stream)
+	// dont show stream names for latest streams
+	if vr.CheckResponse.Stream != "latest" {
+		return fmt.Sprintf("%s/%s@%s", vr.CheckResponse.Org, vr.CheckResponse.Name, vr.CheckResponse.Stream)
+	}
+	return fmt.Sprintf("%s/%s", vr.CheckResponse.Org, vr.CheckResponse.Name)
 }
 
 // VersionChecker :: wrapper struct over the plugin version check utilities


### PR DESCRIPTION
![Screenshot 2023-04-13 at 7 41 30 PM](https://user-images.githubusercontent.com/45908484/231785956-b450e318-30a5-4fee-8ee1-f4c40409c27b.png)
