### PR TITLE
Fixing flag in errors.go

### DIFF
--- a/pkg/error_helpers/errors.go
+++ b/pkg/error_helpers/errors.go
@@ -12,4 +12,4 @@ var InvalidCloudTokenError = fmt.Errorf("Invalid token.\nPlease run %s or setup 
 var InvalidStateError = errors.New("invalid state")
 
 // PluginSdkCompatibilityError is raised when aplugin is built using na incompatible sdk version
-var PluginSdkCompatibilityError = fmt.Sprintf("plugins using SDK version < v4 are no longer supported. Upgrade by running %s", constants.Bold("steampipe plugin update all"))
+var PluginSdkCompatibilityError = fmt.Sprintf("plugins using SDK version < v4 are no longer supported. Upgrade by running %s", constants.Bold("steampipe plugin update --all"))


### PR DESCRIPTION
Fixing the typo as --all is a flag in the update command.