### PR TITLE
Release Steampipe v1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.1.2 [2025-05-06]
+_Bug fixes_
+- Fix issue where system-ingestible output format(csv) was humanised(comma separated) leading to a breaking change in query outputs. ([#4525](https://github.com/turbot/steampipe/issues/4525))
+
 ## v1.1.1 [2025-04-25]
 _Bug fixes_
 - Fix issue where query batch mode outputs(json, csv, line) were not printing the rows received to stdout when any of the other rows returned an API error. ([#4516](https://github.com/turbot/steampipe/issues/4516))

--- a/go.mod
+++ b/go.mod
@@ -42,8 +42,8 @@ require (
 	github.com/spf13/pflag v1.0.6
 	github.com/spf13/viper v1.20.0
 	github.com/thediveo/enumflag/v2 v2.0.7
-	github.com/turbot/go-kit v1.2.0
-	github.com/turbot/pipe-fittings/v2 v2.3.4
+	github.com/turbot/go-kit v1.3.0
+	github.com/turbot/pipe-fittings/v2 v2.3.6
 	github.com/turbot/steampipe-plugin-sdk/v5 v5.11.5
 	github.com/turbot/terraform-components v0.0.0-20250114051614-04b806a9cbed
 	github.com/zclconf/go-cty v1.16.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1256,12 +1256,12 @@ github.com/tklauser/numcpus v0.10.0 h1:18njr6LDBk1zuna922MgdjQuJFjrdppsZG60sHGfj
 github.com/tklauser/numcpus v0.10.0/go.mod h1:BiTKazU708GQTYF4mB+cmlpT2Is1gLk7XVuEeem8LsQ=
 github.com/tkrajina/go-reflector v0.5.8 h1:yPADHrwmUbMq4RGEyaOUpz2H90sRsETNVpjzo3DLVQQ=
 github.com/tkrajina/go-reflector v0.5.8/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
-github.com/turbot/go-kit v1.2.0 h1:4pBDu2LGoqF2y6ypL4xJjqlDW0BkUw3IIDlyHkU0O88=
-github.com/turbot/go-kit v1.2.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
+github.com/turbot/go-kit v1.3.0 h1:6cIYPAO5hO9fG7Zd5UBC4Ch3+C6AiiyYS0UQnrUlTV0=
+github.com/turbot/go-kit v1.3.0/go.mod h1:piKJMYCF8EYmKf+D2B78Csy7kOHGmnQVOWingtLKWWQ=
 github.com/turbot/go-prompt v0.2.6-steampipe.0.0.20221028122246-eb118ec58d50 h1:zs87uA6QZsYLk4RRxDOIxt8ro/B2V6HzoMWm05Lo7ao=
 github.com/turbot/go-prompt v0.2.6-steampipe.0.0.20221028122246-eb118ec58d50/go.mod h1:vFnjEGDIIA/Lib7giyE4E9c50Lvl8j0S+7FVlAwDAVw=
-github.com/turbot/pipe-fittings/v2 v2.3.4 h1:9sCn3G7c9oPdBr8CdkOkXXRdK/ZlGc5/6PW62L8BolQ=
-github.com/turbot/pipe-fittings/v2 v2.3.4/go.mod h1:X2R1AnkbXCmvtMrIhuArybN45Fj/+ZGPUilGeZDDXXs=
+github.com/turbot/pipe-fittings/v2 v2.3.6 h1:w4O5GxKhQSv0ZFVWMW4zj53hDTlEzerCa1usBaSHzoY=
+github.com/turbot/pipe-fittings/v2 v2.3.6/go.mod h1:szte433cBDCaZcGe5zMVGG7uTl9HMaEYaQmuvzZRYIQ=
 github.com/turbot/pipes-sdk-go v0.12.1 h1:mF9Z9Mr6F0uqlWjd1mQn+jqT24GPvWDFDrFTvmkazHc=
 github.com/turbot/pipes-sdk-go v0.12.1/go.mod h1:iQE0ebN74yqiCRrfv7izxVMRcNlZftPWWDPsMFwejt4=
 github.com/turbot/steampipe-plugin-sdk/v5 v5.11.5 h1:UajvoicpQDIAJdFM3A5Fn0UCVzt/V0TdszU+gHE+xBo=

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -18,7 +18,7 @@ Also https://www.digitalocean.com/community/tutorials/using-ldflags-to-set-versi
 **/
 
 // The main version number that is being run at the moment.
-var steampipeVersion = "1.1.1"
+var steampipeVersion = "1.1.2"
 
 // A pre-release marker for the version. If this is "" (empty string)
 // then it means that it is a final release. Otherwise, this is a pre-release

--- a/tests/acceptance/test_files/chaos_and_query.bats
+++ b/tests/acceptance/test_files/chaos_and_query.bats
@@ -262,6 +262,18 @@ load "$LIB_BATS_SUPPORT/load.bash"
   assert_equal "$output" "$(cat $TEST_DATA_DIR/expected_csv_separator_no_header.csv)"
 }
 
+@test "verify system-ingestible format(json) values are unchanged" {
+  run steampipe query --output json "select 100000 as id"
+  id=$(echo $output | jq '.rows.[0].id')
+  assert_equal "$id" "100000"
+}
+
+@test "verify system-ingestible formats(csv) values are unchanged" {
+  run steampipe query --output csv "select 100000 as id"
+  assert_equal "$output" "id
+100000"
+}
+
 @test "json" {
   run steampipe query --output json "select id, string_column, json_column from chaos.chaos_all_column_types where id='0'"
   echo $output > $TEST_DATA_DIR/actual_1.json


### PR DESCRIPTION
## Release Issue

[Steampipe v1.1.2](https://github.com/turbot/steampipe/issues/4527)

## Checklist

- [x] Confirmed that the version has been correctly upgraded.