### PR TITLE
Configure plugin start timeout for go-plugin.Client (#4477)

### DIFF
--- a/pkg/pluginmanager/lifecycle.go
+++ b/pkg/pluginmanager/lifecycle.go
@@ -65,7 +65,7 @@ func start(steampipeExecutablePath string) (*State, error) {
 		Cmd:              pluginManagerCmd,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger:           logger,
-		StartTimeout:     3 * time.Minute, //TODO: macke this configurable
+		StartTimeout:     3 * time.Minute, //TODO: make this configurable
 	})
 
 	if _, err := client.Start(); err != nil {

--- a/pkg/pluginmanager/lifecycle.go
+++ b/pkg/pluginmanager/lifecycle.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
@@ -64,6 +65,7 @@ func start(steampipeExecutablePath string) (*State, error) {
 		Cmd:              pluginManagerCmd,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger:           logger,
+		StartTimeout:     3 * time.Minute, //TODO: macke this configurable
 	})
 
 	if _, err := client.Start(); err != nil {

--- a/pkg/pluginmanager_service/plugin_manager.go
+++ b/pkg/pluginmanager_service/plugin_manager.go
@@ -501,11 +501,25 @@ func (m *PluginManager) startPluginProcess(pluginInstance string, connectionConf
 
 	cmd := exec.Command(pluginPath)
 	m.setPluginMaxMemory(pluginConfig, cmd)
+	pluginStartTimeoutSecs := pluginConfig.GetStartTimeout()
+	if pluginStartTimeoutSecs == 0 {
+		if viper.IsSet(pconstants.ArgPluginStartTimeout) {
+			pluginStartTimeoutSecs = viper.GetInt64(pconstants.ArgPluginStartTimeout)
+		}
+	}
+	if pluginStartTimeoutSecs == 0 {
+		// if we don't have any timeout set use 30 seconds
+		pluginStartTimeoutSecs = int64(30)
+	}
+	pluginStartTimeoutDuration := time.Duration(pluginStartTimeoutSecs) * time.Second
+	log.Printf("[TRACE] %s pluginStartTimeoutDuration: %s", pluginPath, pluginStartTimeoutDuration)
+
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  sdkshared.Handshake,
 		Plugins:          pluginMap,
 		Cmd:              cmd,
 		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+		StartTimeout:     pluginStartTimeoutDuration,
 
 		// pass our logger to the plugin client to ensure plugin logs end up in logfile
 		Logger: m.logger,
@@ -678,7 +692,7 @@ func (m *PluginManager) waitForPluginLoad(p *runningPlugin, req *pb.GetRequest) 
 	}
 	pluginStartTimeoutSecs := pluginConfig.GetStartTimeout()
 	if pluginStartTimeoutSecs == 0 {
-		if viper.IsSet(pconstants.ArgMemoryMaxMbPlugin) {
+		if viper.IsSet(pconstants.ArgPluginStartTimeout) {
 			pluginStartTimeoutSecs = viper.GetInt64(pconstants.ArgPluginStartTimeout)
 		}
 	}


### PR DESCRIPTION
Addresses #4477.

The hashicorp/go-plugin client configuration has a [default timeout of 60s](https://github.com/hashicorp/go-plugin/blob/5b05b3e78c6c3e4e0b8f21a9921cbd739ba72f2a/client.go#L400). This causes steampipe startup to fail if a plugin takes longer than 60s.

This PR ensures a plugin's client is configured with the timeout settings from the steampipe plugin configuration. 

It also extends the plugin manager client start timeout from 1 minute to 3 minutes as testing indicated this timeout setting also governed overall steampipe startup. Ideally this timeout would be set to the maximum plugin timeout setting, however I didn't see any easy way to achieve that so opted to extend the default for now.