### PR TITLE
add silent flag for plugin install cmd

### DIFF
--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -3,6 +3,7 @@ package constants
 // Argument name constants
 const (
 	ArgHelp                 = "help"
+	ArgSilent               = "silent"
 	ArgVersion              = "version"
 	ArgForce                = "force"
 	ArgAll                  = "all"


### PR DESCRIPTION
#2953 
Hello, I have tried to add a `--silent` flag for the plugin install command.

```sh
$ steampipe plugin install --silent docker
````
![Screenshot from 2023-04-15 15-04-30](https://user-images.githubusercontent.com/40317114/232208676-8dfa4c8f-8f0b-4398-b164-29b2836ff591.png)

Though the shorthand doesn't work, it shows in the docs below but I can't pick that up. Any suggestions?

![Screenshot from 2023-04-15 15-53-54](https://user-images.githubusercontent.com/40317114/232208705-ef92af58-4e27-49a6-a3a5-a63aeaa83026.png)


Please review and let me know of any changes.
Thank you
