### PR TITLE
Upgrade Go to 1.26, FDW to 2.2.0, SDK to v5.14.0, and golangci-lint to v2

### DIFF
--- a/.github/workflows/01-steampipe-release.yaml
+++ b/.github/workflows/01-steampipe-release.yaml
@@ -111,7 +111,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.24
+          go-version: 1.26
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -26,16 +26,17 @@ jobs:
           path: pipe-fittings
           ref: v1.6.x
 
-      - name: Set up Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
+      # this is required, check golangci-lint-action docs
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: 1.24
+          go-version: '1.26'
+          cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@0a35821d5c230e903fcfe077583637dea1b27b47 # v9.0.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         continue-on-error: true # we dont want to enforce just yet
         with:
-          version: v1.52.2
-          args: --timeout=15m --config=.golangci.yml
-          skip-pkg-cache: true
-          skip-build-cache: true
+          version: latest
+          args: --timeout=10m
+          working-directory: steampipe
+          skip-cache: true

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.24
+          go-version: 1.26
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -127,7 +127,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.24
+          go-version: 1.26
 
       - name: Prepare for downloads
         id: prepare-for-downloads

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,20 @@
+version: "2"
+
 linters:
-  disable-all: true
+  default: none
   enable:
     # default rules
     - errcheck
-    - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - typecheck
     - unused
     # other rules
     - asasalint
     - asciicheck
     - bidichk
+    - depguard
     - durationcheck
-    - exportloopref
     - forbidigo
     - gocritic
     - gocheckcompilerdirectives
@@ -25,20 +25,48 @@ linters:
     - reassign
     - sqlclosecheck
     - unconvert
+  settings:
+    nolintlint:
+      require-explanation: true
+      require-specific: true
 
-linters-settings:
-  nolintlint:
-    require-explanation: true
-    require-specific: true
+    staticcheck:
+      checks:
+        - "all"
+        - "-ST*"    # stylecheck: not previously enabled (merged into staticcheck in v2)
+        - "-QF*"    # quickfix suggestions: not previously enabled (merged into staticcheck in v2)
 
-  gocritic:
-    disabled-checks:
-      - ifElseChain       # style
-      - singleCaseSwitch  # style & it's actually not a bad idea to use single case switch in some cases
-      - assignOp          # style
-      - commentFormatting # style
+    gosec:
+      excludes:
+        - G101      # false positives on non-credential string constants
+        - G602      # false positives on range loops and safe slice access
+        - G706      # false positives on logging config/environment values
+
+    forbidigo:
+      forbid:
+        - pattern: "^(fmt\\.Print(|f|ln)|print|println)$"
+        - pattern: "^(fmt\\.Fprint(|f|ln)|print|println)$"
+
+    gocritic:
+      disabled-checks:
+        - ifElseChain       # style
+        - singleCaseSwitch  # style & it's actually not a bad idea to use single case switch in some cases
+        - assignOp          # style
+        - commentFormatting # style
+
+    depguard:
+      rules:
+        main:
+          deny:
+            - pkg: "github.com/pkg/errors"
+              desc: Should be replaced by standard lib errors package
+  exclusions:
+    presets:
+      - std-error-handling    # errcheck: unchecked Close/Remove/print calls
+      - common-false-positives # gosec: G103, G204, G304 false positives
+      - legacy                 # gosec: G104, G301, G302, G307
+    paths:
+      - "tests/acceptance"
 
 run:
   timeout: 5m
-  skip-dirs:
-    - "tests/acceptance"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe/v2
 
