### PR TITLE
initialisationComplete flag synchronized closes #4803 (rebased)

### DIFF
--- a/pkg/interactive/interactive_client_init.go
+++ b/pkg/interactive/interactive_client_init.go
@@ -16,7 +16,7 @@ import (
 func (c *InteractiveClient) handleInitResult(ctx context.Context, initResult *db_common.InitResult) {
 	// whatever happens, set initialisationComplete
 	defer func() {
-		c.initialisationComplete = true
+		c.initialisationComplete.Store(true)
 	}()
 
 	if initResult.Error != nil {
@@ -127,7 +127,7 @@ func (c *InteractiveClient) readInitDataStream(ctx context.Context) {
 // return whether the client is initialises
 // there are 3 conditions>
 func (c *InteractiveClient) isInitialised() bool {
-	return c.initialisationComplete
+	return c.initialisationComplete.Load()
 }
 
 func (c *InteractiveClient) waitForInitData(ctx context.Context) error {

--- a/pkg/interactive/interactive_client_test.go
+++ b/pkg/interactive/interactive_client_test.go
@@ -290,9 +290,8 @@ func TestIsInitialised(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &InteractiveClient{
-				initialisationComplete: tt.initialisationComplete,
-			}
+			c := &InteractiveClient{}
+			c.initialisationComplete.Store(tt.initialisationComplete)
 
 			result := c.isInitialised()
 
@@ -543,9 +542,8 @@ func TestCancelActiveQueryIfAny(t *testing.T) {
 //
 // Bug: #4803
 func TestInitialisationComplete_RaceCondition(t *testing.T) {
-	c := &InteractiveClient{
-		initialisationComplete: false,
-	}
+	c := &InteractiveClient{}
+	c.initialisationComplete.Store(false)
 
 	var wg sync.WaitGroup
 
@@ -554,8 +552,8 @@ func TestInitialisationComplete_RaceCondition(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
-			c.initialisationComplete = true
-			c.initialisationComplete = false
+			c.initialisationComplete.Store(true)
+			c.initialisationComplete.Store(false)
 		}
 	}()
 
@@ -574,7 +572,7 @@ func TestInitialisationComplete_RaceCondition(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
 			// Check the flag directly (as handleConnectionUpdateNotification does)
-			if !c.initialisationComplete {
+			if !c.initialisationComplete.Load() {
 				continue
 			}
 		}


### PR DESCRIPTION
## Summary
Fixes a data race condition where the `initialisationComplete` boolean flag was being accessed concurrently by multiple goroutines without synchronization. The flag is written by the initialization goroutine and read by the query executor and notification handler.

This is a rebased version of PR #4848 which had merge conflicts after PR #4864 was merged.

## Changes
- Changed `initialisationComplete` field from `bool` to `atomic.Bool` in `InteractiveClient`
- Added `sync/atomic` import
- Updated all writes to use `.Store(true)`
- Updated all reads to use `.Load()`
- Added test `TestInitialisationComplete_RaceCondition` demonstrating the race condition and verifying the fix
- Updated existing `TestIsInitialised` test to work with `atomic.Bool`

## Test Results
- **With fix**: All tests pass with `-race` flag
- Test simulates concurrent reads and writes to the flag
- Race detector confirms no data races with atomic operations

## Verification
```bash
# Run the race condition test with race detector
go test -race -v -run TestInitialisationComplete_RaceCondition ./pkg/interactive
# PASS

# Run all interactive tests with race detector
go test -race -v ./pkg/interactive
# PASS - all tests pass
```

## Related
- Closes #4803
- Replaces #4848 (had merge conflicts with #4864)

🤖 Generated with [Claude Code](https://claude.com/claude-code)