### PR TITLE
fix: Return empty digest on version file failure (#4762)

### DIFF
--- a/pkg/ociinstaller/db.go
+++ b/pkg/ociinstaller/db.go
@@ -41,7 +41,7 @@ func InstallDB(ctx context.Context, dblocation string) (string, error) {
 	}
 
 	if err := updateVersionFileDB(image); err != nil {
-		return string(image.OCIDescriptor.Digest), err
+		return "", err
 	}
 	return string(image.OCIDescriptor.Digest), nil
 }

--- a/pkg/ociinstaller/fdw.go
+++ b/pkg/ociinstaller/fdw.go
@@ -44,7 +44,7 @@ func InstallFdw(ctx context.Context, dbLocation string) (string, error) {
 	}
 
 	if err := updateVersionFileFdw(image); err != nil {
-		return string(image.OCIDescriptor.Digest), err
+		return "", err
 	}
 
 	return string(image.OCIDescriptor.Digest), nil


### PR DESCRIPTION
## Summary

Fixes #4762 - Version file update failure now returns empty digest instead of ambiguous (digest, error) state.

**Changes:**
- `InstallDB` (db.go:38): Returns `("", error)` instead of `(digest, error)` on version file failure
- `InstallFdw` (fdw.go:41): Returns `("", error)` instead of `(digest, error)` on version file failure  
- Added test `TestUpdateVersionFileDB_FailureHandling_BugDocumentation` documenting the bug and verifying the fix

**Problem:**
When installation succeeded but version file update failed, functions returned both a digest (suggesting success) and an error, creating ambiguous state. This could lead to:
- Version mismatch between installed files and version tracking
- Unnecessary reinstalls on next startup
- Unclear error states for callers

**Solution:**
Since version file tracking is critical for managing installations, its failure is now treated as complete installation failure. This provides clear semantics:
- `("", error)` = installation failed (clear)
- `(digest, nil)` = installation succeeded (clear)
- No ambiguous `(digest, error)` state

## Test plan

- [x] Added test demonstrating the bug behavior (commit 1)
- [x] Verified test fails before fix
- [x] Implemented fix for both `InstallDB` and `InstallFdw` (commit 2)
- [x] Verified test passes after fix
- [x] All existing ociinstaller tests pass

Generated with Claude Code