### PR TITLE
add option to install mod from branch ref

### DIFF
--- a/pkg/modinstaller/resolved_mod_ref.go
+++ b/pkg/modinstaller/resolved_mod_ref.go
@@ -32,6 +32,10 @@ func NewResolvedModRef(requiredModVersion *modconfig.ModVersionConstraint, versi
 	if res.FilePath == "" {
 		res.setGitReference()
 	}
+	// set the git reference to the provided branch name
+	if requiredModVersion.Branch != "" {
+		res.GitReference = plumbing.ReferenceName(requiredModVersion.Branch)
+	}
 
 	return res, nil
 }

--- a/pkg/steampipeconfig/modconfig/plugin_version.go
+++ b/pkg/steampipeconfig/modconfig/plugin_version.go
@@ -18,6 +18,8 @@ type PluginVersion struct {
 	// the minumum version which satisfies the requirement
 	MinVersionString string `cty:"min_version" hcl:"min_version,optional"`
 	Constraint       *semver.Constraints
+	// the branch of mod git repo to install
+	Branch string
 	// the org and name which are parsed from the raw name
 	Org       string
 	Name      string

--- a/pkg/steampipeconfig/modconfig/require.go
+++ b/pkg/steampipeconfig/modconfig/require.go
@@ -2,8 +2,10 @@ package modconfig
 
 import (
 	"fmt"
-	"github.com/turbot/go-kit/hcl_helpers"
+	"net/http"
 	"sort"
+
+	"github.com/turbot/go-kit/hcl_helpers"
 
 	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/hcl/v2"
@@ -160,6 +162,14 @@ func (r *Require) searchInstalledPluginForRequirement(modName string, requiremen
 		}
 		// if org and name matches but the plugin is built locally, return without any validation error
 		if installed.IsLocal() {
+			return nil
+		}
+		// if branch is specified, check if the branch exists
+		if requirement.Branch != "" {
+			res, err := http.Get(requirement.Name)
+			if err != nil || res.StatusCode != 200{
+				return err
+			}
 			return nil
 		}
 		// if org and name matches, check whether the version constraint is satisfied


### PR DESCRIPTION
For #3772 

I have made changes to the `mod install` command to support branch references as Git URLs for installing a mod from a particular branch.

```
steampipe mod install https://github.com/turbot/steampipe-mod-aws-insights/tree/issue-iam
```

Before reviews, can I get a general sense of clarity if I am picking this one right? 

Some concerns to be addressed:
- Separation of version and branch tagging logic
- Versioning of mod after installing from a branch

Thanks.