-go 1.24.0
+go 1.26.0
 
 replace (
 	github.com/c-bata/go-prompt => github.com/turbot/go-prompt v0.2.6-steampipe.0.0.20221028122246-eb118ec58d50
@@ -41,7 +41,7 @@ require (
 	github.com/thediveo/enumflag/v2 v2.0.7
 	github.com/turbot/go-kit v1.3.0
 	github.com/turbot/pipe-fittings/v2 v2.7.3
-	github.com/turbot/steampipe-plugin-sdk/v5 v5.13.2
+	github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0
 	github.com/turbot/terraform-components v0.0.0-20250114051614-04b806a9cbed
 	github.com/zclconf/go-cty v1.16.3 // indirect
 	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394

--- a/go.sum
+++ b/go.sum
@@ -1262,8 +1262,8 @@ github.com/turbot/pipe-fittings/v2 v2.7.3 h1:DacY/pc8zERJYXszkomJCOi1YDK3e2chJ1H
 github.com/turbot/pipe-fittings/v2 v2.7.3/go.mod h1:VYqcgGrYDLsGxn1r4dOkkEh5/KDEgJgUU+nf0SAODY0=
 github.com/turbot/pipes-sdk-go v0.12.1 h1:mF9Z9Mr6F0uqlWjd1mQn+jqT24GPvWDFDrFTvmkazHc=
 github.com/turbot/pipes-sdk-go v0.12.1/go.mod h1:iQE0ebN74yqiCRrfv7izxVMRcNlZftPWWDPsMFwejt4=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.13.2 h1:4SSI20DCC0N3ItU1HGytCaxaekQMKpYuMOySezQ32zQ=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.13.2/go.mod h1:qmfaXKt9z+TgUaFoKkKzwZAwYA5h2Mf/3yuoc+P6otY=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0 h1:CyufzeM2BMbA2nJRuujucchp9NZ6BEeYA2phhdMXsW4=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.14.0/go.mod h1:VHKUVPx29JEHXjuY9Kj/fdabceHdGQB1kaH4Dik/XY8=
 github.com/turbot/terraform-components v0.0.0-20250114051614-04b806a9cbed h1:1ROP+kYJ0vaJu04qpQO5V2PVrUqG7VZmYXzcyP/yDT0=
 github.com/turbot/terraform-components v0.0.0-20250114051614-04b806a9cbed/go.mod h1:QJMOFtDVHtXLCJr6luh4oFgk6dtdCImDh7XbIXxnGsc=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -28,7 +28,7 @@ const (
 // constants for installing db and fdw images
 const (
 	DatabaseVersion = "14.19.0"
-	FdwVersion      = "2.1.5"
+	FdwVersion      = "2.2.0"
 
 	// PostgresImageRef is the OCI Image ref for the database binaries
 	PostgresImageRef    = "ghcr.io/turbot/steampipe/db:14.19.0"


### PR DESCRIPTION
## Summary
- Upgrade Go version from 1.24 to 1.26 in `go.mod` and all CI workflows
- Update FDW version to 2.2.0 and SDK to v5.14.0
- Migrate golangci-lint config from v1 to v2 format (matching powerpipe)
- Update lint workflow to use `golangci-lint-action v9.2.0` with `version: latest`

## Changes
| File | Change |
|------|--------|
| `go.mod` | `go 1.24.0` → `go 1.26.0`, SDK `v5.13.2` → `v5.14.0` |
| `pkg/constants/db.go` | FDW `2.1.5` → `2.2.0` |
| `.golangci.yml` | Migrated to v2 format |
| `.github/workflows/10-test-lint.yaml` | Updated setup-go, golangci-lint action, Go version |
| `.github/workflows/01-steampipe-release.yaml` | `go-version: 1.24` → `1.26` |
| `.github/workflows/11-test-acceptance.yaml` | `go-version: 1.24` → `1.26` |

## Lint config migration (v1 → v2)
- Removed `gosimple`, `typecheck`, `exportloopref` (merged/removed in v2)
- Added `depguard`, `staticcheck` checks config, `gosec` exclusions
- Added exclusion presets (`std-error-handling`, `common-false-positives`, `legacy`)
- Lint remains non-blocking (`continue-on-error: true`); lint fixes to follow in a separate PR

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] `golangci-lint config verify` passes
- [ ] CI workflows pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)