### PR TITLE
Removing `select 1` hack from search path tests. Closes #3885

### DIFF
--- a/tests/acceptance/lib/connection_map_utils.bash
+++ b/tests/acceptance/lib/connection_map_utils.bash
@@ -1,0 +1,40 @@
+# Function to check if all 'state' values 
+# in the steampipe_connection_state stable are "ready"
+wait_connection_map_stable() {
+    local timeout_duration=5
+    local end_time=$(( $(date +%s) + timeout_duration ))
+    local all_ready=false
+
+    while [[ $(date +%s) -lt $end_time ]]
+    do
+      # Run the steampipe query and parse the JSON output
+      local json_output=$(steampipe query "select * from steampipe_connection_state" --output json)
+      if [ $? -ne 0 ]; then
+        echo "Failed to execute steampipe query"
+        return 1
+      fi
+
+      for state in $(echo $json_output | jq -r '.[].state')
+      do
+        if [ "$state" != "ready" ]; then
+          # wait for sometime 
+          sleep 0.5
+          # and try again
+          continue
+        fi
+      done
+      
+      # if we are here that means all are in the ready state 
+      all_ready=true
+      # we can break out of the loop
+      break
+    done
+
+    if [ "$all_ready" = true ]; then
+      return 0
+    else
+      return 1
+    fi
+}
+
+

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -13,8 +13,9 @@ fi
 
 # set this to the source file for development
 export BATS_PATH=$MY_PATH/lib/bats-core/bin/bats
-export LIB_BATS_ASSERT=$MY_PATH/lib/bats-assert
-export LIB_BATS_SUPPORT=$MY_PATH/lib/bats-support
+export LIB=$MY_PATH/lib
+export LIB_BATS_ASSERT=$LIB/bats-assert
+export LIB_BATS_SUPPORT=$LIB/bats-support
 export TEST_DATA_DIR=$MY_PATH/test_data/templates
 export SNAPSHOTS_DIR=$MY_PATH/test_data/snapshots
 export SRC_DATA_DIR=$MY_PATH/test_data/source_files

--- a/tests/acceptance/test_files/search_path.bats
+++ b/tests/acceptance/test_files/search_path.bats
@@ -1,18 +1,21 @@
 load "$LIB_BATS_ASSERT/load.bash"
 load "$LIB_BATS_SUPPORT/load.bash"
+load "$LIB/connection_map_utils.bash"
 
 @test "add connection, check search path updated" {
   cp $SRC_DATA_DIR/single_chaos.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path"
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_1.txt)"
   cp $SRC_DATA_DIR/two_chaos.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path"
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_2.txt)"
@@ -20,15 +23,17 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "delete connection, check search path updated" {
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path"
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_2.txt)"
   cp $SRC_DATA_DIR/single_chaos.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path"
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_1.txt)"
@@ -36,15 +41,17 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "add connection, query with prefix" {
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path"
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_1.txt)"
   cp $SRC_DATA_DIR/two_chaos.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path-prefix foo
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_3.txt)"
@@ -52,15 +59,17 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "delete connection, query with prefix" {
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path"
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_2.txt)"
   cp $SRC_DATA_DIR/single_chaos.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path-prefix foo
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_4.txt)"
@@ -68,15 +77,17 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "query with prefix, add connection, query with prefix" {
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path-prefix foo
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_5.txt)"
   cp $SRC_DATA_DIR/two_chaos.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path-prefix foo2
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_6.txt)"
@@ -84,15 +95,17 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "query with prefix, delete connection, query with prefix" {
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path-prefix foo2
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_6.txt)"
   cp $SRC_DATA_DIR/single_chaos.spc $STEAMPIPE_INSTALL_DIR/config/chaos.spc
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path-prefix foo
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_5.txt)"
@@ -100,8 +113,9 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "verify that 'internal' schema is added" {
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path foo
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_internal_schema_once_1.txt)"
@@ -109,8 +123,9 @@ load "$LIB_BATS_SUPPORT/load.bash"
 
 @test "verify that 'internal' schema is always suffixed if passed in as custom" {
 
-  #TODO: Remove hack [https://github.com/turbot/steampipe/isues/3885]
-  steampipe query "select 1"
+   # Wait for all connection states to be 'ready'
+  run wait_connection_map_stable
+  [ "$status" -eq 0 ]
 
   run steampipe query "show search_path" --search-path foo1,steampipe_internal,foo2
   assert_output "$(cat $TEST_DATA_DIR/expected_search_path_internal_schema_once_2.txt)"


### PR DESCRIPTION
Although the `steampipe query "select ` works, it was a sticking plaster we had to put in to quickly get the tests up and running.

This PR modifies the tests to wait for the connection state table to be stable and for all connections to be in `ready`.