### PR TITLE
Updates messaging when service is started on an unavailable port. Closes #623

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -213,7 +213,6 @@ func startService(ctx context.Context, listenAddresses []string, port int, invok
 
 	// if the service is already running, then service start should make the service persistent
 	if startResult.Status == db_local.ServiceAlreadyRunning {
-
 		// check that we have the same port and listen parameters
 		if port != startResult.DbState.Port {
 			exitCode = constants.ExitCodeInsufficientOrWrongInputs
@@ -221,7 +220,7 @@ func startService(ctx context.Context, listenAddresses []string, port int, invok
 		}
 		if !utils.StringSlicesEqual(listenAddresses, startResult.DbState.ListenAddresses) {
 			exitCode = constants.ExitCodeInsufficientOrWrongInputs
-			error_helpers.FailOnError(fmt.Errorf("service is already running and listening on %s - cannot change listen addresses while it's running", startResult.DbState.ListenAddresses))
+			error_helpers.FailOnError(fmt.Errorf("service is already running and listening on %s - cannot change listen address while it's running", strings.Join(startResult.DbState.ListenAddresses, ", ")))
 		}
 
 		// convert to being invoked by service

--- a/pkg/db/db_local/start_services.go
+++ b/pkg/db/db_local/start_services.go
@@ -248,7 +248,7 @@ func startDB(ctx context.Context, listenAddresses []string, port int, invoker co
 	}
 
 	if err := utils.IsPortBindable(utils.GetFirstListenAddress(listenAddresses), port); err != nil {
-		return res.SetError(fmt.Errorf("cannot listen on %s %s and port %d. To check if there's any other steampipe services running, use %s", utils.Pluralize("address", len(listenAddresses)), constants.Bold(strings.Join(listenAddresses, ",")), constants.Bold(port), constants.Bold("steampipe service status --all")))
+		return res.SetError(fmt.Errorf("cannot listen on %s and port %d. To check if there's any other steampipe services running, use %s", constants.Bold(strings.Join(listenAddresses, ",")), constants.Bold(port), constants.Bold("steampipe service status --all")))
 	}
 
 	if err := migrateLegacyPasswordFile(); err != nil {

--- a/pkg/db/db_local/start_services.go
+++ b/pkg/db/db_local/start_services.go
@@ -248,7 +248,7 @@ func startDB(ctx context.Context, listenAddresses []string, port int, invoker co
 	}
 
 	if err := utils.IsPortBindable(utils.GetFirstListenAddress(listenAddresses), port); err != nil {
-		return res.SetError(fmt.Errorf("cannot listen on listenAddresses %s and port %d", constants.Bold(listenAddresses), constants.Bold(port)))
+		return res.SetError(fmt.Errorf("cannot listen on %s %s and port %d. To check if there's any other steampipe services running, use %s", utils.Pluralize("address", len(listenAddresses)), constants.Bold(strings.Join(listenAddresses, ",")), constants.Bold(port), constants.Bold("steampipe service status --all")))
 	}
 
 	if err := migrateLegacyPasswordFile(); err != nil {

--- a/pkg/db/db_local/start_services.go
+++ b/pkg/db/db_local/start_services.go
@@ -248,7 +248,7 @@ func startDB(ctx context.Context, listenAddresses []string, port int, invoker co
 	}
 
 	if err := utils.IsPortBindable(utils.GetFirstListenAddress(listenAddresses), port); err != nil {
-		return res.SetError(fmt.Errorf("cannot listen on %s and port %d. To check if there's any other steampipe services running, use %s", constants.Bold(strings.Join(listenAddresses, ",")), constants.Bold(port), constants.Bold("steampipe service status --all")))
+		return res.SetError(fmt.Errorf("cannot listen on port %d and %s %s. To check if there's any other steampipe services running, use %s", constants.Bold(port), utils.Pluralize("address", len(listenAddresses)), constants.Bold(strings.Join(listenAddresses, ",")), constants.Bold("steampipe service status --all")))
 	}
 
 	if err := migrateLegacyPasswordFile(); err != nil {


### PR DESCRIPTION
![Screenshot 2023-09-15 at 8 25 22 PM](https://github.com/turbot/steampipe/assets/1114038/a3ac2f8e-8c60-48b1-acfd-191ca538b228)


```
binaek@Turingmbp steampipe-mod-net-insights % steampipe service start --install-dir ~/another
Error: cannot listen on port 9193 and address *. To check if there's any other steampipe services running, use steampipe service status --all
```
```
binaek@Turingmbp steampipe-mod-net-insights % steampipe service start --database-listen 127.0.0.1,::1  --install-dir ~/another
Error: cannot listen on port 9193 and addresses 127.0.0.1,::1. To check if there's any other steampipe services running, use steampipe service status --all
```