### PR TITLE
Improve error message when steampipe fails to parse a mod definition file if a mod block does not exist. Closes #1198

### DIFF
--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -331,7 +331,6 @@ func runModInitCmd(cmd *cobra.Command, args []string) {
 		exitCode = constants.ExitCodeModInitFailed
 		error_helpers.FailOnError(err)
 	}
-	fmt.Printf("Created mod definition file '%s'\n", filepaths.ModFilePath(workspacePath))
 }
 
 // helpers
@@ -344,10 +343,12 @@ func createWorkspaceMod(ctx context.Context, cmd *cobra.Command, workspacePath s
 		fmt.Println("Working folder already contains a mod definition file")
 		return nil, nil
 	}
+	// write mod definition file
 	mod := modconfig.CreateDefaultMod(workspacePath)
 	if err := mod.Save(); err != nil {
 		return nil, err
 	}
+	fmt.Printf("Created mod definition file '%s'\n", filepaths.ModFilePath(workspacePath))
 
 	// load up the written mod file so that we get the updated
 	// block ranges

--- a/cmd/mod.go
+++ b/cmd/mod.go
@@ -348,7 +348,10 @@ func createWorkspaceMod(ctx context.Context, cmd *cobra.Command, workspacePath s
 	if err := mod.Save(); err != nil {
 		return nil, err
 	}
-	fmt.Printf("Created mod definition file '%s'\n", filepaths.ModFilePath(workspacePath))
+	// only print message for mod init (not for mod install)
+	if cmd.Name() == "init" {
+		fmt.Printf("Created mod definition file '%s'\n", filepaths.ModFilePath(workspacePath))
+	}
 
 	// load up the written mod file so that we get the updated
 	// block ranges

--- a/pkg/steampipeconfig/parse/mod.go
+++ b/pkg/steampipeconfig/parse/mod.go
@@ -73,7 +73,7 @@ func ParseModDefinition(modPath string, evalCtx *hcl.EvalContext) (*modconfig.Mo
 	if block == nil {
 		res.Diags = append(res.Diags, &hcl.Diagnostic{
 			Severity: hcl.DiagError,
-			Summary:  fmt.Sprintf("no mod definition found in %s", modPath),
+			Summary:  fmt.Sprintf("failed to parse mod definition file: no mod definition found in %s", fmt.Sprintf("%s/mod.sp", modPath)),
 		})
 		return nil, res
 	}


### PR DESCRIPTION
- empty mod.sp
![Screenshot 2023-09-14 at 7 14 42 PM](https://github.com/turbot/steampipe/assets/45908484/df4ad8e4-42ba-4fc3-a4ea-63cb2003f07b)


- mod.sp with no mod definition block(but not empty)
![Screenshot 2023-09-14 at 7 13 52 PM](https://github.com/turbot/steampipe/assets/45908484/0d8a76a9-6ed4-4d0d-a3c4-8f6486972b52)
