### PR TITLE
Fix race condition on customSearchPath slice closes #4792

### DIFF
--- a/pkg/db/db_client/db_client.go
+++ b/pkg/db/db_client/db_client.go
@@ -54,6 +54,8 @@ type DbClient struct {
 	// if a custom search path or a prefix is used, store it here
 	customSearchPath []string
 	searchPathPrefix []string
+	// allows locked access to customSearchPath and searchPathPrefix
+	searchPathMutex *sync.Mutex
 	// the default user search path
 	userSearchPath []string
 	// disable timing - set whilst in process of querying the timing
@@ -71,6 +73,7 @@ func NewDbClient(ctx context.Context, connectionString string, opts ...ClientOpt
 		parallelSessionInitLock: semaphore.NewWeighted(constants.MaxParallelClientInits),
 		sessions:                make(map[uint32]*db_common.DatabaseSession),
 		sessionsMutex:           &sync.Mutex{},
+		searchPathMutex:         &sync.Mutex{},
 		connectionString:        connectionString,
 	}
 

--- a/pkg/db/db_client/db_client_session_test.go
+++ b/pkg/db/db_client/db_client_session_test.go
@@ -181,6 +181,7 @@ func TestDbClient_SessionSearchPathUpdatesThreadSafe(t *testing.T) {
 	client := &DbClient{
 		customSearchPath: []string{"public", "internal"},
 		userSearchPath:   []string{"public"},
+		searchPathMutex:  &sync.Mutex{},
 	}
 
 	// Number of concurrent operations to test


### PR DESCRIPTION
## Summary
Fixed a data race on the `customSearchPath` and `searchPathPrefix` slices in `DbClient`. These fields were being accessed concurrently from multiple goroutines without synchronization, which could cause race conditions when the race detector is enabled.

The fix adds a dedicated `searchPathMutex` to protect all reads and writes to these fields.

## Changes
- **Commit 1**: Added test demonstrating the race condition
  - Created `TestDbClient_SessionSearchPathUpdatesThreadSafe` which spawns 300 concurrent goroutines that read and write to the search path fields
  - Test fails with `-race` flag before the fix, demonstrating the bug
  
- **Commit 2**: Implemented the fix
  - Added `searchPathMutex` field to `DbClient` struct
  - Protected all `customSearchPath` and `searchPathPrefix` reads/writes with the mutex in:
    - `SetRequiredSessionSearchPath` (writes)
    - `GetRequiredSessionSearchPath` (reads)
    - `GetCustomSearchPath` (reads)
  - Fixed logging to use already-fetched value instead of direct field access
  - Updated test to initialize the mutex for proper testing

## Test plan
- [x] Checkout commit 1, run `go test -race -run TestDbClient_SessionSearchPathUpdatesThreadSafe ./pkg/db/db_client` - should FAIL with race detector warnings
- [x] Checkout commit 2, run `go test -race -run TestDbClient_SessionSearchPathUpdatesThreadSafe ./pkg/db/db_client` - should PASS
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)