### PR TITLE
Fix flaky concurrent rate limiter tests

### DIFF
--- a/pkg/pluginmanager_service/rate_limiters_test.go
+++ b/pkg/pluginmanager_service/rate_limiters_test.go
@@ -108,6 +108,7 @@ func TestPluginManager_ConcurrentUpdateRateLimiterStatus(t *testing.T) {
 				},
 			},
 		},
+		mut: sync.RWMutex{},
 	}
 
 	// Run concurrent operations to trigger race condition
@@ -119,6 +120,9 @@ func TestPluginManager_ConcurrentUpdateRateLimiterStatus(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < iterations; i++ {
+			// Simulate production code behavior - use mutex when writing
+			// (see handleUserLimiterChanges lines 98-100)
+			pm.mut.Lock()
 			pm.userLimiters = connection.PluginLimiterMap{
 				"aws": connection.LimiterMap{
 					"limiter1": &plugin.RateLimiter{
@@ -128,6 +132,7 @@ func TestPluginManager_ConcurrentUpdateRateLimiterStatus(t *testing.T) {
 					},
 				},
 			}
+			pm.mut.Unlock()
 		}
 	}()
 
@@ -187,6 +192,9 @@ func TestPluginManager_ConcurrentRateLimiterMapAccess2(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
+				// Simulate production code behavior - use mutex when writing
+				// (see handleUserLimiterChanges lines 98-100)
+				pm.mut.Lock()
 				pm.userLimiters["aws"] = connection.LimiterMap{
 					"limiter1": &plugin.RateLimiter{
 						Name:   "limiter1",
@@ -194,6 +202,7 @@ func TestPluginManager_ConcurrentRateLimiterMapAccess2(t *testing.T) {
 						Status: plugin.LimiterStatusOverridden,
 					},
 				}
+				pm.mut.Unlock()
 			}
 		}()
 	}


### PR DESCRIPTION
## Summary
Fixes two flaky tests that were failing intermittently in CI:
- `TestPluginManager_ConcurrentUpdateRateLimiterStatus`
- `TestPluginManager_ConcurrentRateLimiterMapAccess2`

## Problem
The tests were crashing with `fatal error: concurrent map read and map write` because test writer goroutines were modifying `pm.userLimiters` without mutex protection while reader goroutines simultaneously accessed the map. This is a safety feature in Go's map implementation that detects unsafe concurrent access.

## Root Cause
The test code wasn't properly simulating production behavior. The production code in `handleUserLimiterChanges` (lines 98-100) correctly protects writes with `pm.mut.Lock/Unlock`, but the tests were writing to the map without any synchronization.

## Solution
- Added missing `mut` field initialization in `TestPluginManager_ConcurrentUpdateRateLimiterStatus`
- Wrapped all `pm.userLimiters` writes in both tests with `pm.mut.Lock/Unlock` to match production code behavior
- Added comments explaining the mutex usage matches production code

## Testing
Ran tests 100+ times consecutively both with and without `-race` flag - all passed successfully. Previously the unfixed version would fail on the 2nd iteration.

**Before fix (without -race):**
```
fatal error: concurrent map read and map write
FAIL (iteration 2/100)
```

**After fix:**
```
PASS (100/100 iterations)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>