### PR TITLE
Add flag for disabling writing of default plugin config during plugin installation. Closes #3531. Closes #2206

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -546,7 +546,7 @@ func installPlugin(ctx context.Context, pluginName string, isUpdate bool, bar *u
 		}
 	}()
 
-	image, err := plugin.Install(ctx, pluginName, progress, ociinstaller.WithSkipConfigEnabled(viper.GetBool(constants.ArgSkipConfig)))
+	image, err := plugin.Install(ctx, pluginName, progress, ociinstaller.WithSkipConfig(viper.GetBool(constants.ArgSkipConfig)))
 	if err != nil {
 		msg := ""
 		_, name, stream := ociinstaller.NewSteampipeImageRef(pluginName).GetOrgNameAndStream()

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -47,25 +47,6 @@ type pluginJsonOutput struct {
 	Warnings  []string          `json:"warnings"`
 }
 
-type configFileOption struct {
-	skip bool
-}
-
-func NewConfigFileOption() *configFileOption {
-	skip := cmdconfig.Viper().GetBool(constants.ArgSkipConfig)
-	return &configFileOption{
-		skip: skip,
-	}
-}
-
-type SkipConfigFile = func(config *configFileOption)
-
-func WithSkipConfig() SkipConfigFile {
-	return func(o *configFileOption) {
-		o.skip = false
-	}
-}
-
 // Plugin management commands
 func pluginCmd() *cobra.Command {
 	var cmd = &cobra.Command{
@@ -565,8 +546,7 @@ func installPlugin(ctx context.Context, pluginName string, isUpdate bool, bar *u
 		}
 	}()
 
-	withSkipConfig := NewConfigFileOption().skip
-	image, err := plugin.Install(ctx, pluginName, progress, withSkipConfig)
+	image, err := plugin.Install(ctx, pluginName, progress, ociinstaller.WithSkipConfigEnabled(viper.GetBool(constants.ArgSkipConfig)))
 	if err != nil {
 		msg := ""
 		_, name, stream := ociinstaller.NewSteampipeImageRef(pluginName).GetOrgNameAndStream()

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -18,7 +18,7 @@ const (
 	ArgDashboard               = "dashboard"
 	ArgDashboardListen         = "dashboard-listen"
 	ArgDashboardPort           = "dashboard-port"
-	ArgDefaultConfig           = "default-config"
+	ArgSkipConfig              = "skip-config"
 	ArgForeground              = "foreground"
 	ArgInvoker                 = "invoker"
 	ArgUpdateCheck             = "update-check"

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -18,6 +18,7 @@ const (
 	ArgDashboard               = "dashboard"
 	ArgDashboardListen         = "dashboard-listen"
 	ArgDashboardPort           = "dashboard-port"
+	ArgDefaultConfig           = "default-config"
 	ArgForeground              = "foreground"
 	ArgInvoker                 = "invoker"
 	ArgUpdateCheck             = "update-check"

--- a/pkg/ociinstaller/config.go
+++ b/pkg/ociinstaller/config.go
@@ -1,0 +1,13 @@
+package ociinstaller
+
+type pluginInstallConfig struct {
+	skipConfigFile bool
+}
+
+type PluginInstallOption = func(config *pluginInstallConfig)
+
+func WithSkipConfigEnabled(skipConfigFile bool) PluginInstallOption {
+	return func(o *pluginInstallConfig) {
+		o.skipConfigFile = skipConfigFile
+	}
+}

--- a/pkg/ociinstaller/config.go
+++ b/pkg/ociinstaller/config.go
@@ -6,7 +6,7 @@ type pluginInstallConfig struct {
 
 type PluginInstallOption = func(config *pluginInstallConfig)
 
-func WithSkipConfigEnabled(skipConfigFile bool) PluginInstallOption {
+func WithSkipConfig(skipConfigFile bool) PluginInstallOption {
 	return func(o *pluginInstallConfig) {
 		o.skipConfigFile = skipConfigFile
 	}

--- a/pkg/ociinstaller/plugin.go
+++ b/pkg/ociinstaller/plugin.go
@@ -22,7 +22,7 @@ import (
 var versionFileUpdateLock = &sync.Mutex{}
 
 // InstallPlugin installs a plugin from an OCI Image
-func InstallPlugin(ctx context.Context, imageRef string, sub chan struct{}) (*SteampipeImage, error) {
+func InstallPlugin(ctx context.Context, imageRef string, sub chan struct{}, withSkipConfig bool) (*SteampipeImage, error) {
 	tempDir := NewTempDir(filepaths.EnsurePluginDir())
 	defer func() {
 		// send a last beacon to signal completion
@@ -50,8 +50,10 @@ func InstallPlugin(ctx context.Context, imageRef string, sub chan struct{}) (*St
 		return nil, fmt.Errorf("plugin installation failed: %s", err)
 	}
 	sub <- struct{}{}
-	if err = installPluginConfigFiles(image, tempDir.Path); err != nil {
-		return nil, fmt.Errorf("plugin installation failed: %s", err)
+	if !withSkipConfig {
+		if err = installPluginConfigFiles(image, tempDir.Path); err != nil {
+			return nil, fmt.Errorf("plugin installation failed: %s", err)
+		}
 	}
 	sub <- struct{}{}
 	if err := updatePluginVersionFiles(image); err != nil {

--- a/pkg/plugin/actions.go
+++ b/pkg/plugin/actions.go
@@ -71,9 +71,8 @@ func Exists(plugin string) (bool, error) {
 }
 
 // Install installs a plugin in the local file system
-func Install(ctx context.Context, plugin string, sub chan struct{}, options ...bool) (*ociinstaller.SteampipeImage, error) {
-	withSkipConfig := options[0]
-	image, err := ociinstaller.InstallPlugin(ctx, plugin, sub, withSkipConfig)
+func Install(ctx context.Context, plugin string, sub chan struct{}, opts ...ociinstaller.PluginInstallOption) (*ociinstaller.SteampipeImage, error) {
+	image, err := ociinstaller.InstallPlugin(ctx, plugin, sub, opts...)
 	return image, err
 }
 

--- a/pkg/plugin/actions.go
+++ b/pkg/plugin/actions.go
@@ -71,8 +71,9 @@ func Exists(plugin string) (bool, error) {
 }
 
 // Install installs a plugin in the local file system
-func Install(ctx context.Context, plugin string, sub chan struct{}) (*ociinstaller.SteampipeImage, error) {
-	image, err := ociinstaller.InstallPlugin(ctx, plugin, sub)
+func Install(ctx context.Context, plugin string, sub chan struct{}, options ...bool) (*ociinstaller.SteampipeImage, error) {
+	withSkipConfig := options[0]
+	image, err := ociinstaller.InstallPlugin(ctx, plugin, sub, withSkipConfig)
 	return image, err
 }
 

--- a/tests/acceptance/test_files/service_and_plugin.bats
+++ b/tests/acceptance/test_files/service_and_plugin.bats
@@ -727,7 +727,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
 @test "verify that plugin installed with --skip-config as true, should not have create a default config .spc file in config folder" {
 >>>>>>> 76591edb (fix: reviewd changes for skip config file creation)
   tmpdir=$(mktemp -d)
-  run steampipe plugin install aws --skip-config=true--install-dir $tmpdir
+  run steampipe plugin install aws --skip-config --install-dir $tmpdir
   assert_success
 
   run test -f $tmpdir/config/aws.spc
@@ -736,9 +736,9 @@ load "$LIB_BATS_SUPPORT/load.bash"
   rm -rf $tmpdir
 }
 
-@test "verify that plugin installed with --skip-config as false, should have default config .spc file in config folder" {
+@test "verify that plugin installed with --skip-config as false(default), should have default config .spc file in config folder" {
   tmpdir=$(mktemp -d)
-  run steampipe plugin install aws --skip-config=false --install-dir $tmpdir
+  run steampipe plugin install aws --install-dir $tmpdir
   assert_success
 
   run test -f $tmpdir/config/aws.spc
@@ -768,7 +768,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
   run steampipe plugin uninstall aws --install-dir $tmpdir
 
-  run steampipe plugin install aws --skip-config=true --install-dir $tmpdir
+  run steampipe plugin install aws --skip-config --install-dir $tmpdir
 
   run test -f $tmpdir/config/aws.spc
   assert_success

--- a/tests/acceptance/test_files/service_and_plugin.bats
+++ b/tests/acceptance/test_files/service_and_plugin.bats
@@ -687,6 +687,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
   rm -rf $tmpdir
 }
 
+<<<<<<< HEAD
 @test "verify that steampipe check should bypass plugin requirement detection if installed plugin is local" {
   tmpdir=$(mktemp -d)
   run steampipe plugin install net --install-dir $tmpdir
@@ -722,8 +723,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
 }
 
 @test "verify that plugin installed with --default-config as false, should not have default config .spc file in config folder" {
+=======
+@test "verify that plugin installed with --skip-config as true, should not have create a default config .spc file in config folder" {
+>>>>>>> 76591edb (fix: reviewd changes for skip config file creation)
   tmpdir=$(mktemp -d)
-  run steampipe plugin install aws --default-config=false --install-dir $tmpdir
+  run steampipe plugin install aws --skip-config=true--install-dir $tmpdir
   assert_success
 
   run test -f $tmpdir/config/aws.spc
@@ -732,9 +736,9 @@ load "$LIB_BATS_SUPPORT/load.bash"
   rm -rf $tmpdir
 }
 
-@test "verify that plugin installed with --default-config as true, should have default config .spc file in config folder" {
+@test "verify that plugin installed with --skip-config as false, should have default config .spc file in config folder" {
   tmpdir=$(mktemp -d)
-  run steampipe plugin install aws --default-config=true --install-dir $tmpdir
+  run steampipe plugin install aws --skip-config=false --install-dir $tmpdir
   assert_success
 
   run test -f $tmpdir/config/aws.spc

--- a/tests/acceptance/test_files/service_and_plugin.bats
+++ b/tests/acceptance/test_files/service_and_plugin.bats
@@ -687,7 +687,6 @@ load "$LIB_BATS_SUPPORT/load.bash"
   rm -rf $tmpdir
 }
 
-<<<<<<< HEAD
 @test "verify that steampipe check should bypass plugin requirement detection if installed plugin is local" {
   tmpdir=$(mktemp -d)
   run steampipe plugin install net --install-dir $tmpdir
@@ -722,10 +721,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
   rm -rf $tmpdir
 }
 
-@test "verify that plugin installed with --default-config as false, should not have default config .spc file in config folder" {
-=======
 @test "verify that plugin installed with --skip-config as true, should not have create a default config .spc file in config folder" {
->>>>>>> 76591edb (fix: reviewd changes for skip config file creation)
   tmpdir=$(mktemp -d)
   run steampipe plugin install aws --skip-config --install-dir $tmpdir
   assert_success

--- a/tests/acceptance/test_files/service_and_plugin.bats
+++ b/tests/acceptance/test_files/service_and_plugin.bats
@@ -721,6 +721,28 @@ load "$LIB_BATS_SUPPORT/load.bash"
   rm -rf $tmpdir
 }
 
+@test "verify that plugin installed with --default-config as false, should not have default config .spc file in config folder" {
+  tmpdir=$(mktemp -d)
+  run steampipe plugin install aws --default-config=false --install-dir $tmpdir
+  assert_success
+
+  run test -f $tmpdir/config/aws.spc
+  assert_failure
+
+  rm -rf $tmpdir
+}
+
+@test "verify that plugin installed with --default-config as true, should have default config .spc file in config folder" {
+  tmpdir=$(mktemp -d)
+  run steampipe plugin install aws --default-config=true --install-dir $tmpdir
+  assert_success
+
+  run test -f $tmpdir/config/aws.spc
+  assert_success
+
+  rm -rf $tmpdir
+}
+
 @test "cleanup" {
   rm -f $STEAMPIPE_INSTALL_DIR/config/chaos_agg.spc
   run steampipe plugin uninstall steampipe


### PR DESCRIPTION
Addressing #3531 

- Have added a `--default-config` flag on `plugin install` command, it is set to `true` by default.
- To omit the setting of default config for the installed plugin the user needs to set it to false.

```
steampipe plugin install --default-config=false supabase
```

The approach is to join the path of the default config dir i.e. `~/.steampipe/config/` and the plugin name with the `.spc` extension. Is there a better way to obtain the file path of the plugin config?
Let me know if this approach is valid, or is it a bit hacky?

Thank you.