### PR TITLE
Fix plugin manager verifyRunning function to avoid false positives, which lead to failure to start the plugin manager. Fixes #4507

### DIFF
--- a/pkg/db/db_local/start_services.go
+++ b/pkg/db/db_local/start_services.go
@@ -90,7 +90,7 @@ func StartServices(ctx context.Context, listenAddresses []string, port int, invo
 	// if we were not successful, stop services again
 	defer func() {
 		if res.Status == ServiceStarted && res.Error != nil {
-			StopServices(ctx, false, invoker)
+			_, _ = StopServices(ctx, false, invoker)
 			res.Status = ServiceFailedToStart
 		}
 	}()

--- a/pkg/pluginmanager/lifecycle.go
+++ b/pkg/pluginmanager/lifecycle.go
@@ -127,7 +127,7 @@ func stop(state *State) error {
 	pluginManager.rawClient.Kill()
 	log.Printf("[TRACE] pluginManager.Shutdown killed raw client")
 
-	// now kill the plugin manager
+	// now kill the plugin manager process itself if needed and clear the state file
 	return state.kill()
 }
 

--- a/pkg/pluginmanager/plugin_manager_client.go
+++ b/pkg/pluginmanager/plugin_manager_client.go
@@ -25,6 +25,7 @@ func NewPluginManagerClient(pluginManagerState *State) (*PluginManagerClient, er
 	}
 	err := res.attachToPluginManager()
 	if err != nil {
+		log.Printf("[TRACE] failed to attach to plugin manager: %s", err.Error())
 		return nil, err
 	}
 

--- a/pkg/pluginmanager/state.go
+++ b/pkg/pluginmanager/state.go
@@ -111,7 +111,7 @@ func (s *State) verifyRunning() (bool, error) {
 	exe, _ := p.Exe()
 	cmd, _ := p.Cmdline()
 	// verify this is a plugin manager process by comparing the executable name and the command line
-	return exe == s.Executable && strings.Contains(cmd, "plugin_manager"), nil
+	return exe == s.Executable && strings.Contains(cmd, "plugin-manager"), nil
 }
 
 // kill the plugin manager process and delete the state


### PR DESCRIPTION
pluginmanager.State.verifyRunning() now checks the process corresponding to the pid is a plugin manager process
pluginmanager.State.kill() deletes the plugin manager state file even if the process is not found