### PR TITLE
feat: handle ssl password

### DIFF
--- a/cmd/service.go
+++ b/cmd/service.go
@@ -67,6 +67,7 @@ connection from any Postgres compatible database client.`,
 		AddIntFlag(constants.ArgDatabasePort, constants.DatabaseDefaultPort, "Database service port").
 		AddStringFlag(constants.ArgDatabaseListenAddresses, string(db_local.ListenTypeNetwork), "Accept connections from: `local` (an alias for `localhost` only), `network` (an alias for `*`), or a comma separated list of hosts and/or IP addresses").
 		AddStringFlag(constants.ArgServicePassword, "", "Set the database password for this session").
+		AddStringFlag(constants.ArgDatabaseSSLPassword, "", "Set the database SSL password for the encrypted private key").
 		// default is false and hides the database user password from service start prompt
 		AddBoolFlag(constants.ArgServiceShowPassword, false, "View database password for connecting from another machine").
 		// dashboard server

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -67,7 +67,6 @@ connection from any Postgres compatible database client.`,
 		AddIntFlag(constants.ArgDatabasePort, constants.DatabaseDefaultPort, "Database service port").
 		AddStringFlag(constants.ArgDatabaseListenAddresses, string(db_local.ListenTypeNetwork), "Accept connections from: `local` (an alias for `localhost` only), `network` (an alias for `*`), or a comma separated list of hosts and/or IP addresses").
 		AddStringFlag(constants.ArgServicePassword, "", "Set the database password for this session").
-		AddStringFlag(constants.ArgDatabaseSSLPassword, "", "Set the database SSL password for the encrypted private key").
 		// default is false and hides the database user password from service start prompt
 		AddBoolFlag(constants.ArgServiceShowPassword, false, "View database password for connecting from another machine").
 		// dashboard server

--- a/pkg/cmdconfig/viper.go
+++ b/pkg/cmdconfig/viper.go
@@ -164,6 +164,7 @@ func setDefaultsFromEnv() {
 		constants.EnvMaxParallel:           {[]string{constants.ArgMaxParallel}, Int},
 		constants.EnvQueryTimeout:          {[]string{constants.ArgDatabaseQueryTimeout}, Int},
 		constants.EnvDatabaseStartTimeout:  {[]string{constants.ArgDatabaseStartTimeout}, Int},
+		constants.EnvDatabaseSSLPassword:   {[]string{constants.ArgDatabaseSSLPassword}, String},
 		constants.EnvDashboardStartTimeout: {[]string{constants.ArgDashboardStartTimeout}, Int},
 		constants.EnvCacheTTL:              {[]string{constants.ArgCacheTtl}, Int},
 		constants.EnvCacheMaxTTL:           {[]string{constants.ArgCacheMaxTtl}, Int},

--- a/pkg/constants/args.go
+++ b/pkg/constants/args.go
@@ -64,6 +64,7 @@ const (
 	ArgSnapshotLocation        = "snapshot-location"
 	ArgSnapshotTitle           = "snapshot-title"
 	ArgDatabaseStartTimeout    = "database-start-timeout"
+	ArgDatabaseSSLPassword     = "database-ssl-password"
 	ArgMemoryMaxMb             = "memory-max-mb"
 	ArgMemoryMaxMbPlugin       = "memory-max-mb-plugin"
 )

--- a/pkg/constants/env.go
+++ b/pkg/constants/env.go
@@ -9,6 +9,7 @@ const (
 	EnvMaxParallel     = "STEAMPIPE_MAX_PARALLEL"
 
 	EnvDatabaseStartTimeout  = "STEAMPIPE_DATABASE_START_TIMEOUT"
+	EnvDatabaseSSLPassword   = "STEAMPIPE_DATABASE_SSL_PASSWORD"
 	EnvDashboardStartTimeout = "STEAMPIPE_DASHBOARD_START_TIMEOUT"
 
 	EnvSnapshotLocation  = "STEAMPIPE_SNAPSHOT_LOCATION"

--- a/pkg/db/db_local/ssl.go
+++ b/pkg/db/db_local/ssl.go
@@ -14,8 +14,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/spf13/viper"
 	filehelpers "github.com/turbot/go-kit/files"
 	"github.com/turbot/steampipe-plugin-sdk/v5/sperr"
+	"github.com/turbot/steampipe/pkg/constants"
 	"github.com/turbot/steampipe/pkg/db/sslio"
 	"github.com/turbot/steampipe/pkg/filepaths"
 	"github.com/turbot/steampipe/pkg/utils"
@@ -284,12 +286,19 @@ func dsnSSLParams() map[string]string {
 		// applications that need certificate validation should always use verify-ca or verify-full.
 		//
 		// Since we are using the Root Certificate, 'require' is overridden with 'verify-ca' anyway
-		return map[string]string{
+
+		dsnSSLParams := map[string]string{
 			"sslmode":     "verify-ca",
 			"sslrootcert": filepaths.GetRootCertLocation(),
 			"sslcert":     filepaths.GetServerCertLocation(),
 			"sslkey":      filepaths.GetServerCertKeyLocation(),
 		}
+
+		if sslpassword := viper.GetString(constants.ArgDatabaseSSLPassword); sslpassword != "" {
+			dsnSSLParams["sslpassword"] = sslpassword
+		}
+
+		return dsnSSLParams
 	}
 	return map[string]string{"sslmode": "disable"}
 }

--- a/pkg/db/db_local/start_services.go
+++ b/pkg/db/db_local/start_services.go
@@ -460,6 +460,14 @@ func createCmd(ctx context.Context, port int, listenAddresses []string) *exec.Cm
 		// Data Directory
 		"-D", filepaths.GetDataLocation())
 
+	if sslpassword := viper.GetString(constants.ArgDatabaseSSLPassword); sslpassword != "" {
+		postgresCmd.Args = append(
+			postgresCmd.Args,
+			"-c", fmt.Sprintf("ssl_passphrase_command_supports_reload=%s", "true"),
+			"-c", fmt.Sprintf("ssl_passphrase_command=%s", "echo "+sslpassword),
+		)
+	}
+
 	postgresCmd.Env = append(os.Environ(), fmt.Sprintf("STEAMPIPE_INSTALL_DIR=%s", filepaths.SteampipeDir))
 
 	//  Check if the /etc/ssl directory exist in os

--- a/tests/acceptance/test_files/ssl.bats
+++ b/tests/acceptance/test_files/ssl.bats
@@ -77,14 +77,13 @@ load "$LIB_BATS_SUPPORT/load.bash"
 }
 
 @test "adding an encrypted private key should work fine and service should start successfully" {
-  # generate a key with passphrase
   run openssl genrsa -aes256 -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passout pass:steampipe -traditional 2048 
   
-  run openssl req -new -key $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passin pass:steampipe -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.csr -subj "/C=US/ST=CA/L=San Francisco/O=Steampipe/OU=Engineering/CN=steampipe.io"
+  run openssl req -key $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passin pass:steampipe -new -x509 -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Steampipe/OU=Engineering/CN=steampipe.io"
 
   steampipe service start --database-ssl-password steampipe
 }
 
 function teardown() {
-  steampipe service stop
+  steampipe service stop --force
 }

