### PR TITLE
initialisationComplete flag synchronized closes #4803 (rebased)

### DIFF
--- a/pkg/interactive/interactive_client_init.go
+++ b/pkg/interactive/interactive_client_init.go
@@ -16,7 +16,7 @@ import (
 func (c *InteractiveClient) handleInitResult(ctx context.Context, initResult *db_common.InitResult) {
 	// whatever happens, set initialisationComplete
 	defer func() {
-		c.initialisationComplete = true
+		c.initialisationComplete.Store(true)
 	}()
 
 	if initResult.Error != nil {
@@ -127,7 +127,7 @@ func (c *InteractiveClient) readInitDataStream(ctx context.Context) {
 // return whether the client is initialises
 // there are 3 conditions>
 func (c *InteractiveClient) isInitialised() bool {
-	return c.initialisationComplete
+	return c.initialisationComplete.Load()
 }
 
 func (c *InteractiveClient) waitForInitData(ctx context.Context) error {

--- a/pkg/interactive/interactive_client_test.go
+++ b/pkg/interactive/interactive_client_test.go
@@ -543,9 +543,8 @@ func TestCancelActiveQueryIfAny(t *testing.T) {
 //
 // Bug: #4803
 func TestInitialisationComplete_RaceCondition(t *testing.T) {
-	c := &InteractiveClient{
-		initialisationComplete: false,
-	}
+	c := &InteractiveClient{}
+	c.initialisationComplete.Store(false)
 
 	var wg sync.WaitGroup
 
@@ -554,8 +553,8 @@ func TestInitialisationComplete_RaceCondition(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
-			c.initialisationComplete = true
-			c.initialisationComplete = false
+			c.initialisationComplete.Store(true)
+			c.initialisationComplete.Store(false)
 		}
 	}()
 
@@ -574,7 +573,7 @@ func TestInitialisationComplete_RaceCondition(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
 			// Check the flag directly (as handleConnectionUpdateNotification does)
-			if !c.initialisationComplete {
+			if !c.initialisationComplete.Load() {
 				continue
 			}
 		}


### PR DESCRIPTION
This PR demonstrates and fixes the issue.

**Two-commit pattern**:
- Commit 1: Test demonstrating the bug (this commit - **should FAIL CI**)
- Commit 2: Fix implementation (will be pushed after CI confirms failure)

This is a re-trigger of PR #4886 to show the proper fail → pass CI pattern.

Closes the same issue as #4886