### PR TITLE
add jd patch to relevant plugins and steampipe tests

### DIFF
--- a/pkg/task/runner.go
+++ b/pkg/task/runner.go
@@ -162,7 +162,8 @@ func showNotificationsForCommand(cmd *cobra.Command, cmdArgs []string) bool {
 		IsPluginManagerCmd(cmd) ||
 		isServiceStopCmd(cmd) ||
 		IsBatchQueryCmd(cmd, cmdArgs) ||
-		isCompletionCmd(cmd))
+		isCompletionCmd(cmd) ||
+		isPluginListCmd(cmd))
 }
 
 func isServiceStopCmd(cmd *cobra.Command) bool {
@@ -179,4 +180,7 @@ func isPluginUpdateCmd(cmd *cobra.Command) bool {
 }
 func IsBatchQueryCmd(cmd *cobra.Command, cmdArgs []string) bool {
 	return cmd.Name() == "query" && len(cmdArgs) > 0
+}
+func isPluginListCmd(cmd *cobra.Command) bool {
+	return cmd.Name() == "list"
 }

--- a/pkg/task/runner.go
+++ b/pkg/task/runner.go
@@ -182,5 +182,5 @@ func IsBatchQueryCmd(cmd *cobra.Command, cmdArgs []string) bool {
 	return cmd.Name() == "query" && len(cmdArgs) > 0
 }
 func isPluginListCmd(cmd *cobra.Command) bool {
-	return cmd.Name() == "list"
+	return cmd.Name() == "list" && cmd.Parent() != nil && cmd.Parent().Name() == "plugin"
 }

--- a/tests/acceptance/test_files/cache.bats
+++ b/tests/acceptance/test_files/cache.bats
@@ -339,12 +339,8 @@ load "$LIB_BATS_SUPPORT/load.bash"
   steampipe service start
 
   steampipe query "select unique_col, a, b from chaos_cache_check" --output json &> output1.json
-  # store the result from 1st query in `content`
-  content=$(cat output1.json)
 
   steampipe query "select unique_col, a, b from chaos_cache_check" --output json &> output2.json
-  # store the result from 2nd query in `new_content`
-  new_content=$(cat output2.json)
 
   echo $content
   echo $new_content
@@ -353,7 +349,9 @@ load "$LIB_BATS_SUPPORT/load.bash"
   steampipe service stop
 
   # verify that `content` and `new_content` are the same
-  assert_equal "$new_content" "$content"
+  run jd -f patch output1.json output2.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
 
   rm -f output1.json
   rm -f output2.json

--- a/tests/acceptance/test_files/cache.bats
+++ b/tests/acceptance/test_files/cache.bats
@@ -342,16 +342,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
   steampipe query "select unique_col, a, b from chaos_cache_check" --output json &> output2.json
 
-  echo $content
-  echo $new_content
-
   # stop service
   steampipe service stop
 
-  # verify that `content` and `new_content` are the same
-  run jd -f patch output1.json output2.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
+  # verify that the json contents of output1 and output2 files are the same
+  run jd output1.json output2.json
+  echo $output
+  assert_success
 
   rm -f output1.json
   rm -f output2.json

--- a/tests/acceptance/test_files/chaos_and_query.bats
+++ b/tests/acceptance/test_files/chaos_and_query.bats
@@ -3,38 +3,34 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "select * from chaos.chaos_high_row_count order by column_0" {
   steampipe query --output json  "select * from chaos.chaos_high_row_count order by column_0 limit 10" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_1.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_1.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "select id, string_column, json_column, boolean_column from chaos.chaos_all_column_types where id='0'" {
   steampipe query --output json  "select id, string_column, json_column, boolean_column from chaos.chaos_all_column_types where id='0'" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_2.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_2.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "select * from chaos.chaos_high_column_count order by column_0" {
   steampipe query --output json  "select * from chaos.chaos_high_column_count order by column_0 limit 10" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_3.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_3.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "select * from chaos.chaos_hydrate_columns_dependency where id='0'" {
   steampipe query --output json "select * from chaos.chaos_hydrate_columns_dependency where id='0'" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_5.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_5.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "select * from chaos.chaos_list_error" {
@@ -60,29 +56,26 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "select * from chaos.chaos_parallel_hydrate_columns  where id='0'" {
   steampipe query --output json "select * from chaos.chaos_parallel_hydrate_columns  where id='0'" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_11.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_11.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "select float32_data, id, int64_data, uint16_data from chaos.chaos_all_numeric_column  where id='31'" {
   steampipe query --output json "select float32_data, id, int64_data, uint16_data from chaos.chaos_all_numeric_column  where id='31'" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_12.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-  
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_12.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "select transform_method_column from chaos_transforms order by id" {
   steampipe query --output json "select transform_method_column from chaos_transforms order by id" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_14.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_14.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "select parent_should_ignore_error from chaos.chaos_list_parent_child" {
@@ -92,11 +85,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "select from_qual_column from chaos_transforms where id=2" {
   steampipe query --output json "select from_qual_column from chaos_transforms where id=2" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_13.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-  
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_13.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "public schema insert select all types" {
@@ -104,21 +96,19 @@ load "$LIB_BATS_SUPPORT/load.bash"
   steampipe query "create table all_columns (nullcolumn CHAR(2), booleancolumn boolean, textcolumn1 CHAR(20), textcolumn2 VARCHAR(20),  textcolumn3 text, integercolumn1 smallint, integercolumn2 int, integercolumn3 SERIAL, integercolumn4 bigint,  integercolumn5 bigserial, numericColumn numeric(6,4), realColumn real, floatcolumn float,  date1 DATE,  time1 TIME,  timestamp1 TIMESTAMP, timestamp2 TIMESTAMPTZ, interval1 INTERVAL, array1 text[], jsondata jsonb, jsondata2 json, uuidcolumn UUID, ipAddress inet, macAddress macaddr, cidrRange cidr, xmlData xml, currency money)"
   steampipe query "INSERT INTO all_columns (nullcolumn, booleancolumn, textcolumn1, textcolumn2, textcolumn3, integercolumn1, integercolumn2, integercolumn3, integercolumn4, integercolumn5, numericColumn, realColumn, floatcolumn, date1, time1, timestamp1, timestamp2, interval1, array1, jsondata, jsondata2, uuidcolumn, ipAddress, macAddress, cidrRange, xmlData, currency) VALUES (NULL, TRUE, 'Yes', 'test for varchar', 'This is a very long text for the PostgreSQL text column', 3278, 21445454, 2147483645, 92233720368547758, 922337203685477580, 23.5141543, 4660.33777, 4.6816421254887534, '1978-02-05', '08:00:00', '2016-06-22 19:10:25-07', '2016-06-22 19:10:25-07', '1 year 2 months 3 days', '{\"(408)-589-5841\"}','{ \"customer\": \"John Doe\", \"items\": {\"product\": \"Beer\",\"qty\": 6}}', '{ \"customer\": \"John Doe\", \"items\": {\"product\": \"Beer\",\"qty\": 6}}', '6948DF80-14BD-4E04-8842-7668D9C001F5', '192.168.0.0', '08:00:2b:01:02:03', '10.1.2.3/32', '<book><title>Manual</title><chapter>...</chapter></book>', 922337203685477.57)"
   steampipe query "select * from all_columns" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_6.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_6.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
   run steampipe query "drop table all_columns"
 }
 
 @test "query json" {
   steampipe query "select 1 as val, 2 as col" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_query_json.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_query_json.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "query csv" {
@@ -192,11 +182,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "json" {
   steampipe query --output json "select id, string_column, json_column from chaos.chaos_all_column_types where id='0'" > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_json.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_json.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "line" {
@@ -261,11 +250,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   # run steampipe query twice - the bug we are testing for caused the workspace lock to be deleted after the first query
   steampipe query "select 1 as a" --output json
   steampipe query "select 1 as a" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/expected_15.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_15.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 function teardown_file() {

--- a/tests/acceptance/test_files/chaos_and_query.bats
+++ b/tests/acceptance/test_files/chaos_and_query.bats
@@ -2,23 +2,39 @@ load "$LIB_BATS_ASSERT/load.bash"
 load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "select * from chaos.chaos_high_row_count order by column_0" {
-  run steampipe query --output json  "select * from chaos.chaos_high_row_count order by column_0 limit 10"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_1.json)"
+  steampipe query --output json  "select * from chaos.chaos_high_row_count order by column_0 limit 10" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_1.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "select id, string_column, json_column, boolean_column from chaos.chaos_all_column_types where id='0'" {
-  run steampipe query --output json  "select id, string_column, json_column, boolean_column from chaos.chaos_all_column_types where id='0'"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_2.json)"
+  steampipe query --output json  "select id, string_column, json_column, boolean_column from chaos.chaos_all_column_types where id='0'" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_2.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "select * from chaos.chaos_high_column_count order by column_0" {
-  run steampipe query --output json  "select * from chaos.chaos_high_column_count order by column_0 limit 10"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_3.json)"
+  steampipe query --output json  "select * from chaos.chaos_high_column_count order by column_0 limit 10" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_3.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "select * from chaos.chaos_hydrate_columns_dependency where id='0'" {
-  run steampipe query --output json "select * from chaos.chaos_hydrate_columns_dependency where id='0'"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_5.json)"
+  steampipe query --output json "select * from chaos.chaos_hydrate_columns_dependency where id='0'" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_5.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "select * from chaos.chaos_list_error" {
@@ -43,18 +59,30 @@ load "$LIB_BATS_SUPPORT/load.bash"
 }
 
 @test "select * from chaos.chaos_parallel_hydrate_columns  where id='0'" {
-  run steampipe query --output json "select * from chaos.chaos_parallel_hydrate_columns  where id='0'"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_11.json)"
+  steampipe query --output json "select * from chaos.chaos_parallel_hydrate_columns  where id='0'" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_11.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "select float32_data, id, int64_data, uint16_data from chaos.chaos_all_numeric_column  where id='31'" {
-  run steampipe query --output json "select float32_data, id, int64_data, uint16_data from chaos.chaos_all_numeric_column  where id='31'"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_12.json)"
+  steampipe query --output json "select float32_data, id, int64_data, uint16_data from chaos.chaos_all_numeric_column  where id='31'" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_12.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+  
+  assert_equal $diff ""
 }
 
 @test "select transform_method_column from chaos_transforms order by id" {
-  run steampipe query --output json "select transform_method_column from chaos_transforms order by id"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_14.json)"
+  steampipe query --output json "select transform_method_column from chaos_transforms order by id" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_14.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "select parent_should_ignore_error from chaos.chaos_list_parent_child" {
@@ -63,22 +91,34 @@ load "$LIB_BATS_SUPPORT/load.bash"
 }
 
 @test "select from_qual_column from chaos_transforms where id=2" {
-  run steampipe query --output json "select from_qual_column from chaos_transforms where id=2"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_13.json)"
+  steampipe query --output json "select from_qual_column from chaos_transforms where id=2" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_13.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+  
+  assert_equal $diff ""
 }
 
 @test "public schema insert select all types" {
   steampipe query "drop table if exists all_columns"
   steampipe query "create table all_columns (nullcolumn CHAR(2), booleancolumn boolean, textcolumn1 CHAR(20), textcolumn2 VARCHAR(20),  textcolumn3 text, integercolumn1 smallint, integercolumn2 int, integercolumn3 SERIAL, integercolumn4 bigint,  integercolumn5 bigserial, numericColumn numeric(6,4), realColumn real, floatcolumn float,  date1 DATE,  time1 TIME,  timestamp1 TIMESTAMP, timestamp2 TIMESTAMPTZ, interval1 INTERVAL, array1 text[], jsondata jsonb, jsondata2 json, uuidcolumn UUID, ipAddress inet, macAddress macaddr, cidrRange cidr, xmlData xml, currency money)"
   steampipe query "INSERT INTO all_columns (nullcolumn, booleancolumn, textcolumn1, textcolumn2, textcolumn3, integercolumn1, integercolumn2, integercolumn3, integercolumn4, integercolumn5, numericColumn, realColumn, floatcolumn, date1, time1, timestamp1, timestamp2, interval1, array1, jsondata, jsondata2, uuidcolumn, ipAddress, macAddress, cidrRange, xmlData, currency) VALUES (NULL, TRUE, 'Yes', 'test for varchar', 'This is a very long text for the PostgreSQL text column', 3278, 21445454, 2147483645, 92233720368547758, 922337203685477580, 23.5141543, 4660.33777, 4.6816421254887534, '1978-02-05', '08:00:00', '2016-06-22 19:10:25-07', '2016-06-22 19:10:25-07', '1 year 2 months 3 days', '{\"(408)-589-5841\"}','{ \"customer\": \"John Doe\", \"items\": {\"product\": \"Beer\",\"qty\": 6}}', '{ \"customer\": \"John Doe\", \"items\": {\"product\": \"Beer\",\"qty\": 6}}', '6948DF80-14BD-4E04-8842-7668D9C001F5', '192.168.0.0', '08:00:2b:01:02:03', '10.1.2.3/32', '<book><title>Manual</title><chapter>...</chapter></book>', 922337203685477.57)"
-  run steampipe query "select * from all_columns" --output json
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_6.json)"
+  steampipe query "select * from all_columns" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_6.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
   run steampipe query "drop table all_columns"
 }
 
 @test "query json" {
-  run steampipe query "select 1 as val, 2 as col" --output json
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_query_json.json)"
+  steampipe query "select 1 as val, 2 as col" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_query_json.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "query csv" {
@@ -151,8 +191,12 @@ load "$LIB_BATS_SUPPORT/load.bash"
 }
 
 @test "json" {
-  run steampipe query --output json "select id, string_column, json_column from chaos.chaos_all_column_types where id='0'"
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_json.json)"
+  steampipe query --output json "select id, string_column, json_column from chaos.chaos_all_column_types where id='0'" > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_json.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 @test "line" {
@@ -216,8 +260,12 @@ load "$LIB_BATS_SUPPORT/load.bash"
   steampipe mod install
   # run steampipe query twice - the bug we are testing for caused the workspace lock to be deleted after the first query
   steampipe query "select 1 as a" --output json
-  run steampipe query "select 1 as a" --output json
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_15.json)"
+  steampipe query "select 1 as a" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/expected_15.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal $diff ""
 }
 
 function teardown_file() {

--- a/tests/acceptance/test_files/check.bats
+++ b/tests/acceptance/test_files/check.bats
@@ -110,11 +110,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cd $CONTROL_RENDERING_TEST_MOD
   run steampipe check control.sample_control_mixed_results_1 --output json --progress=false --export output.json
   output=""
-  run jd -f patch "$TEST_DATA_DIR/expected_check_json.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_check_json.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
   cd -
 }
 
@@ -146,11 +145,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cd $CONTROL_RENDERING_TEST_MOD
   run steampipe check control.sample_control_mixed_results_1 --export test.json --progress=false
   output=""
-  run jd -f patch "$TEST_DATA_DIR/expected_check_json.json" test.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
-  assert_equal "$diff" ""
-  rm -f test.json
+  run jd "$TEST_DATA_DIR/expected_check_json.json" test.json
+  echo $output
+  assert_success
+  rm -f output.json
   cd -
 }
 
@@ -231,11 +229,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cd $CHECK_ALL_MOD
   run steampipe check all --export test.json --progress=false
   output=""
-  run jd -f patch "$TEST_DATA_DIR/expected_check_all.json" test.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f test.json
-
-  assert_equal $diff ""
+  run jd "$TEST_DATA_DIR/expected_check_all.json" test.json
+  echo $output
+  assert_success
+  rm -f output.json
   cd -
 }
 

--- a/tests/acceptance/test_files/check.bats
+++ b/tests/acceptance/test_files/check.bats
@@ -108,8 +108,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "steampipe check - output json" {
   cd $CONTROL_RENDERING_TEST_MOD
-  run steampipe check control.sample_control_mixed_results_1 --output=json --progress=false
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_check_json.json)"
+  run steampipe check control.sample_control_mixed_results_1 --output json --progress=false --export output.json
+  output=""
+  run jd -f patch "$TEST_DATA_DIR/expected_check_json.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
+
+  assert_equal "$diff" ""
   cd -
 }
 
@@ -140,7 +145,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
 @test "steampipe check - export json" {
   cd $CONTROL_RENDERING_TEST_MOD
   run steampipe check control.sample_control_mixed_results_1 --export test.json --progress=false
-  assert_equal "$(cat test.json)" "$(cat $TEST_DATA_DIR/expected_check_json.json)"
+  output=""
+  run jd -f patch "$TEST_DATA_DIR/expected_check_json.json" test.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+
+  assert_equal "$diff" ""
   rm -f test.json
   cd -
 }
@@ -221,8 +230,12 @@ load "$LIB_BATS_SUPPORT/load.bash"
 @test "steampipe check all" {
   cd $CHECK_ALL_MOD
   run steampipe check all --export test.json --progress=false
-  assert_equal "$(cat test.json)" "$(cat $TEST_DATA_DIR/expected_check_all.json)"
+  output=""
+  run jd -f patch "$TEST_DATA_DIR/expected_check_all.json" test.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f test.json
+
+  assert_equal $diff ""
   cd -
 }
 

--- a/tests/acceptance/test_files/dynamic_aggregators.bats
+++ b/tests/acceptance/test_files/dynamic_aggregators.bats
@@ -11,10 +11,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   steampipe query "select c1,c2 from dyn_agg.t1 order by c1" --output json > output.json
   run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_same_tables_cols_result.json" output.json
   diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
 
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_same_table_cols.spc
+  assert_equal $diff ""
 }
 
 # Aggregating two connections with different tables defined.
@@ -23,15 +23,20 @@ load "$LIB_BATS_SUPPORT/load.bash"
   skip "currently does not pass due to bug - https://github.com/turbot/steampipe/issues/3743"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_table_mismatch.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_table_mismatch.spc
 
-  run steampipe query "select c1,c2 from dyn_agg.t1 order by c1" --output json
-  echo $output
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t1.json)"
+  steampipe query "select c1,c2 from dyn_agg.t1 order by c1" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t1.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  rm output.json
 
-  run steampipe query "select c1,c2 from dyn_agg.t2 order by c1" --output json
-  echo $output
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t2.json)"
+  assert_equal "$diff" ""
 
+  steampipe query "select c1,c2 from dyn_agg.t2 order by c1" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t2.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+
+  rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_table_mismatch.spc
+  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching columns.
@@ -41,11 +46,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   skip "currently does not pass due to bug - https://github.com/turbot/steampipe/issues/3743"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_mismatch.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_mismatch.spc
 
-  run steampipe query "select c1,c2,c3 from dyn_agg.t1 order by c1,c2,c3" --output json
-  echo $output
+  steampipe query "select c1,c2,c3 from dyn_agg.t1 order by c1,c2,c3" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_mismatch.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
 
+  rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_mismatch.spc
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_col_mismatch.json)"
+  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -55,11 +62,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   skip "currently does not pass due to bug - https://github.com/turbot/steampipe/issues/3743"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch.spc
 
-  run steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json
-  echo $output
+  steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
 
+  rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch.spc
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch.json)"
+  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -69,11 +78,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   skip "currently does not pass due to bug - https://github.com/turbot/steampipe/issues/3743"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch_2.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_2.spc
 
-  run steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json
-  echo $output
+  steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_2.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
 
+  rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_2.spc
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_2.json)"
+  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -83,11 +94,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   skip "currently does not pass due to bug - https://github.com/turbot/steampipe/issues/3743"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch_3.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_3.spc
 
-  run steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json
-  echo $output
+  steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_3.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
 
+  rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_3.spc
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_3.json)"
+  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -98,10 +111,12 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch_4.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_4.spc
 
   run steampipe query "select c1, c2 from dyn_agg.t1 order by c1,c2" --output json
-  echo $output
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_4.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
 
+  rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_4.spc
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_4.json)"
+  assert_equal "$diff" ""
 }
 
 function setup_file() {

--- a/tests/acceptance/test_files/dynamic_aggregators.bats
+++ b/tests/acceptance/test_files/dynamic_aggregators.bats
@@ -8,11 +8,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   skip "currently does not pass due to bug - https://github.com/turbot/steampipe/issues/3743"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_same_table_cols.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_same_table_cols.spc
 
-  run steampipe query "select c1,c2 from dyn_agg.t1 order by c1" --output json
-  echo $output
+  steampipe query "select c1,c2 from dyn_agg.t1 order by c1" --output json > output.json
+  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_same_tables_cols_result.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
 
+  rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_same_table_cols.spc
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/dynamic_aggregators_same_tables_cols_result.json)"
 }
 
 # Aggregating two connections with different tables defined.

