### PR TITLE
fix: change default listen address from `localhost` back to `network` and show all interfaces the service is listening on

### DIFF
--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -15,7 +15,7 @@ const (
 )
 
 const (
-	DatabaseDefaultListenAddresses   = "localhost"
+	DatabaseDefaultListenAddresses   = "network"
 	DatabaseDefaultPort              = 9193
 	DatabaseDefaultCheckQueryTimeout = 240
 	DatabaseSuperUser                = "root"

--- a/pkg/db/db_local/running_info.go
+++ b/pkg/db/db_local/running_info.go
@@ -39,6 +39,10 @@ func newRunningDBInstanceInfo(cmd *exec.Cmd, listenAddresses []string, port int,
 		StructVersion:   RunningDBStructVersion,
 	}
 
+	if len(dbState.ListenAddresses) == 1 && dbState.ListenAddresses[0] == "*" {
+		addrs, _ := utils.LocalAddresses()
+		dbState.ListenAddresses = append(dbState.ListenAddresses, addrs...)
+	}
 	return dbState
 }
 


### PR DESCRIPTION
Try and fix #3593.

With this change:

```
# steampipe service start --database-listen "*"
Steampipe service is running:

Database:

  Host(s):            [* 192.168.1.5 192.168.122.1 192.168.39.1]
  Port:               9193
  Database:           steampipe
  User:               steampipe
  Password:           ********* [use --show-password to reveal]
  Connection string:  postgres://steampipe@127.0.0.1:9193/steampipe

Managing the Steampipe service:

  # Get status of the service
  steampipe service status

  # View database password for connecting from another machine
  steampipe service status --show-password

  # Restart the service
  steampipe service restart

  # Stop the service
  steampipe service stop

# steampipe service status
Steampipe service is running:

Database:

  Host(s):            [* 192.168.1.5 192.168.122.1 192.168.39.1]
  Port:               9193
  Database:           steampipe
  User:               steampipe
  Password:           ********* [use --show-password to reveal]
  Connection string:  postgres://steampipe@127.0.0.1:9193/steampipe

Managing the Steampipe service:

  # Get status of the service
  steampipe service status

  # View database password for connecting from another machine
  steampipe service status --show-password

  # Restart the service
  steampipe service restart

  # Stop the service
  steampipe service stop

```


```
# steampipe service start --database-listen network
Steampipe service is running:

Database:

  Host(s):            [* 192.168.1.5 192.168.122.1 192.168.39.1 100.106.208.87 172.17.0.1 172.18.0.1 10.0.17.107]
  Port:               9193
  Database:           steampipe
  User:               steampipe
  Password:           ********* [use --show-password to reveal]
  Connection string:  postgres://steampipe@127.0.0.1:9193/steampipe

Managing the Steampipe service:

  # Get status of the service
  steampipe service status

  # View database password for connecting from another machine
  steampipe service status --show-password

  # Restart the service
  steampipe service restart

  # Stop the service
  steampipe service stop

# steampipe service status
Steampipe service is running:

Database:

  Host(s):            [* 192.168.1.5 192.168.122.1 192.168.39.1 100.106.208.87 172.17.0.1 172.18.0.1 10.0.17.107]
  Port:               9193
  Database:           steampipe
  User:               steampipe
  Password:           ********* [use --show-password to reveal]
  Connection string:  postgres://steampipe@127.0.0.1:9193/steampipe

Managing the Steampipe service:

  # Get status of the service
  steampipe service status

  # View database password for connecting from another machine
  steampipe service status --show-password

  # Restart the service
  steampipe service restart

  # Stop the service
  steampipe service stop
```