### PR TITLE
initialisationComplete flag synchronized closes #4803

### DIFF
--- a/pkg/interactive/interactive_client_init.go
+++ b/pkg/interactive/interactive_client_init.go
@@ -16,7 +16,7 @@ import (
 func (c *InteractiveClient) handleInitResult(ctx context.Context, initResult *db_common.InitResult) {
 	// whatever happens, set initialisationComplete
 	defer func() {
-		c.initialisationComplete = true
+		c.initialisationComplete.Store(true)
 	}()
 
 	if initResult.Error != nil {
@@ -127,7 +127,7 @@ func (c *InteractiveClient) readInitDataStream(ctx context.Context) {
 // return whether the client is initialises
 // there are 3 conditions>
 func (c *InteractiveClient) isInitialised() bool {
-	return c.initialisationComplete
+	return c.initialisationComplete.Load()
 }
 
 func (c *InteractiveClient) waitForInitData(ctx context.Context) error {


### PR DESCRIPTION
## Summary
Fixes a data race condition where the `initialisationComplete` boolean flag was being accessed concurrently by multiple goroutines without synchronization. The flag is written by the initialization goroutine and read by the query executor and notification handler.

## Changes
- **Commit 1**: Added test demonstrating the race condition
  - Test simulates concurrent reads and writes to the flag
  - Fails with `-race` flag before the fix
- **Commit 2**: Implemented fix using `atomic.Bool`
  - Changed `initialisationComplete` from `bool` to `atomic.Bool`
  - Updated all writes to use `.Store()`
  - Updated all reads to use `.Load()`

## Test Results
- **Before fix**: Race detector reports data race in multiple locations
- **After fix**: All tests pass with `-race` flag

## Verification
```bash
# Commit 1 (test only)
go test -race -v -run TestInitialisationComplete_RaceCondition ./pkg/interactive
# FAIL: race detected during execution of test

# Commit 2 (with fix)
go test -race -v -run TestInitialisationComplete_RaceCondition ./pkg/interactive
# PASS
```

The two-phase push ensures CI runs separately on each commit, demonstrating:
1. First CI run: Test fails with race detection (proving the bug exists)
2. Second CI run: Test passes (proving the fix works)