### PR TITLE
Fixes issue where steampipe was returning index out of range error when children property of a benchmark had an invalid name. Closes #3563

### DIFF
--- a/pkg/steampipeconfig/modconfig/parsed_property_path.go
+++ b/pkg/steampipeconfig/modconfig/parsed_property_path.go
@@ -64,11 +64,14 @@ func ParseResourcePropertyPath(propertyPath string) (*ParsedPropertyPath, error)
 		res.Mod = parts[0]
 		res.ItemType = parts[1]
 		res.Name = parts[2]
-	default:
+	case 4:
 		res.Mod = parts[0]
 		res.ItemType = parts[1]
 		res.Name = parts[2]
 		res.PropertyPath = parts[3:]
+	default:
+		res.Mod = parts[0]
+		res.ItemType = parts[1]
 	}
 
 	if !IsValidResourceItemType(res.ItemType) {

--- a/pkg/steampipeconfig/modconfig/parsed_property_path.go
+++ b/pkg/steampipeconfig/modconfig/parsed_property_path.go
@@ -55,8 +55,12 @@ func ParseResourcePropertyPath(propertyPath string) (*ParsedPropertyPath, error)
 	}
 
 	if IsValidResourceItemType(parts[0]) {
-		// put empty mod as first part
+		// put empty mod as first part - so we can assume always that the first part is mod
 		parts = append([]string{""}, parts...)
+	}
+	// at this point the length of property path must be at least 3 (i.e.<mod>.<resource>.<name>)
+	if len(parts) < 3 {
+		return nil, fmt.Errorf("invalid property path '%s' passed to ParseResourcePropertyPath", propertyPath)
 	}
 	switch len(parts) {
 	case 3:
@@ -64,14 +68,11 @@ func ParseResourcePropertyPath(propertyPath string) (*ParsedPropertyPath, error)
 		res.Mod = parts[0]
 		res.ItemType = parts[1]
 		res.Name = parts[2]
-	case 4:
+	default:
 		res.Mod = parts[0]
 		res.ItemType = parts[1]
 		res.Name = parts[2]
 		res.PropertyPath = parts[3:]
-	default:
-		res.Mod = parts[0]
-		res.ItemType = parts[1]
 	}
 
 	if !IsValidResourceItemType(res.ItemType) {

--- a/pkg/steampipeconfig/modconfig/parsed_property_path_test.go
+++ b/pkg/steampipeconfig/modconfig/parsed_property_path_test.go
@@ -1,14 +1,14 @@
 package modconfig
 
 import (
-	"github.com/turbot/go-kit/helpers"
 	"reflect"
 	"testing"
 )
 
 type parsePropertyPathTest struct {
-	input    string
-	expected any
+	input        string
+	expected     any
+	errorMessage string
 }
 
 var parsePropertyPathTestCases = map[string]parsePropertyPathTest{
@@ -19,6 +19,11 @@ var parsePropertyPathTestCases = map[string]parsePropertyPathTest{
 			Name:     "q1",
 			Original: "query.q1",
 		},
+	},
+	"invalid resource name": {
+		input:        "m1.q1",
+		expected:     "ERROR",
+		errorMessage: "unexpected error invalid property path 'm1.q1' passed to ParseResourcePropertyPath",
 	},
 	"qualified resource name": {
 		input: "m1.query.q1",
@@ -77,13 +82,7 @@ var parsePropertyPathTestCases = map[string]parsePropertyPathTest{
 }
 
 func TestParsePropertyPath(t *testing.T) {
-	testsToRun := []string{"self input"}
-
 	for name, test := range parsePropertyPathTestCases {
-		if len(testsToRun) > 0 && !helpers.StringSliceContains(testsToRun, name) {
-			continue
-		}
-
 		res, err := ParseResourcePropertyPath(test.input)
 		if err != nil {
 			if test.expected != "ERROR" {
@@ -91,7 +90,7 @@ func TestParsePropertyPath(t *testing.T) {
 			}
 			continue
 		}
-		if test.expected == "ERROR" {
+		if test.expected == "ERROR" && test.errorMessage == err.Error() {
 			t.Errorf("Test: '%s'' FAILED - expected error", name)
 			continue
 		}

--- a/pkg/steampipeconfig/modconfig/parsed_property_path_test.go
+++ b/pkg/steampipeconfig/modconfig/parsed_property_path_test.go
@@ -23,7 +23,7 @@ var parsePropertyPathTestCases = map[string]parsePropertyPathTest{
 	"invalid resource name": {
 		input:        "m1.q1",
 		expected:     "ERROR",
-		errorMessage: "unexpected error invalid property path 'm1.q1' passed to ParseResourcePropertyPath",
+		errorMessage: "invalid property path 'm1.q1' passed to ParseResourcePropertyPath",
 	},
 	"qualified resource name": {
 		input: "m1.query.q1",
@@ -87,12 +87,12 @@ func TestParsePropertyPath(t *testing.T) {
 		if err != nil {
 			if test.expected != "ERROR" {
 				t.Errorf("Test: '%s'' FAILED : \nunexpected error %v", name, err)
+				continue
 			}
-			continue
-		}
-		if test.expected == "ERROR" && test.errorMessage == err.Error() {
-			t.Errorf("Test: '%s'' FAILED - expected error", name)
-			continue
+			if test.expected == "ERROR" && test.errorMessage == err.Error() {
+				// test passed and error message matched
+				continue
+			}
 		}
 		if !propertyPathsEqual(res, test.expected.(*ParsedPropertyPath)) {
 			t.Errorf("Test: '%s'' FAILED : \nexpected:\n %v, \ngot:\n %v\n", name, test.expected, res)


### PR DESCRIPTION
![Screenshot 2023-08-31 at 3 49 48 PM](https://github.com/turbot/steampipe/assets/45908484/758a0ae3-7bb5-4392-aba4-72844afac511)
