### PR TITLE
Fix: Handle empty string in isValidDatabaseName (Fixes #4699)

### DIFF
--- a/pkg/db/db_local/install.go
+++ b/pkg/db/db_local/install.go
@@ -378,6 +378,9 @@ func startServiceForInstall(port int) (*psutils.Process, error) {
 }
 
 func isValidDatabaseName(databaseName string) bool {
+	if databaseName == "" {
+		return false
+	}
 	return databaseName[0] == '_' || (databaseName[0] >= 'a' && databaseName[0] <= 'z')
 }
 

--- a/pkg/db/db_local/install_test.go
+++ b/pkg/db/db_local/install_test.go
@@ -8,6 +8,7 @@ func TestIsValidDatabaseName(t *testing.T) {
 		"_valid_name": true,
 		"InvalidName": false,
 		"123Invalid":  false,
+		"":            false, // empty string should return false
 	}
 
 	for dbName, expectedResult := range tests {


### PR DESCRIPTION
Fixes #4699

## Summary

This PR fixes a panic that occurs when `isValidDatabaseName` is called with an empty string. The function was attempting to access the first character without checking if the string was empty.

**Changes:**
- Added empty string check at the start of `isValidDatabaseName` function in `pkg/db/db_local/install.go`
- Added test case for empty string in `TestIsValidDatabaseName` in `pkg/db/db_local/install_test.go`
- All tests pass successfully

## Test Plan

- ✅ Run `go test -v ./pkg/db/db_local/ -run TestIsValidDatabaseName`
- ✅ Verify empty string test case passes
- ✅ Verify all existing test cases still pass

**Related Issue:** Fixes #4699

🤖 Generated with [Claude Code](https://claude.com/claude-code)
