### PR TITLE
Fixes issue where dependency tree is not printed in a specific order

### DIFF
--- a/pkg/steampipeconfig/versionmap/dependency_version_map.go
+++ b/pkg/steampipeconfig/versionmap/dependency_version_map.go
@@ -1,6 +1,8 @@
 package versionmap
 
 import (
+	"sort"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/turbot/steampipe/pkg/steampipeconfig/modconfig"
 	"github.com/xlab/treeprint"
@@ -41,7 +43,13 @@ func (m DependencyVersionMap) GetDependencyTree(rootName string) treeprint.Tree 
 
 func (m DependencyVersionMap) buildTree(name string, tree treeprint.Tree) {
 	deps := m[name]
-	for name, version := range deps {
+	depNames := []string{}
+	for k := range deps {
+		depNames = append(depNames, k)
+	}
+	sort.Strings(depNames)
+	for _, name := range depNames {
+		version := deps[name]
 		fullName := modconfig.BuildModDependencyPath(name, version.Version)
 		child := tree.AddBranch(fullName)
 		// if there are children add them

--- a/pkg/steampipeconfig/versionmap/dependency_version_map.go
+++ b/pkg/steampipeconfig/versionmap/dependency_version_map.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/turbot/steampipe/pkg/steampipeconfig/modconfig"
 	"github.com/xlab/treeprint"
+	"golang.org/x/exp/maps"
 )
 
 type DependencyVersionMap map[string]ResolvedVersionMap
@@ -43,10 +44,7 @@ func (m DependencyVersionMap) GetDependencyTree(rootName string) treeprint.Tree 
 
 func (m DependencyVersionMap) buildTree(name string, tree treeprint.Tree) {
 	deps := m[name]
-	depNames := []string{}
-	for k := range deps {
-		depNames = append(depNames, k)
-	}
+	depNames := maps.Keys(deps)
 	sort.Strings(depNames)
 	for _, name := range depNames {
 		version := deps[name]


### PR DESCRIPTION
Update to printing tree branches in alphabetical order