### PR TITLE
Clean up tmp dirs before plugin install

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -12,6 +14,7 @@ import (
 	"github.com/gosuri/uiprogress"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/turbot/go-kit/files"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe/pkg/cmdconfig"
 	"github.com/turbot/steampipe/pkg/constants"
@@ -19,6 +22,7 @@ import (
 	"github.com/turbot/steampipe/pkg/db/db_local"
 	"github.com/turbot/steampipe/pkg/display"
 	"github.com/turbot/steampipe/pkg/error_helpers"
+	"github.com/turbot/steampipe/pkg/filepaths"
 	"github.com/turbot/steampipe/pkg/installationstate"
 	"github.com/turbot/steampipe/pkg/ociinstaller"
 	"github.com/turbot/steampipe/pkg/ociinstaller/versionfile"
@@ -864,4 +868,29 @@ func getConnectionState(ctx context.Context) (steampipeconfig.ConnectionStateMap
 	}
 
 	return connectionStateMap, res
+}
+
+func cleanupOldTmpDirs() {
+	const tmpDirAgeThreshold = 24 * time.Hour
+	tmpDirs, err := files.ListFiles(filepaths.EnsurePluginDir(), &files.ListOptions{
+		Include: []string{"tmp-*"},
+		Flags:   files.AllRecursive,
+	})
+	if err != nil {
+		log.Printf("Error while globbing for tmp dirs in plugin dir: %s\n", err)
+		return
+	}
+
+	for _, tmpDir := range tmpDirs {
+		stat, err := os.Stat(tmpDir)
+		if err != nil {
+			log.Printf("Error while stating tmp dir %s: %s\n", tmpDir, err)
+			continue
+		}
+		if time.Since(stat.ModTime()) > tmpDirAgeThreshold {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				log.Printf("Error while removing old tmp dir %s: %s\n", tmpDir, err)
+			}
+		}
+	}
 }

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -299,6 +299,7 @@ func runPluginInstallCmd(cmd *cobra.Command, args []string) {
 func doPluginInstall(ctx context.Context, bar *uiprogress.Bar, pluginName string, wg *sync.WaitGroup, returnChannel chan *display.PluginInstallReport) {
 	var report *display.PluginInstallReport
 
+	cleanupOldTmpDirs()
 	pluginAlreadyInstalled, _ := plugin.Exists(pluginName)
 	if pluginAlreadyInstalled {
 		// set the bar to MAX

--- a/cmd/plugin_manager.go
+++ b/cmd/plugin_manager.go
@@ -117,4 +117,3 @@ func createPluginManagerLog() hclog.Logger {
 	log.SetFlags(0)
 	return logger
 }
-

--- a/cmd/plugin_manager.go
+++ b/cmd/plugin_manager.go
@@ -117,3 +117,26 @@ func createPluginManagerLog() hclog.Logger {
 	log.SetFlags(0)
 	return logger
 }
+
+func cleanupOldTmpDirs() {
+	const tmpDirAgeThreshold = 24 * time.Hour
+	tmpDirPattern := filepath.Join(filepaths.EnsurePluginDir(), "tmp-*")
+	tmpDirs, err := filepath.Glob(tmpDirPattern)
+	if err != nil {
+		log.Printf("Error while globbing for tmp dirs in plugin dir: %s\n", err)
+		return
+	}
+
+	for _, tmpDir := range tmpDirs {
+		stat, err := os.Stat(tmpDir)
+		if err != nil {
+			log.Printf("Error while stating tmp dir %s: %s\n", tmpDir, err)
+			continue
+		}
+		if time.Since(stat.ModTime()) > tmpDirAgeThreshold {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				log.Printf("Error while removing old tmp dir %s: %s\n", tmpDir, err)
+			}
+		}
+	}
+}

--- a/cmd/plugin_manager.go
+++ b/cmd/plugin_manager.go
@@ -118,25 +118,3 @@ func createPluginManagerLog() hclog.Logger {
 	return logger
 }
 
-func cleanupOldTmpDirs() {
-	const tmpDirAgeThreshold = 24 * time.Hour
-	tmpDirPattern := filepath.Join(filepaths.EnsurePluginDir(), "tmp-*")
-	tmpDirs, err := filepath.Glob(tmpDirPattern)
-	if err != nil {
-		log.Printf("Error while globbing for tmp dirs in plugin dir: %s\n", err)
-		return
-	}
-
-	for _, tmpDir := range tmpDirs {
-		stat, err := os.Stat(tmpDir)
-		if err != nil {
-			log.Printf("Error while stating tmp dir %s: %s\n", tmpDir, err)
-			continue
-		}
-		if time.Since(stat.ModTime()) > tmpDirAgeThreshold {
-			if err := os.RemoveAll(tmpDir); err != nil {
-				log.Printf("Error while removing old tmp dir %s: %s\n", tmpDir, err)
-			}
-		}
-	}
-}

--- a/pkg/plugin/cleanup.go
+++ b/pkg/plugin/cleanup.go
@@ -1,0 +1,35 @@
+package plugin
+
+import (
+	"log"
+	"os"
+	"time"
+
+	"github.com/turbot/go-kit/files"
+	"github.com/turbot/steampipe/pkg/filepaths"
+)
+
+func CleanupOldTmpDirs() {
+	const tmpDirAgeThreshold = 24 * time.Second
+	tmpDirs, err := files.ListFiles(filepaths.EnsurePluginDir(), &files.ListOptions{
+		Include: []string{"tmp-*"},
+		Flags:   files.DirectoriesRecursive,
+	})
+	if err != nil {
+		log.Printf("Error while globbing for tmp dirs in plugin dir: %s\n", err)
+		return
+	}
+
+	for _, tmpDir := range tmpDirs {
+		stat, err := os.Stat(tmpDir)
+		if err != nil {
+			log.Printf("Error while stating tmp dir %s: %s\n", tmpDir, err)
+			continue
+		}
+		if time.Since(stat.ModTime()) > tmpDirAgeThreshold {
+			if err := os.RemoveAll(tmpDir); err != nil {
+				log.Printf("Error while removing old tmp dir %s: %s\n", tmpDir, err)
+			}
+		}
+	}
+}

--- a/pkg/plugin/cleanup.go
+++ b/pkg/plugin/cleanup.go
@@ -10,7 +10,7 @@ import (
 )
 
 func CleanupOldTmpDirs() {
-	const tmpDirAgeThreshold = 24 * time.Second
+	const tmpDirAgeThreshold = 24 * time.Hour
 	tmpDirs, err := files.ListFiles(filepaths.EnsurePluginDir(), &files.ListOptions{
 		Include: []string{"tmp-*"},
 		Flags:   files.DirectoriesRecursive,

--- a/pkg/plugin/cleanup.go
+++ b/pkg/plugin/cleanup.go
@@ -16,19 +16,19 @@ func CleanupOldTmpDirs() {
 		Flags:   files.DirectoriesRecursive,
 	})
 	if err != nil {
-		log.Printf("Error while globbing for tmp dirs in plugin dir: %s\n", err)
+		log.Printf("[TRACE] Error while globbing for tmp dirs in plugin dir: %s", err)
 		return
 	}
 
 	for _, tmpDir := range tmpDirs {
 		stat, err := os.Stat(tmpDir)
 		if err != nil {
-			log.Printf("Error while stating tmp dir %s: %s\n", tmpDir, err)
+			log.Printf("[TRACE] Error while stating tmp dir %s: %s", tmpDir, err)
 			continue
 		}
 		if time.Since(stat.ModTime()) > tmpDirAgeThreshold {
 			if err := os.RemoveAll(tmpDir); err != nil {
-				log.Printf("Error while removing old tmp dir %s: %s\n", tmpDir, err)
+				log.Printf("[TRACE] Error while removing old tmp dir %s: %s", tmpDir, err)
 			}
 		}
 	}


### PR DESCRIPTION
#3438 

- Have added a single function that looks for `tmp-` dirs in the plugin path
- Remove that directory that has modified time greater than a day.

I have used that function before installing any plugin with the `plugin install` command, is there any other place this method needs to be called? Any further changes, let me know.

Thank you.