--- a/tests/acceptance/test_files/dynamic_aggregators.bats
+++ b/tests/acceptance/test_files/dynamic_aggregators.bats
@@ -9,12 +9,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_same_table_cols.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_same_table_cols.spc
 
   steampipe query "select c1,c2 from dyn_agg.t1 order by c1" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_same_tables_cols_result.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_same_tables_cols_result.json" output.json
+  echo $output
+  assert_success
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_same_table_cols.spc
-  assert_equal $diff ""
 }
 
 # Aggregating two connections with different tables defined.
@@ -24,19 +23,17 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_table_mismatch.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_table_mismatch.spc
 
   steampipe query "select c1,c2 from dyn_agg.t1 order by c1" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t1.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm output.json
-
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t1.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 
   steampipe query "select c1,c2 from dyn_agg.t2 order by c1" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t2.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_table_mismatch_t2.json" output.json
+  echo $output
+  assert_success
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_table_mismatch.spc
-  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching columns.
@@ -47,12 +44,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_mismatch.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_mismatch.spc
 
   steampipe query "select c1,c2,c3 from dyn_agg.t1 order by c1,c2,c3" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_mismatch.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_col_mismatch.json" output.json
+  echo $output
+  assert_success
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_mismatch.spc
-  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -63,12 +59,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch.spc
 
   steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch.json" output.json
