### PR TITLE
ociinstaller: simplify `installPluginConfigFiles`

### DIFF
--- a/pkg/ociinstaller/plugin.go
+++ b/pkg/ociinstaller/plugin.go
@@ -150,13 +150,8 @@ func installPluginConfigFiles(image *SteampipeImage, tempdir string) error {
 	}
 	// install config files (if they dont already exist)
 	sourcePath := filepath.Join(tempdir, image.Plugin.ConfigFileDir)
-	directory, err := os.Open(sourcePath)
-	if err != nil {
-		return fmt.Errorf("couldn't open source dir: %s", err)
-	}
-	defer directory.Close()
 
-	objects, err := directory.Readdir(-1)
+	objects, err := os.ReadDir(sourcePath)
 	if err != nil {
 		return fmt.Errorf("couldn't read source dir: %s", err)
 	}


### PR DESCRIPTION
We can simplify the following code

```go
dir, err := os.Open(dirname)
if err != nil {
	return err
}
defer dir.Close()

dirs, err := dir.Readdir(-1)
```

with just `os.ReadDir(dirname)`. The official documentation recommends `os.ReadDir` over `Readdir()` whenever possible [^1].

[^1]: "Most clients are better served by the more efficient ReadDir method." https://pkg.go.dev/os#File.Readdir