### PR TITLE
Changing plugins hub url to correct one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [<picture><source media="(prefers-color-scheme: dark)" srcset="https://steampipe.io/images/steampipe-color-logo-and-wordmark-with-white-bubble.svg"><source media="(prefers-color-scheme: light)" srcset="https://steampipe.io/images/steampipe-color-logo-and-wordmark-with-white-bubble.svg"><img width="67%" alt="Steampipe Logo" src="https://steampipe.io/images/steampipe-color-logo-and-wordmark-with-white-bubble.svg"></picture>](https://steampipe.io)
 
-[![plugins](https://img.shields.io/badge/apis_supported-145-blue)](https://hub.powerpipe.io/plugins) &nbsp; 
+[![plugins](https://img.shields.io/badge/apis_supported-145-blue)](https://hub.steampipe.io/plugins) &nbsp; 
 [![slack](https://img.shields.io/badge/slack-2695-blue)](https://turbot.com/community/join) &nbsp;
 [![maintained by](https://img.shields.io/badge/maintained%20by-Turbot-blue)](https://turbot.com)
 


### PR DESCRIPTION
Greetings,

Previously the URL to Steampipe plugins hub was set to powerpipe.io domain. In this pull request, I have fixed that issue.