### PR TITLE
Set dashboard timeout with env

### DIFF
--- a/pkg/cmdconfig/viper.go
+++ b/pkg/cmdconfig/viper.go
@@ -101,6 +101,9 @@ func setBaseDefaults() {
 		constants.ArgDatabaseStartTimeout:    constants.DBStartTimeout.Seconds(),
 		constants.ArgServiceCacheEnabled:     true,
 		constants.ArgCacheMaxTtl:             300,
+
+		// dashboard
+		constants.ArgDashboardStartTimeout: constants.DashboardStartTimeout.Seconds(),
 	}
 
 	for k, v := range defaults {
@@ -148,8 +151,9 @@ func SetDefaultsFromEnv() {
 		constants.EnvMaxParallel:          {[]string{constants.ArgMaxParallel}, Int},
 		constants.EnvQueryTimeout:         {[]string{constants.ArgDatabaseQueryTimeout}, Int},
 		constants.EnvDatabaseStartTimeout: {[]string{constants.ArgDatabaseStartTimeout}, Int},
-		constants.EnvCacheTTL:             {[]string{constants.ArgCacheTtl}, Int},
-		constants.EnvCacheMaxTTL:          {[]string{constants.ArgCacheMaxTtl}, Int},
+		constants.EnvDashboardStartTimeout: {[]string{constants.ArgDashboardStartTimeout}, Int},
+		constants.EnvCacheTTL:              {[]string{constants.ArgCacheTtl}, Int},
+		constants.EnvCacheMaxTTL:           {[]string{constants.ArgCacheMaxTtl}, Int},
 
 		// we need this value to go into different locations
 		constants.EnvCacheEnabled: {[]string{

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -18,6 +18,7 @@ const (
 	ArgDashboard               = "dashboard"
 	ArgDashboardListen         = "dashboard-listen"
 	ArgDashboardPort           = "dashboard-port"
+	ArgDashboardStartTimeout   = "dashboard-start-timeout"
 	ArgForeground              = "foreground"
 	ArgInvoker                 = "invoker"
 	ArgUpdateCheck             = "update-check"
@@ -63,7 +64,6 @@ const (
 	ArgSnapshotLocation        = "snapshot-location"
 	ArgSnapshotTitle           = "snapshot-title"
 	ArgDatabaseStartTimeout    = "database-start-timeout"
-	ArgDashboardStartTimeout = "dashboard-start-timeout"
 )
 
 // metaquery mode arguments

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -63,6 +63,7 @@ const (
 	ArgSnapshotLocation        = "snapshot-location"
 	ArgSnapshotTitle           = "snapshot-title"
 	ArgDatabaseStartTimeout    = "database-start-timeout"
+	ArgDashboardStartTimeout = "dashboard-start-timeout"
 )
 
 // metaquery mode arguments

--- a/pkg/constants/duration.go
+++ b/pkg/constants/duration.go
@@ -3,10 +3,10 @@ package constants
 import "time"
 
 var (
-	DashboardServiceStartTimeout = 30 * time.Second
-	DBStartTimeout               = 30 * time.Second
-	DBConnectionRetryBackoff     = 200 * time.Millisecond
-	DBRecoveryTimeout            = 24 * time.Hour
-	DBRecoveryRetryBackoff       = 200 * time.Millisecond
-	ServicePingInterval          = 50 * time.Millisecond
+	DashboardStartTimeout    = 30 * time.Second
+	DBStartTimeout           = 30 * time.Second
+	DBConnectionRetryBackoff = 200 * time.Millisecond
+	DBRecoveryTimeout        = 24 * time.Hour
+	DBRecoveryRetryBackoff   = 200 * time.Millisecond
+	ServicePingInterval      = 50 * time.Millisecond
 )

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -8,7 +8,8 @@ const (
 	EnvServicePassword = "STEAMPIPE_DATABASE_PASSWORD"
 	EnvMaxParallel     = "STEAMPIPE_MAX_PARALLEL"
 
-	EnvDatabaseStartTimeout = "STEAMPIPE_DATABASE_START_TIMEOUT"
+	EnvDatabaseStartTimeout  = "STEAMPIPE_DATABASE_START_TIMEOUT"
+	EnvDashboardStartTimeout = "STEAMPIPE_DASHBOARD_START_TIMEOUT"
 
 	EnvSnapshotLocation  = "STEAMPIPE_SNAPSHOT_LOCATION"
 	EnvWorkspaceDatabase = "STEAMPIPE_WORKSPACE_DATABASE"

--- a/pkg/dashboard/dashboardserver/service.go
+++ b/pkg/dashboard/dashboardserver/service.go
@@ -177,7 +177,7 @@ func waitForDashboardService(ctx context.Context) error {
 	defer utils.LogTime("db.waitForDashboardServerStartup end")
 
 	pingTimer := time.NewTicker(constants.ServicePingInterval)
-	timeoutAt := time.After(constants.DashboardServiceStartTimeout)
+	timeoutAt := time.After(time.Duration(viper.GetInt(constants.ArgDashboardStartTimeout)) * time.Second)
 	defer pingTimer.Stop()
 
 	for {

--- a/pkg/steampipeconfig/load_config_test.go
+++ b/pkg/steampipeconfig/load_config_test.go
@@ -26,6 +26,9 @@ var databaseListen = "local"
 var databaseSearchPath = "aws,gcp,foo"
 var databaseQueryTimeout int64 = 240
 
+var globalDashboardPort = 9194
+var globalDashboardListen = "local"
+
 var terminalMulti = false
 var terminalOutput = "table"
 var terminalHeader = true
@@ -162,6 +165,10 @@ var testCasesLoadConfig = map[string]loadConfigTest{
 				Listen:     &databaseListen,
 				SearchPath: &databaseSearchPath,
 			},
+			GlobalDashboardOptions: &options.GlobalDashboard{
+				Port:   &globalDashboardPort,
+				Listen: &globalDashboardListen,
+			},
 			GeneralOptions: &options.General{
 				UpdateCheck: &generalUpdateCheck,
 			},
@@ -208,6 +215,10 @@ var testCasesLoadConfig = map[string]loadConfigTest{
 				Listen:     &databaseListen,
 				SearchPath: &databaseSearchPath,
 			},
+			GlobalDashboardOptions: &options.GlobalDashboard{
+				Port:   &globalDashboardPort,
+				Listen: &globalDashboardListen,
+			},
 			GeneralOptions: &options.General{
 				UpdateCheck: &generalUpdateCheck,
 			},
@@ -248,6 +259,10 @@ var testCasesLoadConfig = map[string]loadConfigTest{
 				Port:       &databasePort,
 				Listen:     &databaseListen,
 				SearchPath: &databaseSearchPath,
+			},
+			GlobalDashboardOptions: &options.GlobalDashboard{
+				Port:   &globalDashboardPort,
+				Listen: &globalDashboardListen,
 			},
 			GeneralOptions: &options.General{
 				UpdateCheck: &generalUpdateCheck,
@@ -292,6 +307,10 @@ var testCasesLoadConfig = map[string]loadConfigTest{
 				Listen:     &databaseListen,
 				SearchPath: &databaseSearchPath,
 			},
+			GlobalDashboardOptions: &options.GlobalDashboard{
+				Port:   &globalDashboardPort,
+				Listen: &globalDashboardListen,
+			},
 			GeneralOptions: &options.General{
 				UpdateCheck: &generalUpdateCheck,
 			},
@@ -309,6 +328,10 @@ var testCasesLoadConfig = map[string]loadConfigTest{
 				Port:       &databasePort,
 				Listen:     &databaseListen,
 				SearchPath: &databaseSearchPath,
+			},
+			GlobalDashboardOptions: &options.GlobalDashboard{
+				Port:   &globalDashboardPort,
+				Listen: &globalDashboardListen,
 			},
 			GeneralOptions: &options.General{
 				UpdateCheck: &generalUpdateCheck,
@@ -383,6 +406,7 @@ func SteampipeConfigEquals(left, right *SteampipeConfig) bool {
 
 	return reflect.DeepEqual(left.DefaultConnectionOptions, right.DefaultConnectionOptions) &&
 		reflect.DeepEqual(left.DatabaseOptions, right.DatabaseOptions) &&
+		reflect.DeepEqual(left.GlobalDashboardOptions, right.GlobalDashboardOptions) &&
 		reflect.DeepEqual(left.TerminalOptions, right.TerminalOptions) &&
 		reflect.DeepEqual(left.GeneralOptions, right.GeneralOptions)
 }

--- a/pkg/steampipeconfig/options/dashboard.go
+++ b/pkg/steampipeconfig/options/dashboard.go
@@ -15,8 +15,9 @@ type WorkspaceProfileDashboard struct {
 
 type GlobalDashboard struct {
 	// server settings
-	Port   *int    `hcl:"port"`
-	Listen *string `hcl:"listen"`
+	Port         *int    `hcl:"port"`
+	Listen       *string `hcl:"listen"`
+	StartTimeout *int    `hcl:"start_timeout"`
 }
 
 func (t *WorkspaceProfileDashboard) SetBaseProperties(otherOptions Options) {
@@ -77,6 +78,11 @@ func (d *GlobalDashboard) ConfigMap() map[string]interface{} {
 	if d.Listen != nil {
 		res[constants.ArgDashboardListen] = d.Listen
 	}
+	if d.StartTimeout != nil {
+		res[constants.ArgDashboardStartTimeout] = d.StartTimeout
+	} else {
+		res[constants.ArgDashboardStartTimeout] = constants.DashboardStartTimeout.Seconds()
+	}
 	return res
 }
 
@@ -93,6 +99,9 @@ func (d *GlobalDashboard) Merge(otherOptions Options) {
 		}
 		if o.Listen != nil {
 			d.Listen = o.Listen
+		}
+		if o.StartTimeout != nil {
+			d.StartTimeout = o.StartTimeout
 		}
 	}
 }
@@ -111,6 +120,11 @@ func (d *GlobalDashboard) String() string {
 		str = append(str, "  Listen: nil")
 	} else {
 		str = append(str, fmt.Sprintf("  Listen: %s", *d.Listen))
+	}
+	if d.StartTimeout == nil {
+		str = append(str, "  StartTimeout: nil")
+	} else {
+		str = append(str, fmt.Sprintf("  StartTimeout: %d", *d.StartTimeout))
 	}
 	return strings.Join(str, "\n")
 }

--- a/pkg/steampipeconfig/options/database.go
+++ b/pkg/steampipeconfig/options/database.go
@@ -108,9 +108,9 @@ func (d *Database) String() string {
 		str = append(str, fmt.Sprintf("  SearchPath: %s", *d.SearchPath))
 	}
 	if d.StartTimeout == nil {
-		str = append(str, "  ServiceStartTimeout: nil")
+		str = append(str, "  StartTimeout: nil")
 	} else {
-		str = append(str, fmt.Sprintf("  ServiceStartTimeout: %d", *d.StartTimeout))
+		str = append(str, fmt.Sprintf("  StartTimeout: %d", *d.StartTimeout))
 	}
 	if d.SearchPathPrefix == nil {
 		str = append(str, "  SearchPathPrefix: nil")

--- a/pkg/steampipeconfig/steampipeconfig.go
+++ b/pkg/steampipeconfig/steampipeconfig.go
@@ -22,6 +22,7 @@ type SteampipeConfig struct {
 	// Steampipe options
 	DefaultConnectionOptions *options.Connection
 	DatabaseOptions          *options.Database
+	GlobalDashboardOptions   *options.GlobalDashboard
 	TerminalOptions          *options.Terminal
 	GeneralOptions           *options.General
 	// TODO remove this
@@ -73,6 +74,9 @@ func (c *SteampipeConfig) ConfigMap() map[string]interface{} {
 	if c.DatabaseOptions != nil {
 		res.PopulateConfigMapForOptions(c.DatabaseOptions)
 	}
+	if c.GlobalDashboardOptions != nil {
+		res.PopulateConfigMapForOptions(c.GlobalDashboardOptions)
+	}
 	if c.TerminalOptions != nil {
 		res.PopulateConfigMapForOptions(c.TerminalOptions)
 	}
@@ -98,6 +102,12 @@ func (c *SteampipeConfig) SetOptions(opts options.Options) (errorsAndWarnings *m
 			c.DatabaseOptions = o
 		} else {
 			c.DatabaseOptions.Merge(o)
+		}
+	case *options.GlobalDashboard:
+		if c.GlobalDashboardOptions == nil {
+			c.GlobalDashboardOptions = o
+		} else {
+			c.GlobalDashboardOptions.Merge(o)
 		}
 	case *options.Terminal:
 		// TODO: remove in 0.21 [https://github.com/turbot/steampipe/issues/3251]
@@ -228,6 +238,12 @@ DefaultConnectionOptions:
 
 DatabaseOptions:
 %s`, c.DatabaseOptions.String())
+	}
+	if c.GlobalDashboardOptions != nil {
+		str += fmt.Sprintf(`
+
+GlobalDashboardOptions:
+%s`, c.GlobalDashboardOptions.String())
 	}
 	if c.TerminalOptions != nil {
 		str += fmt.Sprintf(`


### PR DESCRIPTION
When you have a lot of dashboards it may take more then 30 seconds to start up especially in a resource contained environment i.e. running it in a container in Kubernetes