### PR TITLE
fix: do not abort when unrelated connections are not yet loaded

### DIFF
--- a/pkg/steampipeconfig/connection_plugin.go
+++ b/pkg/steampipeconfig/connection_plugin.go
@@ -2,9 +2,10 @@ package steampipeconfig
 
 import (
 	"fmt"
-	typehelpers "github.com/turbot/go-kit/types"
 	"log"
 	"strings"
+
+	typehelpers "github.com/turbot/go-kit/types"
 
 	"github.com/hashicorp/go-plugin"
 	sdkgrpc "github.com/turbot/steampipe-plugin-sdk/v5/grpc"
@@ -144,13 +145,13 @@ func CreateConnectionPlugins(pluginManager pluginshared.PluginManager, connectio
 		}
 
 		// do we have a reattach config for this connection's plugin
-		if _, ok := getResponse.ReattachMap[connection.Name]; !ok {
+		reattach, ok := getResponse.ReattachMap[connection.Name]
+		if !ok {
 			log.Printf("[TRACE] CreateConnectionPlugins skipping connection '%s', plugin '%s' as plugin manager failed to start it", connection.Name, typehelpers.SafeString(connection.PluginInstance))
 			continue
 		}
 
 		// so we have a reattach - create a connection plugin
-		reattach := getResponse.ReattachMap[connection.Name]
 		connectionPlugin, err := createConnectionPlugin(connection, reattach)
 		if err != nil {
 			res.AddWarning(fmt.Sprintf("failed to attach to plugin process for '%s': %s", typehelpers.SafeString(connection.PluginInstance), err))
@@ -325,7 +326,8 @@ func createConnectionPlugin(connection *modconfig.Connection, reattach *proto.Re
 		// we assume this has been populated either by the hub (if this is being invoked from the fdw) or the CLI
 		config, ok := GlobalConfig.Connections[c]
 		if !ok {
-			return nil, fmt.Errorf("no connection config loaded for '%s'", c)
+			log.Printf("[WARN] no connection config loaded for '%s', skipping", c)
+			continue
 		}
 		connectionPlugin.addConnection(c, config.Config, config.Options, config.Type)
 	}

--- a/pkg/steampipeconfig/parse/parser.go
+++ b/pkg/steampipeconfig/parse/parser.go
@@ -2,12 +2,13 @@ package parse
 
 import (
 	"fmt"
-	"github.com/turbot/steampipe/pkg/filepaths"
 	"io"
 	"log"
 	"os"
 	"path/filepath"
 	"sort"
+
+	"github.com/turbot/steampipe/pkg/filepaths"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclparse"
@@ -29,7 +30,7 @@ func LoadFileData(paths ...string) (map[string][]byte, hcl.Diagnostics) {
 
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
+				Severity: hcl.DiagWarning,
 				Summary:  fmt.Sprintf("failed to read config file %s", configPath),
 				Detail:   err.Error()})
 			continue


### PR DESCRIPTION
This PR resolves issues when connection configurations are created dynamically concurrently to executing queries.

Symptoms are that an unrelated connection that hasn't completed loading breaks other connections:
```
2024-04-05 12:05:19.955 UTC [INFO]  hub: goFdwBeginForeignScan, connection 'aws_000000000000', table 'aws_ec2_transit_gateway', explain: false
2024-04-05 12:05:19.957 UTC [WARN]  hub: pluginHub.GetIterator FAILED: failed to attach to plugin process for 'aws@0.133.0': no connection config loaded for 'aws_222222222222'
2024-04-05 12:05:19.957 UTC [299] ERROR:  failed to attach to plugin process for 'aws@0.133.0': no connection config loaded for 'aws_222222222222'
2024-04-05 12:05:19.957 UTC [299] STATEMENT:  SELECT 'APIGATEWAY' AS subtype, row_to_json(r) AS data FROM (SELECT
[...SNIP...]
2024-04-05 12:05:19.958 UTC [INFO]  hub: goFdwAbortCallback
2024-04-05 12:05:19.958 UTC [INFO]  hub: Hub Abort
2024-04-05 12:05:20.023 UTC [INFO]  hub: goFdwIterateForeignScan returned empty row - this scan complete (0xc00226f080)
2024-04-05 12:05:20.025 UTC [INFO]  hub: goFdwIterateForeignScan calling pluginHub.StartScan, table 'aws_account' (0xc00226f680)
2024-04-05 12:05:20.025 UTC [INFO]  hub: StartScan for table: aws_account, cache enabled: false, iterator 0xc00226f680, 0 quals (1712318705836)
2024-04-05 12:05:20.026 UTC [INFO]  hub: goFdwIterateForeignScan returned empty row - this scan complete (0xc00226f680)
2024-04-05 12:05:20.028 UTC [INFO]  hub: goFdwReScanForeignScan, connection '', table 'aws_ec2_transit_gateway'
2024-04-05 12:05:20.028 UTC [INFO]  hub: goFdwBeginForeignScan, connection 'aws_111111111111', table 'aws_ec2_transit_gateway', explain: false
2024-04-05 12:05:20.030 UTC [WARN]  hub: pluginHub.GetIterator FAILED: failed to attach to plugin process for 'aws@0.133.0': no connection config loaded for 'aws_222222222222'
2024-04-05 12:05:20.030 UTC [INFO]  hub: .
******************************************************

                steampipe postgres fdw shutdown

******************************************************
```

This problem seems to happen more frequently when connections are slower to load, most notably when limiters are configured.

See https://turbot-community.slack.com/archives/C01UECB59A7/p1712324097931309

For this change to be effective, the FDW has to be rebuilt with:
```
go mod edit -replace="github.com/turbot/steampipe=github.com/pdecat/steampipe @0a5b8a0928292f08ad842a63211188306e9998de"
```