### PR TITLE
fix: show scan info only when timing config is verbose

### DIFF
--- a/pkg/display/display.go
+++ b/pkg/display/display.go
@@ -402,13 +402,19 @@ func displayTable(ctx context.Context, result *queryresult.Result) (int, *queryr
 }
 
 func getTiming(result *queryresult.Result, count int) *queryresult.TimingResult {
-	if timingConfig := viper.GetString(constants.ArgTiming); timingConfig == constants.ArgOff || timingConfig == "false" {
+	timingConfig := viper.GetString(constants.ArgTiming)
+
+	if timingConfig == constants.ArgOff || timingConfig == "false" {
 		return nil
 	}
 	// now we have iterated the rows, get the timing
 	timingResult := <-result.TimingResult
 	// set rows returned
 	timingResult.RowsReturned = int64(count)
+
+	if timingConfig != constants.ArgVerbose {
+		timingResult.Scans = nil
+	}
 	return timingResult
 }
 


### PR DESCRIPTION
Addressing #4292 
Added a check when the timing config is not `verbose`, then removed the Scan results. This somehow sends the scan result only for JSON but not for CSV and table output. 

Let me know if this is a good fix or if we need to do specific to the JSON output so as not to populate the Scan results in the first place.
Thanks