### PR TITLE
Fixes issue where deprecation warning was not shown for using 'options.connection' in 'connection' block. Closes #3223.

### DIFF
--- a/pkg/steampipeconfig/load_config.go
+++ b/pkg/steampipeconfig/load_config.go
@@ -191,8 +191,8 @@ func loadConfig(configFolder string, steampipeConfig *SteampipeConfig, opts *loa
 		switch block.Type {
 		case modconfig.BlockTypeConnection:
 			connection, moreDiags := parse.DecodeConnection(block)
+			diags = append(diags, moreDiags...)
 			if moreDiags.HasErrors() {
-				diags = append(diags, moreDiags...)
 				continue
 			}
 			_, alreadyThere := steampipeConfig.Connections[connection.Name]

--- a/pkg/steampipeconfig/parse/connection.go
+++ b/pkg/steampipeconfig/parse/connection.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/hcl/v2/gohcl"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
+	"github.com/turbot/steampipe/pkg/constants"
 	"github.com/turbot/steampipe/pkg/ociinstaller"
 	"github.com/turbot/steampipe/pkg/steampipeconfig/modconfig"
 )
@@ -71,7 +72,7 @@ func DecodeConnection(block *hcl.Block) (*modconfig.Connection, hcl.Diagnostics)
 			if connection.Options != nil {
 				diags = append(diags, &hcl.Diagnostic{
 					Severity: hcl.DiagWarning,
-					Summary:  "connection options have been deprecated and will be removed in subsequent versions of steampipe",
+					Summary:  fmt.Sprintf("%s in %s have been deprecated and will be removed in subsequent versions of steampipe", constants.Bold("'connection' options"), constants.Bold("'connection' blocks")),
 					Subject:  &connectionBlock.DefRange,
 				})
 			}

--- a/pkg/steampipeconfig/steampipeconfig.go
+++ b/pkg/steampipeconfig/steampipeconfig.go
@@ -86,6 +86,8 @@ func (c *SteampipeConfig) SetOptions(opts options.Options) (errorsAndWarnings *m
 
 	switch o := opts.(type) {
 	case *options.Connection:
+		// TODO: remove in 0.21 [https://github.com/turbot/steampipe/issues/3251]
+		errorsAndWarnings.AddWarning(deprecationWarning("connection options"))
 		if c.DefaultConnectionOptions == nil {
 			c.DefaultConnectionOptions = o
 		} else {


### PR DESCRIPTION
![Screenshot 2023-05-10 at 5 43 58 PM](https://github.com/turbot/steampipe/assets/1114038/01f9dad0-e520-4991-831a-4baa4cd744f8)
