### PR TITLE
add test: symlinked binary

### DIFF
--- a/tests/acceptance/test_files/brew.bats
+++ b/tests/acceptance/test_files/brew.bats
@@ -21,6 +21,32 @@ load "$LIB_BATS_SUPPORT/load.bash"
   assert_equal $directory_count 0
 }
 
+# This is to test that the steampipe binary can be symlinked and still function correctly.
+# This is important for Homebrew and other package managers that may symlink the binary.
+# We had a failure in v2.0.0 where the symlinked binary left over steampipe plugin processes
+# running in the background, due to a pluginmanager bug. 
+# This test ensures that the symlinked binary works properly and does not leave any processes 
+# running in the background.
+@test "symlinked steampipe binary should work" {
+  export STEAMPIPE_LOG=info
+  # create a fresh target dir
+  target_directory=$(mktemp -d)
+
+  # create a symlink to the steampipe binary
+  ln -s $(which steampipe) $target_directory/sp
+
+  # add the target directory to PATH
+  export PATH=$target_directory:$PATH
+
+  # run a steampipe command to verify the symlink has been created correctly
+  run $target_directory/sp --version
+  assert_success
+
+  # check if querying is successful
+  run $target_directory/sp query "select * from chaos_all_column_types"
+  assert_success
+}
+
 function teardown_file() {
   # list running processes
   ps -ef | grep steampipe


### PR DESCRIPTION
This is to test that the steampipe binary can be symlinked and still function correctly. This is important for Homebrew and other package managers that may symlink the binary.

We had a failure in v2.0.0 where the symlinked binary left over steampipe plugin processes
running in the background, due to a pluginmanager bug. 

This test ensures that the symlinked binary works properly and does not leave any processes 
running in the background.