### PR TITLE
Fix: Add nil checks to ResetPools (Fixes #4698)

### DIFF
--- a/pkg/db/db_client/db_client.go
+++ b/pkg/db/db_client/db_client.go
@@ -241,8 +241,12 @@ func (c *DbClient) ResetPools(ctx context.Context) {
 	log.Println("[TRACE] db_client.ResetPools start")
 	defer log.Println("[TRACE] db_client.ResetPools end")
 
-	c.userPool.Reset()
-	c.managementPool.Reset()
+	if c.userPool != nil {
+		c.userPool.Reset()
+	}
+	if c.managementPool != nil {
+		c.managementPool.Reset()
+	}
 }
 
 func (c *DbClient) buildSchemasQuery(schemas ...string) string {


### PR DESCRIPTION
Fixes #4698

## Summary
- Added nil checks before calling `Reset()` on `userPool` and `managementPool` in `ResetPools()` method
- Prevents panic when pools are nil

## Changes
- Modified `pkg/db/db_client/db_client.go:244-249` to check for nil before calling `Reset()`

## Test plan
- [x] Code compiles successfully
- [ ] Verified fix prevents nil pointer panic

Fixes #4698

🤖 Generated with [Claude Code](https://claude.com/claude-code)
