### PR TITLE
Fix issue where daily update check message showed a <nil> when there was no message to show .Closes #4206

### DIFF
--- a/pkg/task/display.go
+++ b/pkg/task/display.go
@@ -105,15 +105,17 @@ func (r *Runner) displayNotifications(cmd *cobra.Command, cmdArgs []string) erro
 	if err != nil {
 		return err
 	}
+
 	// table can be nil if there are no notifications to display
-	if tableBuffer == nil && ppTable == nil {
-		return nil
+	if tableBuffer != nil {
+		fmt.Println()            //nolint:forbidigo // acceptable
+		fmt.Println(tableBuffer) //nolint:forbidigo // acceptable
 	}
 
-	fmt.Println()            //nolint:forbidigo // acceptable
-	fmt.Println(tableBuffer) //nolint:forbidigo // acceptable
-	ppTable.Render()
-	fmt.Println() //nolint:forbidigo // acceptable
+	if ppTable != nil {
+		ppTable.Render()
+		fmt.Println() //nolint:forbidigo // acceptable
+	}
 
 	return nil
 }


### PR DESCRIPTION
No steampipe update check message:
<img width="664" alt="Screenshot 2024-03-19 at 4 13 26 PM" src="https://github.com/turbot/steampipe/assets/45908484/587bae08-0b67-4781-9581-fa037d86a871">

With both steampipe update check msg and powerpipe notice:
<img width="756" alt="Screenshot 2024-03-19 at 4 14 18 PM" src="https://github.com/turbot/steampipe/assets/45908484/da57660d-ab00-489c-b22c-c3685a9b5c13">