+  echo $output
+  assert_success
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch.spc
-  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -79,12 +74,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch_2.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_2.spc
 
   steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_2.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_2.json" output.json
+  echo $output
+  assert_success
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_2.spc
-  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -95,12 +89,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch_3.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_3.spc
 
   steampipe query "select c1, c2 from dyn_agg.t1 order by c2" --output json > output.json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_3.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_3.json" output.json
+  echo $output
+  assert_success
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_3.spc
-  assert_equal "$diff" ""
 }
 
 # Aggregating two connections with same tables defined, but mismatching type of columns.
@@ -111,12 +104,11 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cp $SRC_DATA_DIR/dynamic_aggregator_tests/dynamic_aggregator_col_type_mismatch_4.spc $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_4.spc
 
   run steampipe query "select c1, c2 from dyn_agg.t1 order by c1,c2" --output json
-  run jd -f patch "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_4.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd "$TEST_DATA_DIR/dynamic_aggregators_col_type_mismatch_4.json" output.json
+  echo $output
+  assert_success
   rm -f output.json
   rm -f $STEAMPIPE_INSTALL_DIR/config/dynamic_aggregator_col_type_mismatch_4.spc
-  assert_equal "$diff" ""
 }
 
 function setup_file() {

--- a/tests/acceptance/test_files/introspection.bats
+++ b/tests/acceptance/test_files/introspection.bats
@@ -22,8 +22,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "8d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_query.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_query.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=control | steampipe_introspection=info" {
@@ -39,8 +41,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "11d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_control.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_control.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=variable | steampipe_introspection=info" {
@@ -58,8 +62,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "33d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_variable.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_variable.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=benchmark | steampipe_introspection=info" {
@@ -75,8 +81,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "10d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_benchmark.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_benchmark.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard | steampipe_introspection=info" {
@@ -92,8 +100,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "11d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_card | steampipe_introspection=info" {
@@ -109,8 +119,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "8d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_card.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_card.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_image | steampipe_introspection=info" {
@@ -126,8 +138,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_image.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_image.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_text | steampipe_introspection=info" {
@@ -143,8 +157,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "7d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_text.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_text.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_chart | steampipe_introspection=info" {
@@ -160,8 +176,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_chart.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_chart.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_flow | steampipe_introspection=info" {
@@ -177,8 +195,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "13d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_flow.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_flow.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_graph | steampipe_introspection=info" {
@@ -194,8 +214,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "14d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_graph.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_graph.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_hierarchy | steampipe_introspection=info" {
@@ -211,8 +233,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "13d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_hierarchy.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_hierarchy.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_input | steampipe_introspection=info" {
@@ -228,8 +252,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_input.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_input.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "resource=dashboard_table | steampipe_introspection=info" {
@@ -245,8 +271,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_dashboard_table.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_table.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "ensure mod name in introspection table is <mod_name> not mod.<mod_name>" {
@@ -319,8 +347,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "11d" output.json
   fi
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_info_control.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_control.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "steampipe check --where | steampipe_introspection=control" {
@@ -328,8 +358,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   export STEAMPIPE_INTROSPECTION=control
   steampipe check control.sample_control_1 --where "severity in ('high')" --export output.json
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_check_where.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_check_where.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 @test "steampipe check --tag | steampipe_introspection=control" {
@@ -337,8 +369,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   export STEAMPIPE_INTROSPECTION=control
   steampipe check control.sample_control_1 --tag foo=bar --export output.json
 
-  assert_equal "$(cat output.json)" "$(cat $TEST_DATA_DIR/expected_introspection_check_where.json)"
+  run jd -f patch "$TEST_DATA_DIR/expected_introspection_check_where.json" output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
   rm -f output.json*
+  assert_equal "$diff" ""
 }
 
 function teardown_file() {

--- a/tests/acceptance/test_files/introspection.bats
+++ b/tests/acceptance/test_files/introspection.bats
@@ -22,10 +22,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "8d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_query.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_query.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=control | steampipe_introspection=info" {
@@ -41,10 +41,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "11d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_control.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_control.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=variable | steampipe_introspection=info" {
@@ -62,10 +62,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "33d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_variable.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_variable.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=benchmark | steampipe_introspection=info" {
@@ -81,10 +81,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "10d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_benchmark.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_benchmark.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard | steampipe_introspection=info" {
@@ -100,10 +100,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "11d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_card | steampipe_introspection=info" {
@@ -119,10 +119,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "8d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_card.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_card.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_image | steampipe_introspection=info" {
@@ -138,10 +138,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_image.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_image.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_text | steampipe_introspection=info" {
@@ -157,10 +157,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "7d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_text.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_text.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_chart | steampipe_introspection=info" {
@@ -176,10 +176,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_chart.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_chart.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_flow | steampipe_introspection=info" {
@@ -195,10 +195,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "13d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_flow.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_flow.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_graph | steampipe_introspection=info" {
@@ -214,10 +214,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "14d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_graph.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_graph.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_hierarchy | steampipe_introspection=info" {
@@ -233,10 +233,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "13d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_hierarchy.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_hierarchy.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_input | steampipe_introspection=info" {
@@ -252,10 +252,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_input.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_input.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "resource=dashboard_table | steampipe_introspection=info" {
@@ -271,10 +271,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "9d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_dashboard_table.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_dashboard_table.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "ensure mod name in introspection table is <mod_name> not mod.<mod_name>" {
@@ -347,10 +347,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
     run sed -i "11d" output.json
   fi
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_info_control.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_info_control.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "steampipe check --where | steampipe_introspection=control" {
@@ -358,10 +358,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   export STEAMPIPE_INTROSPECTION=control
   steampipe check control.sample_control_1 --where "severity in ('high')" --export output.json
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_check_where.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_check_where.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 @test "steampipe check --tag | steampipe_introspection=control" {
@@ -369,10 +369,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   export STEAMPIPE_INTROSPECTION=control
   steampipe check control.sample_control_1 --tag foo=bar --export output.json
 
-  run jd -f patch "$TEST_DATA_DIR/expected_introspection_check_where.json" output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  rm -f output.json*
-  assert_equal "$diff" ""
+  run jd "$TEST_DATA_DIR/expected_introspection_check_where.json" output.json
+  echo $output
+  assert_success
+  rm -f output.json
 }
 
 function teardown_file() {

--- a/tests/acceptance/test_files/plugin.bats
+++ b/tests/acceptance/test_files/plugin.bats
@@ -73,14 +73,17 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
   # check table output
   run steampipe plugin list --install-dir $MY_TEST_COPY
-  echo $output
+
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_plugin_list_table.txt)"
 
   # check json output
-  run steampipe plugin list --install-dir $MY_TEST_COPY --output json
-  echo $output
+  steampipe plugin list --install-dir $MY_TEST_COPY --output json > output.json
+  run jd -f patch $TEST_DATA_DIR/expected_plugin_list_json.json output.json
+
+  diff=$($FILE_PATH/json_patch.sh $output)
+
   rm -rf $MY_TEST_COPY
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_plugin_list_json.json)"
+  assert_equal "$diff" ""
 }
 
 @test "plugin list - output table and json (with a missing plugin)" {
@@ -95,14 +98,16 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
   # check table output
   run steampipe plugin list --install-dir $MY_TEST_COPY
-  echo $output
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_plugin_list_table_with_missing_plugins.txt)"
 
   # check json output
-  run steampipe plugin list --install-dir $MY_TEST_COPY --output json
-  echo $output
-  rm -rf $MY_TEST_COPY
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_plugin_list_json_with_missing_plugins.json)"
+  steampipe plugin list --install-dir $MY_TEST_COPY --output json > output.json
+
+  run jd -f patch $TEST_DATA_DIR/expected_plugin_list_json_with_missing_plugins.json output.json
+  diff=$($FILE_PATH/json_patch.sh $output)
+  
+  rm -rf $MY_TEST_COPY   
+  assert_equal "$diff" ""
 }
 
 # # TODO: finds other ways to simulate failed plugins
@@ -123,10 +128,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_plugin_list_table_with_failed_plugins.txt)"
 
   # check json output
-  run steampipe plugin list --install-dir $MY_TEST_COPY --output json
-  echo $output
+  steampipe plugin list --install-dir $MY_TEST_COPY --output json > output.json
+  run jd -f patch $TEST_DATA_DIR/expected_plugin_list_json_with_failed_plugins.json output.json
+
+  diff=$($FILE_PATH/json_patch.sh $output)
+
   rm -rf $MY_TEST_COPY
-  assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_plugin_list_json_with_failed_plugins.json)"
+  assert_equal "$diff" ""
 }
 
 @test "verify that installing plugins creates individual version.json files" {
@@ -167,10 +175,20 @@ load "$LIB_BATS_SUPPORT/load.bash"
   
   [ ! -f $vFile1 ] && fail "could not find $vFile1"
   [ ! -f $vFile2 ] && fail "could not find $vFile2"
-  
-  assert_equal "$(cat $vFile1)" "$file1Content"
-  assert_equal "$(cat $vFile2)" "$file2Content"
-  
+  echo "$file1Content" > $MY_TEST_COPY/f1.json
+  echo "$file2Content" > $MY_TEST_COPY/f2.json
+  cat "$vFile1" > $MY_TEST_COPY/v1.json
+  cat "$vFile2" > $MY_TEST_COPY/v2.json
+
+  # Compare the json file contents
+  run jd -f patch "$MY_TEST_COPY/f1.json" "$MY_TEST_COPY/v1.json"
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
+
+  run jd -f patch "$MY_TEST_COPY/f2.json" "$MY_TEST_COPY/v2.json"
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
+
   rm -rf $MY_TEST_COPY
 }
 
@@ -196,8 +214,19 @@ load "$LIB_BATS_SUPPORT/load.bash"
   [ ! -f $vFile1 ] && fail "could not find $vFile1"
   [ ! -f $vFile2 ] && fail "could not find $vFile2"
   
-  assert_equal "$(cat $vFile1)" "$file1Content"
-  assert_equal "$(cat $vFile2)" "$file2Content"
+  echo "$file1Content" > $MY_TEST_COPY/f1.json
+  echo "$file2Content" > $MY_TEST_COPY/f2.json
+  cat "$vFile1" > $MY_TEST_COPY/v1.json
+  cat "$vFile2" > $MY_TEST_COPY/v2.json
+
+  # Compare the json file contents
+  run jd -f patch "$MY_TEST_COPY/f1.json" "$MY_TEST_COPY/v1.json"
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
+
+  run jd -f patch "$MY_TEST_COPY/f2.json" "$MY_TEST_COPY/v2.json"
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
   
   rm -rf $MY_TEST_COPY
 }
@@ -223,7 +252,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   
   [ ! -f $vFile ] && fail "could not find $vFile"
   
-  assert_equal "$(cat $vFile)" "$fileContent"
+  echo "$fileContent" > $MY_TEST_COPY/f.json
+  cat "$vFile" > $MY_TEST_COPY/v.json
+
+  # Compare the json file contents
+  run jd -f patch "$MY_TEST_COPY/f.json" "$MY_TEST_COPY/v.json"
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
   
   rm -rf $MY_TEST_COPY
 }
@@ -246,7 +281,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   
   [ ! -f $vFile ] && fail "could not find $vFile"
   
-  assert_equal "$(cat $vFile)" "$fileContent"
+  echo "$fileContent" > $MY_TEST_COPY/f.json
+  cat "$vFile" > $MY_TEST_COPY/v.json
+
+  # Compare the json file contents
+  run jd -f patch "$MY_TEST_COPY/f.json" "$MY_TEST_COPY/v.json"
+  diff=$($FILE_PATH/json_patch.sh $output)
+  assert_equal $diff ""
   
   rm -rf $MY_TEST_COPY
 }

--- a/tests/acceptance/test_files/plugin.bats
+++ b/tests/acceptance/test_files/plugin.bats
@@ -78,12 +78,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
   # check json output
   steampipe plugin list --install-dir $MY_TEST_COPY --output json > output.json
-  run jd -f patch $TEST_DATA_DIR/expected_plugin_list_json.json output.json
-
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd $TEST_DATA_DIR/expected_plugin_list_json.json output.json
+  echo $output
+  assert_success
   rm -rf $MY_TEST_COPY
-  assert_equal "$diff" ""
 }
 
 @test "plugin list - output table and json (with a missing plugin)" {
@@ -103,11 +101,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   # check json output
   steampipe plugin list --install-dir $MY_TEST_COPY --output json > output.json
 
-  run jd -f patch $TEST_DATA_DIR/expected_plugin_list_json_with_missing_plugins.json output.json
-  diff=$($FILE_PATH/json_patch.sh $output)
-  
-  rm -rf $MY_TEST_COPY   
-  assert_equal "$diff" ""
+  run jd $TEST_DATA_DIR/expected_plugin_list_json_with_missing_plugins.json output.json
+  echo $output
+  assert_success
+  rm -rf $MY_TEST_COPY
 }
 
 # # TODO: finds other ways to simulate failed plugins
@@ -129,12 +126,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
   # check json output
   steampipe plugin list --install-dir $MY_TEST_COPY --output json > output.json
-  run jd -f patch $TEST_DATA_DIR/expected_plugin_list_json_with_failed_plugins.json output.json
-
-  diff=$($FILE_PATH/json_patch.sh $output)
-
+  run jd $TEST_DATA_DIR/expected_plugin_list_json_with_failed_plugins.json output.json
+  echo $output
+  assert_success
   rm -rf $MY_TEST_COPY
-  assert_equal "$diff" ""
 }
 
 @test "verify that installing plugins creates individual version.json files" {
@@ -181,14 +176,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cat "$vFile2" > $MY_TEST_COPY/v2.json
 
   # Compare the json file contents
-  run jd -f patch "$MY_TEST_COPY/f1.json" "$MY_TEST_COPY/v1.json"
-  diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
+  run jd "$MY_TEST_COPY/f1.json" "$MY_TEST_COPY/v1.json"
+  echo $output
+  assert_success
 
-  run jd -f patch "$MY_TEST_COPY/f2.json" "$MY_TEST_COPY/v2.json"
-  diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
-
+  run jd "$MY_TEST_COPY/f2.json" "$MY_TEST_COPY/v2.json"
+  echo $output
+  assert_success
   rm -rf $MY_TEST_COPY
 }
 
@@ -220,13 +214,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cat "$vFile2" > $MY_TEST_COPY/v2.json
 
   # Compare the json file contents
-  run jd -f patch "$MY_TEST_COPY/f1.json" "$MY_TEST_COPY/v1.json"
-  diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
+  run jd "$MY_TEST_COPY/f1.json" "$MY_TEST_COPY/v1.json"
+  echo $output
+  assert_success
 
-  run jd -f patch "$MY_TEST_COPY/f2.json" "$MY_TEST_COPY/v2.json"
-  diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
+  run jd "$MY_TEST_COPY/f2.json" "$MY_TEST_COPY/v2.json"
+  echo $output
+  assert_success
   
   rm -rf $MY_TEST_COPY
 }
@@ -256,10 +250,10 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cat "$vFile" > $MY_TEST_COPY/v.json
 
   # Compare the json file contents
-  run jd -f patch "$MY_TEST_COPY/f.json" "$MY_TEST_COPY/v.json"
-  diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
-  
+  run jd "$MY_TEST_COPY/f.json" "$MY_TEST_COPY/v.json"
+  echo $output
+  assert_success
+
   rm -rf $MY_TEST_COPY
 }
 
@@ -285,9 +279,9 @@ load "$LIB_BATS_SUPPORT/load.bash"
   cat "$vFile" > $MY_TEST_COPY/v.json
 
   # Compare the json file contents
-  run jd -f patch "$MY_TEST_COPY/f.json" "$MY_TEST_COPY/v.json"
-  diff=$($FILE_PATH/json_patch.sh $output)
-  assert_equal $diff ""
+  run jd "$MY_TEST_COPY/f.json" "$MY_TEST_COPY/v.json"
+  echo $output
+  assert_success
   
   rm -rf $MY_TEST_COPY
 }


### PR DESCRIPTION
For #3556 

- Added the `plugin list` command for suppressing the upgrade version notification.
- Refactored the existing tests that are relevant for the `jd -f patch` comparisons of JSON files. 

Is there an environment variable to suppress the version notification?
This is just a chunk of the tests that I have refactored for now, if there is any issue or review, then I could change it accordingly.
Thanks.