### PR TITLE
Fix #4866: Increase snapshot row streaming timeout from 5s to 30s

### DIFF
--- a/pkg/snapshot/snapshot.go
+++ b/pkg/snapshot/snapshot.go
@@ -211,8 +211,8 @@ func SnapshotToQueryResult[T queryresult.TimingContainer](snap *steampipeconfig.
 			case <-done:
 				// Cancelled, stop sending rows
 				return
-			case <-time.After(5 * time.Second):
-				// Timeout - consumer likely stopped reading, exit to prevent leak
+			case <-time.After(30 * time.Second):
+				// Timeout after 30s - consumer likely stopped reading, exit to prevent leak
 				return
 			}
 		}


### PR DESCRIPTION
## Problem

The snapshot acceptance tests are flaky, contributing to the ~50% CI failure rate. The snapshot row streaming goroutine has a 5-second timeout per row, which is too aggressive for CI environments.

## Changes

**File**: `pkg/snapshot/snapshot.go:214`

Changed the row streaming timeout from **5 seconds to 30 seconds**:
```diff
-case <-time.After(5 * time.Second):
-    // Timeout - consumer likely stopped reading, exit to prevent leak
+case <-time.After(30 * time.Second):
+    // Timeout after 30s - consumer likely stopped reading, exit to prevent leak
```

## Why This Helps

In slow CI environments or when the system is under load, the 5-second timeout can expire before data is fully consumed, resulting in incomplete snapshot output. This manifests as test failures where:
- **Expected**: 15 lines (header + 12 data rows)
- **Actual**: 3 lines (header only, no data)

The 30-second timeout provides adequate time for data consumption while still preventing goroutine leaks when consumers abandon results.

## Evidence of Problem

- Recent CI runs show ~50% failure rate
- PR #4865 demonstrated the failure: snapshot URL generated successfully, but output contained only header
- Timeout is hit prematurely in CI, not due to actual consumer abandonment

## Impact

✅ **Reduces CI flakiness** - Should significantly reduce snapshot test failures  
✅ **No negative side effects** - Timeout only matters when consumer abandons result  
✅ **Simple, targeted fix** - Single line change with clear benefit  

## Testing

This change will be validated by upcoming CI runs. The timeout only affects the edge case where consumers stop reading, so normal operation is unaffected.

Closes #4866