### PR TITLE
Fix issue where plugin start timeout was getting limited to 60s. Closes #4477

### DIFF
--- a/pkg/cmdconfig/viper.go
+++ b/pkg/cmdconfig/viper.go
@@ -111,6 +111,9 @@ func setBaseDefaults() error {
 		// memory
 		pconstants.ArgMemoryMaxMbPlugin: 1024,
 		pconstants.ArgMemoryMaxMb:       1024,
+
+		// plugin start timeout
+		pconstants.ArgPluginStartTimeout: constants.PluginStartTimeout.Seconds(),
 	}
 
 	for k, v := range defaults {

--- a/pkg/constants/default_options.go
+++ b/pkg/constants/default_options.go
@@ -28,6 +28,6 @@ const DefaultConnectionConfigContent = `
 
 # options "plugin" {
 #   memory_max_mb    = "1024"	# the default maximum memory to allow a plugin process - used if there is not max memory specified in the 'plugin' block' for that plugin
-#   start_timeout    = 180    # the default maximum time (in seconds) to wait for a plugin to start up
+#   start_timeout    = 30       # maximum time (in seconds) to wait for a plugin to start up
 # }
 `

--- a/pkg/constants/default_options.go
+++ b/pkg/constants/default_options.go
@@ -28,6 +28,6 @@ const DefaultConnectionConfigContent = `
 
 # options "plugin" {
 #   memory_max_mb    = "1024"	# the default maximum memory to allow a plugin process - used if there is not max memory specified in the 'plugin' block' for that plugin
-#   start_timeout    = 180    # maximum time (in seconds) to wait for a plugin to start up
+#   start_timeout    = 180    # the default maximum time (in seconds) to wait for a plugin to start up
 # }
 `

--- a/pkg/constants/default_options.go
+++ b/pkg/constants/default_options.go
@@ -28,6 +28,6 @@ const DefaultConnectionConfigContent = `
 
 # options "plugin" {
 #   memory_max_mb    = "1024"	# the default maximum memory to allow a plugin process - used if there is not max memory specified in the 'plugin' block' for that plugin
-#   start_timeout    = 30       # maximum time (in seconds) to wait for a plugin to start up
+#   start_timeout    = 180    # maximum time (in seconds) to wait for a plugin to start up
 # }
 `

--- a/pkg/constants/duration.go
+++ b/pkg/constants/duration.go
@@ -9,5 +9,5 @@ var (
 	DBRecoveryTimeout        = 24 * time.Hour
 	DBRecoveryRetryBackoff   = 200 * time.Millisecond
 	ServicePingInterval      = 50 * time.Millisecond
-	PluginStartTimeout       = 30 * time.Second
+	PluginStartTimeout       = 3 * time.Minute
 )

--- a/pkg/options/plugin.go
+++ b/pkg/options/plugin.go
@@ -22,8 +22,6 @@ func (t *Plugin) ConfigMap() map[string]interface{} {
 	}
 	if t.StartTimeout != nil {
 		res[constants.ArgPluginStartTimeout] = t.StartTimeout
-	} else {
-		res[constants.ArgPluginStartTimeout] = constants.PluginStartTimeout.Seconds()
 	}
 
 	return res

--- a/pkg/pluginmanager/lifecycle.go
+++ b/pkg/pluginmanager/lifecycle.go
@@ -6,9 +6,11 @@ import (
 	"log"
 	"os/exec"
 	"syscall"
+	"time"
 
 	"github.com/hashicorp/go-hclog"
 	"github.com/hashicorp/go-plugin"
+	"github.com/spf13/viper"
 	"github.com/turbot/pipe-fittings/v2/app_specific"
 	"github.com/turbot/pipe-fittings/v2/constants"
 	"github.com/turbot/steampipe-plugin-sdk/v5/logging"
@@ -64,6 +66,7 @@ func start(steampipeExecutablePath string) (*State, error) {
 		Cmd:              pluginManagerCmd,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger:           logger,
+		StartTimeout:     time.Duration(viper.GetInt(pconstants.ArgPluginStartTimeout)) * time.Second,
 	})
 
 	if _, err := client.Start(); err != nil {

--- a/pkg/pluginmanager/lifecycle.go
+++ b/pkg/pluginmanager/lifecycle.go
@@ -66,7 +66,7 @@ func start(steampipeExecutablePath string) (*State, error) {
 		Cmd:              pluginManagerCmd,
 		AllowedProtocols: []plugin.Protocol{plugin.ProtocolGRPC},
 		Logger:           logger,
-		StartTimeout:     time.Duration(viper.GetInt(pconstants.ArgPluginStartTimeout)) * time.Second,
+		StartTimeout:     time.Duration(viper.GetInt(constants.ArgPluginStartTimeout)) * time.Second,
 	})
 
 	if _, err := client.Start(); err != nil {

--- a/pkg/pluginmanager_service/plugin_manager.go
+++ b/pkg/pluginmanager_service/plugin_manager.go
@@ -501,11 +501,16 @@ func (m *PluginManager) startPluginProcess(pluginInstance string, connectionConf
 
 	cmd := exec.Command(pluginPath)
 	m.setPluginMaxMemory(pluginConfig, cmd)
+
+	pluginStartTimeoutDuration := time.Duration(viper.GetInt64(pconstants.ArgPluginStartTimeout)) * time.Second
+	log.Printf("[TRACE] %s pluginStartTimeoutDuration: %s", pluginPath, pluginStartTimeoutDuration)
+
 	client := goplugin.NewClient(&goplugin.ClientConfig{
 		HandshakeConfig:  sdkshared.Handshake,
 		Plugins:          pluginMap,
 		Cmd:              cmd,
 		AllowedProtocols: []goplugin.Protocol{goplugin.ProtocolGRPC},
+		StartTimeout:     pluginStartTimeoutDuration,
 
 		// pass our logger to the plugin client to ensure plugin logs end up in logfile
 		Logger: m.logger,
@@ -678,13 +683,9 @@ func (m *PluginManager) waitForPluginLoad(p *runningPlugin, req *pb.GetRequest) 
 	}
 	pluginStartTimeoutSecs := pluginConfig.GetStartTimeout()
 	if pluginStartTimeoutSecs == 0 {
-		if viper.IsSet(pconstants.ArgMemoryMaxMbPlugin) {
+		if viper.IsSet(pconstants.ArgPluginStartTimeout) {
 			pluginStartTimeoutSecs = viper.GetInt64(pconstants.ArgPluginStartTimeout)
 		}
-	}
-	if pluginStartTimeoutSecs == 0 {
-		// if we don't have any timeout set use 30 seconds
-		pluginStartTimeoutSecs = int64(30)
 	}
 
 	log.Printf("[TRACE] waitForPluginLoad: waiting %d seconds (%p)", pluginStartTimeoutSecs, req)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -23,7 +23,7 @@ var steampipeVersion = "1.1.0"
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release
 // such as "dev" (in development), "beta", "rc1", etc.
-var prerelease = "alpha.0"
+var prerelease = "rc.0"
 
 // SteampipeVersion is an instance of semver.Version. This has the secondary
 // benefit of verifying during tests and init time that our version is a


### PR DESCRIPTION
Also, increase the default plugin start timeout to 3mins.