### PR TITLE
Fix interactive timing output not including scan metadata (hydrate calls/ rows). CLoses #3420

### DIFF
--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -57,13 +57,13 @@ const (
 	ConnectionStateError             = "error"
 
 	// foreign tables in internal schema
-	CommandTableScanMetadata              = "steampipe_scan_metadata"
-	CommandTableSettings                  = "steampipe_settings"
-	CommandTableSettingsKeyColumn         = "name"
-	CommandTableSettingsValueColumn       = "value"
-	CommandTableSettingsCacheKey          = "cache"
-	CommandTableSettingsCacheTtlKey       = "cache_ttl"
-	CommandTableSettingsCacheClearTimeKey = "cache_clear_time"
+	ForeignTableScanMetadata              = "steampipe_scan_metadata"
+	ForeighTableSettings                  = "steampipe_settings"
+	ForeignTableSettingsKeyColumn         = "name"
+	ForeignTableSettingsValueColumn       = "value"
+	ForeignTableSettingsCacheKey          = "cache"
+	ForeignTableSettingsCacheTtlKey       = "cache_ttl"
+	ForeignTableSettingsCacheClearTimeKey = "cache_clear_time"
 )
 
 // ConnectionStates is a handy array of all states

--- a/pkg/db/db_client/db_client_execute.go
+++ b/pkg/db/db_client/db_client_execute.go
@@ -195,7 +195,7 @@ func (c *DbClient) getQueryTiming(ctx context.Context, startTime time.Time, sess
 		resultChannel <- timingResult
 	}()
 
-	res, err := c.ExecuteSyncInSession(ctx, session, fmt.Sprintf("select id, rows_fetched, cache_hit, hydrate_calls from %s.scan_metadata where id > %d", constants.InternalSchema, session.ScanMetadataMaxId))
+	res, err := c.ExecuteSyncInSession(ctx, session, fmt.Sprintf("select id, rows_fetched, cache_hit, hydrate_calls from %s.%s where id > %d", constants.InternalSchema, constants.ForeignTableScanMetadata, session.ScanMetadataMaxId))
 	// if we failed to read scan metadata (either because the query failed or the plugin does not support it)
 	// just return
 	if err != nil || len(res.Rows) == 0 {

--- a/pkg/db/db_common/cache_control.go
+++ b/pkg/db/db_common/cache_control.go
@@ -13,27 +13,27 @@ import (
 func SetCacheTtl(ctx context.Context, duration time.Duration, connection *pgx.Conn) error {
 	duration = duration.Truncate(time.Second)
 	seconds := int(duration.Seconds())
-	return executeCacheCommand(ctx, constants.CommandTableSettingsCacheTtlKey, fmt.Sprint(seconds), connection)
+	return executeCacheCommand(ctx, constants.ForeignTableSettingsCacheTtlKey, fmt.Sprint(seconds), connection)
 }
 
 // CacheClear resets the max time on the cache
 // anything below this is not accepted
 func CacheClear(ctx context.Context, connection *pgx.Conn) error {
-	return executeCacheCommand(ctx, constants.CommandTableSettingsCacheClearTimeKey, "", connection)
+	return executeCacheCommand(ctx, constants.ForeignTableSettingsCacheClearTimeKey, "", connection)
 }
 
 // SetCacheEnabled enables/disables the cache
 func SetCacheEnabled(ctx context.Context, enabled bool, connection *pgx.Conn) error {
-	return executeCacheCommand(ctx, constants.CommandTableSettingsCacheKey, fmt.Sprint(enabled), connection)
+	return executeCacheCommand(ctx, constants.ForeignTableSettingsCacheKey, fmt.Sprint(enabled), connection)
 }
 
 func executeCacheCommand(ctx context.Context, settingName string, settingValue string, connection *pgx.Conn) error {
 	_, err := connection.Exec(ctx, fmt.Sprintf(
 		"insert into %s.%s (%s,%s) values ('%s','%s')",
 		constants.InternalSchema,
-		constants.CommandTableSettings,
-		constants.CommandTableSettingsKeyColumn,
-		constants.CommandTableSettingsValueColumn,
+		constants.ForeighTableSettings,
+		constants.ForeignTableSettingsKeyColumn,
+		constants.ForeignTableSettingsValueColumn,
 		settingName,
 		settingValue,
 	))

--- a/pkg/db/db_local/internal.go
+++ b/pkg/db/db_local/internal.go
@@ -38,8 +38,8 @@ func setupInternal(ctx context.Context, conn *pgx.Conn) error {
 		fmt.Sprintf(`CREATE SCHEMA IF NOT EXISTS %s;`, constants.InternalSchema),
 		fmt.Sprintf(`GRANT USAGE ON SCHEMA %s TO %s;`, constants.InternalSchema, constants.DatabaseUsersRole),
 		fmt.Sprintf("IMPORT FOREIGN SCHEMA \"%s\" FROM SERVER steampipe INTO %s;\n", constants.InternalSchema, constants.InternalSchema),
-		fmt.Sprintf("GRANT INSERT ON %s.%s TO %s;", constants.InternalSchema, constants.CommandTableSettings, constants.DatabaseUsersRole),
-		fmt.Sprintf("GRANT SELECT ON %s.%s TO %s;", constants.InternalSchema, constants.CommandTableScanMetadata, constants.DatabaseUsersRole),
+		fmt.Sprintf("GRANT INSERT ON %s.%s TO %s;", constants.InternalSchema, constants.ForeighTableSettings, constants.DatabaseUsersRole),
+		fmt.Sprintf("GRANT SELECT ON %s.%s TO %s;", constants.InternalSchema, constants.ForeignTableScanMetadata, constants.DatabaseUsersRole),
 	}
 	queries = append(queries, getFunctionAddStrings(db_common.Functions)...)
 	if _, err := ExecuteSqlInTransaction(ctx, conn, queries...); err != nil {


### PR DESCRIPTION
…