### PR TITLE
Refactor: remove redundant postgres log path check

### DIFF
--- a/pkg/db/db_local/locations.go
+++ b/pkg/db/db_local/locations.go
@@ -32,15 +32,6 @@ func getDatabaseLocation() string {
 	return loc
 }
 
-func getDatabaseLogDirectory() string {
-	loc := filepaths.EnsureLogDir()
-	if _, err := os.Stat(loc); os.IsNotExist(err) {
-		err = os.MkdirAll(loc, 0755)
-		error_helpers.FailOnErrorWithMessage(err, "could not create postgres logging directory")
-	}
-	return loc
-}
-
 func getDataLocation() string {
 	loc := filepath.Join(databaseInstanceDir(), "data")
 	if _, err := os.Stat(loc); os.IsNotExist(err) {

--- a/pkg/db/db_local/logs.go
+++ b/pkg/db/db_local/logs.go
@@ -5,12 +5,14 @@ import (
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/turbot/steampipe/pkg/filepaths"
 )
 
 const logRetentionDays = 7
 
 func TrimLogs() {
-	fileLocation := getDatabaseLogDirectory()
+	fileLocation := filepaths.EnsureLogDir()
 	files, err := os.ReadDir(fileLocation)
 	if err != nil {
 		log.Println("[TRACE] error listing db log directory", err)


### PR DESCRIPTION
Whilst reading the source researching #3535, I stumbled upon some an unnecessary function. My testing suggests this refactor has no side effects.