### PR TITLE
Update help for 'steampipe plugin install'

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -103,6 +103,9 @@ is latest. The name is a required argument.
 
 Examples:
 
+	# Install all missing plugins that are specified in configuration files
+	steampipe plugin install
+
   # Install a common plugin (turbot/aws)
   steampipe plugin install aws
 

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -103,8 +103,8 @@ is latest. The name is a required argument.
 
 Examples:
 
-	# Install all missing plugins that are specified in configuration files
-	steampipe plugin install
+  # Install all missing plugins that are specified in configuration files
+  steampipe plugin install
 
   # Install a common plugin (turbot/aws)
   steampipe plugin install aws


### PR DESCRIPTION
`steampipe plugin install` can now auto discover required plugins and install them. It doesn't need arguments anymore