### PR TITLE
Fix custom registries bugs

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -578,6 +578,9 @@ func installPlugin(ctx context.Context, pluginName string, isUpdate bool, bar *u
 		versionString = " v" + image.Config.Plugin.Version
 	}
 	docURL := fmt.Sprintf("https://hub.steampipe.io/plugins/%s/%s", org, name)
+	if !image.ImageRef.IsFromSteampipeHub() {
+		docURL = fmt.Sprintf("https://%s/%s", org, name)
+	}
 	return &display.PluginInstallReport{
 		Plugin:         fmt.Sprintf("%s@%s", name, stream),
 		Skipped:        false,

--- a/pkg/ociinstaller/imageref.go
+++ b/pkg/ociinstaller/imageref.go
@@ -84,15 +84,19 @@ func sanitizeRefStream(ref string) string {
 	return ref
 }
 
+func (r *SteampipeImageRef) IsFromSteampipeHub() (bool) {
+	return strings.HasPrefix(r.DisplayImageRef(), constants.SteampipeHubOCIBase)
+}
+
 // GetOrgNameAndStream splits the full image reference into (org, name, stream)
 func (r *SteampipeImageRef) GetOrgNameAndStream() (string, string, string) {
 	// plugin.Name looks like `hub.steampipe.io/plugins/turbot/aws@latest`
 	split := strings.Split(r.DisplayImageRef(), "/")
 	pluginNameAndStream := strings.Split(split[len(split)-1], "@")
-	if strings.HasPrefix(r.DisplayImageRef(), constants.SteampipeHubOCIBase) {
+	if r.IsFromSteampipeHub() {
 		return split[len(split)-2], pluginNameAndStream[0], pluginNameAndStream[1]
 	}
-	return strings.Join(split[0:len(split)-2], "/"), pluginNameAndStream[0], pluginNameAndStream[1]
+	return strings.Join(split[0:len(split)-1], "/"), pluginNameAndStream[0], pluginNameAndStream[1]
 }
 
 // GetFriendlyName returns the minimum friendly name so that the original name can be rebuilt using preset defaults:

--- a/pkg/ociinstaller/imageref_test.go
+++ b/pkg/ociinstaller/imageref_test.go
@@ -129,8 +129,8 @@ func TestGetOrgNameAndStream(t *testing.T) {
 		"otherOrg/aws@latest":                          {"otherOrg", "aws", "latest"},
 		"hub.steampipe.io/plugins/otherOrg/aws@1.0.0":  {"otherOrg", "aws", "1.0.0"},
 		"otherOrg/aws@1.0.0":                           {"otherOrg", "aws", "1.0.0"},
-		"differentRegistry.com/otherOrg/aws@latest":    {"differentRegistry.com", "aws", "latest"},
-		"differentRegistry.com/otherOrg/aws@1.0.0":     {"differentRegistry.com", "aws", "1.0.0"},
+		"example.com/otherOrg/aws@latest":              {"example.com/otherOrg", "aws", "latest"},
+		"example.com/otherOrg/aws@1.0.0":               {"example.com/otherOrg", "aws", "1.0.0"},
 	}
 
 	for testCase, want := range cases {
@@ -140,6 +140,32 @@ func TestGetOrgNameAndStream(t *testing.T) {
 			got := [3]string{org, name, stream}
 			if got != want {
 				t.Errorf("TestGetOrgNameAndStream failed for case '%s': expected %s, got %s", testCase, want, got)
+			}
+		})
+	}
+
+}
+
+func TestIsFromSteampipeHub(t *testing.T) {
+	cases := map[string]bool{
+		"hub.steampipe.io/plugins/turbot/aws@latest":   true,
+		"turbot/aws@latest":                            true,
+		"aws@latest":                                   true,
+		"hub.steampipe.io/plugins/turbot/aws@1.0.0":    true,
+		"hub.steampipe.io/plugins/otherOrg/aws@latest": true,
+		"otherOrg/aws@latest":                          true,
+		"hub.steampipe.io/plugins/otherOrg/aws@1.0.0":  true,
+		"otherOrg/aws@1.0.0":                           true,
+		"example.com/otherOrg/aws@latest":              false,
+		"example.com/otherOrg/aws@1.0.0":               false,
+	}
+
+	for testCase, want := range cases {
+		t.Run(testCase, func(t *testing.T) {
+			r := NewSteampipeImageRef(testCase)
+			got := r.IsFromSteampipeHub()
+			if got != want {
+				t.Errorf("TestIsFromSteampipeHub failed for case '%s': expected %t, got %t", testCase, want, got)
 			}
 		})
 	}

--- a/pkg/ociinstaller/imageref_test.go
+++ b/pkg/ociinstaller/imageref_test.go
@@ -118,3 +118,30 @@ func TestDisplayImageRef(t *testing.T) {
 	}
 
 }
+
+func TestGetOrgNameAndStream(t *testing.T) {
+	cases := map[string][3]string{
+		"hub.steampipe.io/plugins/turbot/aws@latest":   {"turbot", "aws", "latest"},
+		"turbot/aws@latest":                            {"turbot", "aws", "latest"},
+		"aws@latest":                                   {"turbot", "aws", "latest"},
+		"hub.steampipe.io/plugins/turbot/aws@1.0.0":    {"turbot", "aws", "1.0.0"},
+		"hub.steampipe.io/plugins/otherOrg/aws@latest": {"otherOrg", "aws", "latest"},
+		"otherOrg/aws@latest":                          {"otherOrg", "aws", "latest"},
+		"hub.steampipe.io/plugins/otherOrg/aws@1.0.0":  {"otherOrg", "aws", "1.0.0"},
+		"otherOrg/aws@1.0.0":                           {"otherOrg", "aws", "1.0.0"},
+		"differentRegistry.com/otherOrg/aws@latest":    {"differentRegistry.com", "aws", "latest"},
+		"differentRegistry.com/otherOrg/aws@1.0.0":     {"differentRegistry.com", "aws", "1.0.0"},
+	}
+
+	for testCase, want := range cases {
+		t.Run(testCase, func(t *testing.T) {
+			r := NewSteampipeImageRef(testCase)
+			org, name, stream := r.GetOrgNameAndStream()
+			got := [3]string{org, name, stream}
+			if got != want {
+				t.Errorf("TestGetOrgNameAndStream failed for case '%s': expected %s, got %s", testCase, want, got)
+			}
+		})
+	}
+
+}


### PR DESCRIPTION
- the documentation link was not correct
- the uninstall message was not correct
- checking requirements on mods was always failing

## When installing ghcr.io/francois2metz/scalingo:

Before:
> Installed plugin: scalingo@latest v0.18.0
> Documentation:    https://hub.steampipe.io/plugins/ghcr.io/scalingo

After: 
> Installed plugin: scalingo@latest v0.18.0
>Documentation:    https://ghcr.io/francois2metz/scalingo

**I didn't updated the name of the plugin, but I believe the message scalingo@latest  could be misleading. What do you think ?**

## Uninstall

Before:
> Uninstalled plugin:
> * ghcr.io/scalingo

After:
> Uninstalled plugin:
> * ghcr.io/francois2metz/scalingo

## Mod requirement

A simple mod with this requirement would always fail regardless of the installation of the plugin
```
  require {
    plugin "ghcr.io/francois2metz/scalingo" {
      version = "0.18.0"
    }
  }
```