### PR TITLE
Race condition in rate limiter map access closes #4799

### DIFF
--- a/pkg/pluginmanager_service/plugin_manager.go
+++ b/pkg/pluginmanager_service/plugin_manager.go
@@ -772,9 +772,11 @@ func (m *PluginManager) setRateLimiters(pluginInstance string, pluginClient *sdk
 	log.Printf("[INFO] setRateLimiters for plugin '%s'", pluginInstance)
 	var defs []*sdkproto.RateLimiterDefinition
 
+	m.mut.RLock()
 	for _, l := range m.userLimiters[pluginInstance] {
 		defs = append(defs, RateLimiterAsProto(l))
 	}
+	m.mut.RUnlock()
 
 	req := &sdkproto.SetRateLimitersRequest{Definitions: defs}
 


### PR DESCRIPTION
## Summary
Fixed a race condition in the rate limiter map access where `getUserDefinedLimitersForPlugin` and other methods were reading from the `userLimiters` map without proper mutex protection while other goroutines could be writing to it concurrently.

## Changes
- **Commit 1**: Added comprehensive test that demonstrates the race condition
- **Commit 2**: Fixed the issue by adding RWMutex protection to all map accesses

The following methods now properly protect access to `m.userLimiters`:
- `getUserDefinedLimitersForPlugin`: Added RLock for map read
- `getPluginsWithChangedLimiters`: Added RLock for map iteration
- `handleUserLimiterChanges`: Added Lock for map write
- `refreshRateLimiterTable`: Added RLock for map iteration
- `setRateLimiters`: Added RLock for map read

## Test Plan
Run the test with race detection:
```bash
go test -race -v -run TestPluginManager_ConcurrentRateLimiterMapAccess ./pkg/pluginmanager_service
```

**Expected results:**
- At commit 1: Test fails with race detector warnings
- At commit 2: Test passes cleanly with no race warnings

The test creates concurrent goroutines that read and write the `userLimiters` map, simulating real-world concurrent access patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>