### PR TITLE
Fix autocomplete regression: suggestions disappear when typing table name after 'from '

### DIFF
--- a/pkg/interactive/interactive_client_test.go
+++ b/pkg/interactive/interactive_client_test.go
@@ -587,9 +587,10 @@ func TestInitialisationComplete_RaceCondition(t *testing.T) {
 //
 // This is important for autocomplete - when a user types "from " (with a space),
 // the system should recognize they are about to enter a table name and enable
-// table suggestions.
+// table suggestions. It should also remain true while typing a table name so
+// that autocomplete can filter suggestions as the user types.
 //
-// Bug: #4810
+// Bug: #4810, #4928
 func TestGetQueryInfo_FromDetection(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -598,22 +599,28 @@ func TestGetQueryInfo_FromDetection(t *testing.T) {
 		expectedEditTable bool
 	}{
 		{
-			name:              "just_from",
+			name:              "just_from_with_space",
 			input:             "from ",
 			expectedTable:     "",
-			expectedEditTable: true, // Should be true - user is about to enter table name
+			expectedEditTable: true,
 		},
 		{
-			name:              "from_with_table",
+			name:              "from_typing_table",
 			input:             "from my_table",
 			expectedTable:     "my_table",
-			expectedEditTable: false, // Not editing, already entered
+			expectedEditTable: true, // Still editing - prevWord is "from"
 		},
 		{
 			name:              "from_keyword_only",
 			input:             "from",
 			expectedTable:     "",
 			expectedEditTable: false,
+		},
+		{
+			name:              "from_table_done",
+			input:             "from my_table ",
+			expectedTable:     "my_table",
+			expectedEditTable: false, // Done editing - prevWord is now "my_table"
 		},
 	}
 

--- a/pkg/interactive/interactive_helpers.go
+++ b/pkg/interactive/interactive_helpers.go
@@ -17,17 +17,12 @@ func getQueryInfo(text string) *queryCompletionInfo {
 
 	return &queryCompletionInfo{
 		Table:        table,
-		EditingTable: isEditingTable(text, prevWord),
+		EditingTable: isEditingTable(prevWord),
 	}
 }
 
-func isEditingTable(text string, prevWord string) bool {
-	// Only consider it editing table if:
-	// 1. The previous word is "from"
-	// 2. The text ends with a space (meaning cursor is after "from ", not in the middle of typing a table name)
-	endsWithSpace := len(text) > 0 && text[len(text)-1] == ' '
-	var editingTable = prevWord == "from" && endsWithSpace
-	return editingTable
+func isEditingTable(prevWord string) bool {
+	return prevWord == "from"
 }
 
 func getTable(text string) string {


### PR DESCRIPTION
## Summary
- Fixes #4928 — autocomplete suggestions disappear as soon as the user starts typing a table name after `from `
- This is a regression introduced in #4884 (v2.3.3) where an `endsWithSpace` check was added to `isEditingTable()`, causing it to return `false` while typing a table name prefix
- Reverts `isEditingTable()` back to the simple `prevWord == "from"` check, which correctly relies on `FilterHasPrefix` in `queryCompleter` to narrow suggestions as the user types
- Retains the valid `getPreviousWord()` fix from #4884

## Test plan
- [x] `TestIsEditingTable` — updated for reverted single-arg signature, added "table name after from" case
- [x] `TestGetQueryInfo` — added regression test cases: `typing table name after from`, `typing partial table name`, `typing qualified table name`, `past table into where clause`
- [x] `TestGetQueryInfo_FromDetection` — fixed expectations and added `from_table_done` case
- [x] All 68 tests in `pkg/interactive/` pass
- [x] Manual verification: type `select * from aws` in interactive prompt and confirm suggestions filter correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)