--- a/tests/acceptance/test_files/ssl.bats
+++ b/tests/acceptance/test_files/ssl.bats
@@ -79,7 +79,7 @@ load "$LIB_BATS_SUPPORT/load.bash"
 @test "adding an encrypted private key should work fine and service should start successfully" {
   run openssl genrsa -aes256 -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passout pass:steampipe -traditional 2048 
   
-  run openssl req -key $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passin pass:steampipe -new -x509 -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.crt -subj "/C=US/ST=CA/L=San Francisco/O=Steampipe/OU=Engineering/CN=steampipe.io"
+  run openssl req -key $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passin pass:steampipe -new -x509 -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.crt -subj "/CN=steampipe.io"
 
   steampipe service start --database-ssl-password steampipe
 }

--- a/tests/acceptance/test_files/ssl.bats
+++ b/tests/acceptance/test_files/ssl.bats
@@ -76,6 +76,15 @@ load "$LIB_BATS_SUPPORT/load.bash"
   assert_equal "$flag" "0"
 }
 
+@test "adding an encrypted private key should work fine and service should start successfully" {
+  # generate a key with passphrase
+  run openssl genrsa -aes256 -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passout pass:steampipe -traditional 2048 
+  
+  run openssl req -new -key $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passin pass:steampipe -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.csr -subj "/C=US/ST=CA/L=San Francisco/O=Steampipe/OU=Engineering/CN=steampipe.io"
+
+  steampipe service start --database-ssl-password steampipe
+}
+
 function teardown() {
   steampipe service stop
 }


### PR DESCRIPTION
We figured out that steampipe does not handle private key protected with a passphrase.
This should fix that by adding [sslpassword](https://www.postgresql.org/docs/14/libpq-connect.html#LIBPQ-CONNECT-SSLPASSWORD) and [ssl_passphrase_command](https://www.postgresql.org/docs/14/runtime-config-connection.html#GUC-SSL-PASSPHRASE-COMMAND) options (and [ssl_passphrase_command_supports_reload](https://www.postgresql.org/docs/14/runtime-config-connection.html#GUC-SSL-PASSPHRASE-COMMAND-SUPPORTS-RELOAD))

#### Note

The `server.key` content **must** contains [Proc-Type](https://datatracker.ietf.org/doc/html/rfc1421#section-4.6.1.1) and [DEK-Info](https://datatracker.ietf.org/doc/html/rfc1421#section-4.6.1.3) headers.

It is possible by adding `-traditional` to `openssl` command:

```bash
openssl genrsa -aes256 -out $STEAMPIPE_INSTALL_DIR/db/14.2.0/data/server.key -passout pass:steampipe -traditional 2048
```