### PR TITLE
add  sprig functions needed to create fragment ids

### DIFF
--- a/pkg/control/controldisplay/template_functions.go
+++ b/pkg/control/controldisplay/template_functions.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"text/template"
 	"time"
+
 	"github.com/Masterminds/sprig/v3"
 )
 

--- a/pkg/control/controldisplay/template_functions.go
+++ b/pkg/control/controldisplay/template_functions.go
@@ -8,7 +8,11 @@ import (
 	"sync"
 	"text/template"
 	"time"
-
+	"regexp"
+	"golang.org/x/text/runes"
+	"golang.org/x/text/transform"
+	"golang.org/x/text/unicode/norm"
+	"unicode"
 	"github.com/Masterminds/sprig/v3"
 )
 
@@ -34,6 +38,7 @@ func templateFuncs(renderContext TemplateRenderContext) template.FuncMap {
 	formatterTemplateFuncMap := template.FuncMap{
 		"durationInSeconds": durationInSeconds,
 		"toCsvCell":         toCSVCellFnFactory(renderContext.Config.Separator),
+		"safeFragmentId": safeFragmentId,
 	}
 	for k, v := range formatterTemplateFuncMap {
 		funcs[k] = v
@@ -67,3 +72,36 @@ func toCSVCellFnFactory(comma string) func(interface{}) string {
 
 // durationInSeconds returns the passed in duration as seconds
 func durationInSeconds(t time.Duration) float64 { return t.Seconds() }
+
+func safeFragmentId(s string) string {
+	// Normalize unicode characters
+	t := transform.Chain(norm.NFD, runes.Remove(runes.In(unicode.Mn)), norm.NFC)
+	s, _, _ = transform.String(t, s)
+
+	// Lowercase the string
+	s = strings.ToLower(s)
+
+	// Convert ampersands to "and"
+	s = strings.ReplaceAll(s, "&", "and")
+
+	// Replace spaces, hyphens, and underscores with single hyphen
+	s = regexp.MustCompile(`[\s-_]+`).ReplaceAllString(s, "-")
+
+	// Keep only alphanumeric characters and hyphens
+	s = regexp.MustCompile(`[^a-z0-9-]+`).ReplaceAllString(s, "")
+
+	// Trim leading and trailing hyphens
+	s = strings.Trim(s, "-")
+
+	// Use "id" if the string is empty after sanitization
+	if len(s) == 0 {
+			s = "id"
+	}
+
+	// Truncate the string to 100 characters
+	if len(s) > 100 {
+			s = s[:100]
+	}
+
+	return s
+}

--- a/pkg/control/controldisplay/template_functions_test.go
+++ b/pkg/control/controldisplay/template_functions_test.go
@@ -11,36 +11,3 @@ func BenchmarkToCsvCell(b *testing.B) {
 		toCsvCell(i)
 	}
 }
-
-
-func TestSafeFragmentId(t *testing.T) {
-	cases := []struct {
-		input, want string
-	}{
-		{"This is a test", "this-is-a-test"},
-		{"Thîs ïs à Unicôde Strïng", "this-is-a-unicode-string"},
-		{"With special & characters!", "with-special-and-characters"},
-		{"", "id"}, // testing empty string, the function should return a default "id"
-		{"!!!!", "id"}, // testing string with characters that will be removed
-		{"'Single' & \"Double\" quotes", "single-and-double-quotes"},
-		{"   Trim spaces   ", "trim-spaces"},
-		{"-Trim-hyphens--", "trim-hyphens"},
-		{"Mixed CASE", "mixed-case"},
-		{"Spaces and_underscores", "spaces-and-underscores"},
-		{"Trailing hyphen-", "trailing-hyphen"},
-		{"_Leading and trailing underscore_", "leading-and-trailing-underscore"},
-		{"01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"},
-		{"Non-ASCII characters like éçà", "non-ascii-characters-like-eca"},
-		{"Multiple spaces   in   a   row", "multiple-spaces-in-a-row"},
-		{"Hyphens--in--a--row", "hyphens-in-a-row"},
-		{"Underscores__in__a__row", "underscores-in-a-row"},
-		{"-_-Leading and trailing hyphens and underscores -_-", "leading-and-trailing-hyphens-and-underscores"},
-}
-
-	for _, c := range cases {
-		got := safeFragmentId(c.input)
-		if got != c.want {
-			t.Errorf("safeFragmentId(%q) == %q, want %q", c.input, got, c.want)
-		}
-	}
-}

--- a/pkg/control/controldisplay/template_functions_test.go
+++ b/pkg/control/controldisplay/template_functions_test.go
@@ -11,3 +11,36 @@ func BenchmarkToCsvCell(b *testing.B) {
 		toCsvCell(i)
 	}
 }
+
+
+func TestSafeFragmentId(t *testing.T) {
+	cases := []struct {
+		input, want string
+	}{
+		{"This is a test", "this-is-a-test"},
+		{"Thîs ïs à Unicôde Strïng", "this-is-a-unicode-string"},
+		{"With special & characters!", "with-special-and-characters"},
+		{"", "id"}, // testing empty string, the function should return a default "id"
+		{"!!!!", "id"}, // testing string with characters that will be removed
+		{"'Single' & \"Double\" quotes", "single-and-double-quotes"},
+		{"   Trim spaces   ", "trim-spaces"},
+		{"-Trim-hyphens--", "trim-hyphens"},
+		{"Mixed CASE", "mixed-case"},
+		{"Spaces and_underscores", "spaces-and-underscores"},
+		{"Trailing hyphen-", "trailing-hyphen"},
+		{"_Leading and trailing underscore_", "leading-and-trailing-underscore"},
+		{"01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789", "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"},
+		{"Non-ASCII characters like éçà", "non-ascii-characters-like-eca"},
+		{"Multiple spaces   in   a   row", "multiple-spaces-in-a-row"},
+		{"Hyphens--in--a--row", "hyphens-in-a-row"},
+		{"Underscores__in__a__row", "underscores-in-a-row"},
+		{"-_-Leading and trailing hyphens and underscores -_-", "leading-and-trailing-hyphens-and-underscores"},
+}
+
+	for _, c := range cases {
+		got := safeFragmentId(c.input)
+		if got != c.want {
+			t.Errorf("safeFragmentId(%q) == %q, want %q", c.input, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
Doubtless useful in other ways, but here's the immediate use:

```
{{ $loweredAndHyphenated := .Description | lower | replace " " "-" }}
{{ $nonAsciiRemoved := $loweredAndHyphenated | regexReplaceAllLiteral "[^a-zA-Z0-9]+" "" }}

<section class="control" id="{{ if $nonAsciiRemoved }}{{ $nonAsciiRemoved | trunc 100 }}{{ else }}{{ $loweredAndHyphenated | trunc 100}}{{ end }}">
```