### PR TITLE
added http config api to `PluginManager` for synchronous connection config updates

### DIFF
--- a/pkg/pluginmanager_service/config_api_server.go
+++ b/pkg/pluginmanager_service/config_api_server.go
@@ -1,0 +1,241 @@
+package pluginmanager_service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+
+	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe/v2/pkg/connection"
+	"github.com/turbot/steampipe/v2/pkg/db/db_common"
+)
+
+// SetConnectionConfigRequest is the JSON request body for the config API endpoint.
+type SetConnectionConfigRequest struct {
+	Connection      string `json:"connection"`
+	Plugin          string `json:"plugin"`
+	PluginShortName string `json:"plugin_short_name"`
+	Config          string `json:"config"`
+	PluginInstance  string `json:"plugin_instance"`
+}
+
+// SetConnectionConfigResponse is the JSON response from the config API endpoint.
+type SetConnectionConfigResponse struct {
+	Success bool   `json:"success"`
+	Error   string `json:"error,omitempty"`
+}
+
+// startConfigAPIServer starts the HTTP config API server if STEAMPIPE_CONFIG_API_PORT is set.
+// The server runs in a goroutine and provides a synchronous endpoint for updating
+// connection configs, bypassing the file watcher.
+func (m *PluginManager) startConfigAPIServer() {
+	port := os.Getenv("STEAMPIPE_CONFIG_API_PORT")
+	if port == "" || port == "0" {
+		return
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/connection/config", m.handleSetConnectionConfig)
+
+	addr := fmt.Sprintf("127.0.0.1:%s", port)
+	server := &http.Server{
+		Addr:    addr,
+		Handler: mux,
+	}
+
+	go func() {
+		log.Printf("[INFO] Config API server listening on %s", addr)
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Printf("[WARN] Config API server error: %s", err.Error())
+		}
+	}()
+}
+
+// getConnLock returns the per-connection mutex for the given connection name,
+// creating one if it doesn't exist. This serializes concurrent requests for the
+// same connection so that ensureConnectionSchema completes before any concurrent
+// request can return success. Different connections are fully parallel.
+func (m *PluginManager) getConnLock(connectionName string) *sync.Mutex {
+	m.connLocksMu.Lock()
+	mu, ok := m.connLocks[connectionName]
+	if !ok {
+		mu = &sync.Mutex{}
+		m.connLocks[connectionName] = mu
+	}
+	m.connLocksMu.Unlock()
+	return mu
+}
+
+// handleSetConnectionConfig handles POST /v1/connection/config.
+// It updates a single connection's config in the plugin manager synchronously,
+// sending the update to the running plugin via gRPC before returning.
+//
+// Per-connection locking ensures that when multiple concurrent requests arrive
+// for the same connection, only the first creates the schema — the rest wait
+// until it's done, then proceed (as credential-rotation updates, not new connections).
+func (m *PluginManager) handleSetConnectionConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req SetConnectionConfigRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeConfigAPIResponse(w, http.StatusBadRequest, SetConnectionConfigResponse{
+			Error: fmt.Sprintf("invalid JSON: %s", err.Error()),
+		})
+		return
+	}
+
+	if err := validateSetConnectionConfigRequest(&req); err != nil {
+		writeConfigAPIResponse(w, http.StatusBadRequest, SetConnectionConfigResponse{
+			Error: err.Error(),
+		})
+		return
+	}
+
+	// Acquire per-connection lock. This serializes the entire config-update +
+	// schema-creation sequence for the same connection name. Without this, 30
+	// concurrent requests all see isNewConnection=true (first) or false (rest),
+	// but the "rest" return 200 before the first thread's ensureConnectionSchema
+	// has finished, causing "relation does not exist" errors.
+	connLock := m.getConnLock(req.Connection)
+	connLock.Lock()
+	defer connLock.Unlock()
+
+	// Build the new ConnectionConfig proto
+	newConfig := &sdkproto.ConnectionConfig{
+		Connection:      req.Connection,
+		Plugin:          req.Plugin,
+		PluginShortName: req.PluginShortName,
+		Config:          req.Config,
+		PluginInstance:  req.PluginInstance,
+	}
+
+	// Acquire the PluginManager state lock and update the config map
+	m.mut.Lock()
+
+	// Track whether this is a new connection (needs schema creation) or an update (creds only)
+	_, isNewConnection := m.connectionConfigMap[req.Connection]
+	isNewConnection = !isNewConnection
+
+	// Resolve PluginInstance and Plugin to match the full image refs used as keys
+	// in m.plugins (e.g., "hub.steampipe.io/plugins/turbot/aws@latest"), not short
+	// names like "aws". For existing connections, inherit from the current config.
+	// For new connections, inherit from any existing connection using the same plugin.
+	if existing, ok := m.connectionConfigMap[req.Connection]; ok {
+		if newConfig.PluginInstance != existing.PluginInstance {
+			newConfig.PluginInstance = existing.PluginInstance
+		}
+		if newConfig.Plugin == "" {
+			newConfig.Plugin = existing.Plugin
+		}
+	} else {
+		// New connection: resolve PluginInstance from any existing connection
+		// that uses the same plugin, so the FDW can find the running plugin process.
+		for _, existing := range m.connectionConfigMap {
+			if existing.PluginShortName == req.PluginShortName {
+				newConfig.PluginInstance = existing.PluginInstance
+				if newConfig.Plugin == "" {
+					newConfig.Plugin = existing.Plugin
+				}
+				break
+			}
+		}
+	}
+
+	newConfigMap := m.buildMergedConfigMap(newConfig)
+	err := m.handleConnectionConfigChanges(context.Background(), newConfigMap)
+	m.mut.Unlock()
+
+	if err != nil {
+		log.Printf("[WARN] Config API: handleConnectionConfigChanges failed for connection '%s': %s", req.Connection, err.Error())
+		writeConfigAPIResponse(w, http.StatusInternalServerError, SetConnectionConfigResponse{
+			Error: fmt.Sprintf("failed to update connection config: %s", err.Error()),
+		})
+		return
+	}
+
+	// For new connections, create the FDW schema in postgres so the connection
+	// is immediately queryable. For existing connections (credential rotation),
+	// the schema already exists and only the credentials needed updating.
+	// This runs under connLock, so concurrent requests for the same connection
+	// wait until schema creation is complete before proceeding.
+	if isNewConnection && m.pool != nil {
+		if err := m.ensureConnectionSchema(context.Background(), req.Connection, req.PluginShortName); err != nil {
+			log.Printf("[WARN] Config API: schema creation failed for connection '%s': %s", req.Connection, err.Error())
+			writeConfigAPIResponse(w, http.StatusInternalServerError, SetConnectionConfigResponse{
+				Error: fmt.Sprintf("connection config updated but schema creation failed: %s", err.Error()),
+			})
+			return
+		}
+	}
+
+	log.Printf("[INFO] Config API: updated connection '%s' (plugin: %s)", req.Connection, req.PluginShortName)
+	writeConfigAPIResponse(w, http.StatusOK, SetConnectionConfigResponse{Success: true})
+}
+
+// buildMergedConfigMap creates a new ConnectionConfigMap by copying the existing map
+// and adding or updating the given connection config.
+func (m *PluginManager) buildMergedConfigMap(config *sdkproto.ConnectionConfig) connection.ConnectionConfigMap {
+	newMap := make(connection.ConnectionConfigMap, len(m.connectionConfigMap)+1)
+	for k, v := range m.connectionConfigMap {
+		newMap[k] = v
+	}
+	newMap[config.Connection] = config
+	return newMap
+}
+
+func validateSetConnectionConfigRequest(req *SetConnectionConfigRequest) error {
+	if req.Connection == "" {
+		return fmt.Errorf("'connection' is required")
+	}
+	if req.PluginShortName == "" {
+		return fmt.Errorf("'plugin_short_name' is required")
+	}
+	if req.Config == "" {
+		return fmt.Errorf("'config' is required")
+	}
+	if req.PluginInstance == "" {
+		return fmt.Errorf("'plugin_instance' is required")
+	}
+	return nil
+}
+
+// ensureConnectionSchema creates the FDW schema for a new connection.
+// The plugin manager config was already updated in-memory via
+// handleConnectionConfigChanges(), so the FDW import path can resolve this
+// connection directly through plugin manager gRPC without any disk config files.
+func (m *PluginManager) ensureConnectionSchema(ctx context.Context, connectionName, pluginShortName string) error {
+	// Create the FDW schema in postgres
+	sql := db_common.GetUpdateConnectionQuery(connectionName, pluginShortName)
+	log.Printf("[INFO] Config API: creating schema for connection '%s' (plugin schema: %s)", connectionName, pluginShortName)
+
+	conn, err := m.pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire db connection: %w", err)
+	}
+	defer conn.Release()
+
+	_, err = conn.Exec(ctx, sql)
+	if err != nil {
+		return fmt.Errorf("failed to create connection schema: %w", err)
+	}
+
+	// Notify listeners that the schema has changed
+	if notifyErr := m.SendPostgresSchemaNotification(ctx); notifyErr != nil {
+		log.Printf("[WARN] Config API: failed to send schema notification: %s", notifyErr.Error())
+	}
+
+	return nil
+}
+
+func writeConfigAPIResponse(w http.ResponseWriter, status int, resp SetConnectionConfigResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(resp)
+}

--- a/pkg/pluginmanager_service/config_api_server_test.go
+++ b/pkg/pluginmanager_service/config_api_server_test.go
@@ -1,0 +1,395 @@
+package pluginmanager_service
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	sdkproto "github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe/v2/pkg/connection"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeConfigRequest(t *testing.T, connection, plugin, shortName, config, instance string) *bytes.Buffer {
+	t.Helper()
+	body := SetConnectionConfigRequest{
+		Connection:      connection,
+		Plugin:          plugin,
+		PluginShortName: shortName,
+		Config:          config,
+		PluginInstance:  instance,
+	}
+	b, err := json.Marshal(body)
+	require.NoError(t, err)
+	return bytes.NewBuffer(b)
+}
+
+// Test 1: Add a new connection via the config API
+func TestConfigAPIServer_SetConnectionConfig_NewConnection(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/connection/config",
+		makeConfigRequest(t, "aws_tenant_1", "hub.steampipe.io/plugins/turbot/aws@latest", "aws",
+			`connection "aws_tenant_1" { regions = ["us-east-1"] }`, "aws"))
+	w := httptest.NewRecorder()
+
+	pm.handleSetConnectionConfig(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body SetConnectionConfigResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.True(t, body.Success)
+	assert.Empty(t, body.Error)
+
+	// Verify the connection was added to the config map
+	pm.mut.RLock()
+	cfg, ok := pm.connectionConfigMap["aws_tenant_1"]
+	pm.mut.RUnlock()
+
+	assert.True(t, ok, "connection should exist in connectionConfigMap")
+	assert.Equal(t, "aws_tenant_1", cfg.Connection)
+	assert.Equal(t, "aws", cfg.PluginShortName)
+	assert.Equal(t, "aws", cfg.PluginInstance)
+}
+
+// Test 2: Update an existing connection's config
+func TestConfigAPIServer_SetConnectionConfig_UpdateExisting(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	// Seed an existing connection
+	pm.connectionConfigMap["aws_tenant_1"] = &sdkproto.ConnectionConfig{
+		Connection:      "aws_tenant_1",
+		Plugin:          "hub.steampipe.io/plugins/turbot/aws@latest",
+		PluginShortName: "aws",
+		Config:          `connection "aws_tenant_1" { regions = ["us-east-1"] }`,
+		PluginInstance:  "aws",
+	}
+
+	// Update with new config
+	newConfig := `connection "aws_tenant_1" { regions = ["us-west-2", "eu-west-1"] }`
+	req := httptest.NewRequest(http.MethodPost, "/v1/connection/config",
+		makeConfigRequest(t, "aws_tenant_1", "hub.steampipe.io/plugins/turbot/aws@latest", "aws", newConfig, "aws"))
+	w := httptest.NewRecorder()
+
+	pm.handleSetConnectionConfig(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var body SetConnectionConfigResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.True(t, body.Success)
+
+	// Verify the config was updated
+	pm.mut.RLock()
+	cfg := pm.connectionConfigMap["aws_tenant_1"]
+	pm.mut.RUnlock()
+
+	assert.Equal(t, newConfig, cfg.Config)
+}
+
+// Test 3: Missing required fields return 400
+func TestConfigAPIServer_SetConnectionConfig_MissingFields(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	tests := []struct {
+		name       string
+		body       SetConnectionConfigRequest
+		errContain string
+	}{
+		{
+			name:       "missing connection",
+			body:       SetConnectionConfigRequest{PluginShortName: "aws", Config: "x", PluginInstance: "aws"},
+			errContain: "'connection' is required",
+		},
+		{
+			name:       "missing plugin_short_name",
+			body:       SetConnectionConfigRequest{Connection: "c1", Config: "x", PluginInstance: "aws"},
+			errContain: "'plugin_short_name' is required",
+		},
+		{
+			name:       "missing config",
+			body:       SetConnectionConfigRequest{Connection: "c1", PluginShortName: "aws", PluginInstance: "aws"},
+			errContain: "'config' is required",
+		},
+		{
+			name:       "missing plugin_instance",
+			body:       SetConnectionConfigRequest{Connection: "c1", PluginShortName: "aws", Config: "x"},
+			errContain: "'plugin_instance' is required",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, _ := json.Marshal(tt.body)
+			req := httptest.NewRequest(http.MethodPost, "/v1/connection/config", bytes.NewBuffer(b))
+			w := httptest.NewRecorder()
+
+			pm.handleSetConnectionConfig(w, req)
+
+			resp := w.Result()
+			assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+			var body SetConnectionConfigResponse
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			assert.False(t, body.Success)
+			assert.Contains(t, body.Error, tt.errContain)
+		})
+	}
+}
+
+// Test 4: Invalid JSON returns 400
+func TestConfigAPIServer_SetConnectionConfig_InvalidJSON(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	req := httptest.NewRequest(http.MethodPost, "/v1/connection/config",
+		bytes.NewBufferString(`{invalid json`))
+	w := httptest.NewRecorder()
+
+	pm.handleSetConnectionConfig(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+
+	var body SetConnectionConfigResponse
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.False(t, body.Success)
+	assert.Contains(t, body.Error, "invalid JSON")
+}
+
+// Test 5: GET request returns 405
+func TestConfigAPIServer_SetConnectionConfig_MethodNotAllowed(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/connection/config", nil)
+	w := httptest.NewRecorder()
+
+	pm.handleSetConnectionConfig(w, req)
+
+	assert.Equal(t, http.StatusMethodNotAllowed, w.Result().StatusCode)
+}
+
+// Test 6: Concurrent updates don't race
+func TestConfigAPIServer_SetConnectionConfig_Concurrent(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	var wg sync.WaitGroup
+	numGoroutines := 20
+	errors := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			connName := fmt.Sprintf("conn_%d", idx)
+			body := makeConfigRequest(t, connName, "hub.steampipe.io/plugins/turbot/aws@latest", "aws",
+				fmt.Sprintf(`connection "%s" { regions = ["us-east-1"] }`, connName), "aws")
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/connection/config", body)
+			w := httptest.NewRecorder()
+
+			pm.handleSetConnectionConfig(w, req)
+
+			if w.Result().StatusCode != http.StatusOK {
+				errors <- fmt.Errorf("connection %s: expected 200, got %d", connName, w.Result().StatusCode)
+			}
+		}(i)
+	}
+
+	wg.Wait()
+	close(errors)
+
+	for err := range errors {
+		t.Error(err)
+	}
+
+	// All connections should be in the map
+	pm.mut.RLock()
+	defer pm.mut.RUnlock()
+	assert.Equal(t, numGoroutines, len(pm.connectionConfigMap))
+}
+
+// Test 7: Updating one connection preserves existing connections
+func TestConfigAPIServer_SetConnectionConfig_PreservesExisting(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	// Seed two existing connections
+	pm.connectionConfigMap = connection.ConnectionConfigMap{
+		"conn_a": &sdkproto.ConnectionConfig{
+			Connection:      "conn_a",
+			Plugin:          "hub.steampipe.io/plugins/turbot/aws@latest",
+			PluginShortName: "aws",
+			Config:          `connection "conn_a" { regions = ["us-east-1"] }`,
+			PluginInstance:  "aws",
+		},
+		"conn_b": &sdkproto.ConnectionConfig{
+			Connection:      "conn_b",
+			Plugin:          "hub.steampipe.io/plugins/turbot/k8s@latest",
+			PluginShortName: "kubernetes",
+			Config:          `connection "conn_b" { context = "minikube" }`,
+			PluginInstance:  "kubernetes",
+		},
+	}
+
+	// Update only conn_a
+	req := httptest.NewRequest(http.MethodPost, "/v1/connection/config",
+		makeConfigRequest(t, "conn_a", "hub.steampipe.io/plugins/turbot/aws@latest", "aws",
+			`connection "conn_a" { regions = ["eu-west-1"] }`, "aws"))
+	w := httptest.NewRecorder()
+
+	pm.handleSetConnectionConfig(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+
+	// Verify conn_a was updated
+	pm.mut.RLock()
+	defer pm.mut.RUnlock()
+
+	assert.Equal(t, `connection "conn_a" { regions = ["eu-west-1"] }`, pm.connectionConfigMap["conn_a"].Config)
+
+	// Verify conn_b is untouched
+	assert.Equal(t, `connection "conn_b" { context = "minikube" }`, pm.connectionConfigMap["conn_b"].Config)
+	assert.Equal(t, "kubernetes", pm.connectionConfigMap["conn_b"].PluginShortName)
+}
+
+// Test 8: buildMergedConfigMap creates a correct merged copy
+func TestBuildMergedConfigMap_NewEntry(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	pm.connectionConfigMap = connection.ConnectionConfigMap{
+		"existing": &sdkproto.ConnectionConfig{
+			Connection:     "existing",
+			PluginInstance: "aws",
+		},
+	}
+
+	newCfg := &sdkproto.ConnectionConfig{
+		Connection:     "new_conn",
+		PluginInstance: "gcp",
+	}
+
+	merged := pm.buildMergedConfigMap(newCfg)
+
+	assert.Len(t, merged, 2)
+	assert.Equal(t, "existing", merged["existing"].Connection)
+	assert.Equal(t, "new_conn", merged["new_conn"].Connection)
+
+	// Original map should be unmodified
+	assert.Len(t, pm.connectionConfigMap, 1)
+}
+
+func TestBuildMergedConfigMap_OverwriteExisting(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	pm.connectionConfigMap = connection.ConnectionConfigMap{
+		"conn1": &sdkproto.ConnectionConfig{
+			Connection: "conn1",
+			Config:     "old",
+		},
+	}
+
+	newCfg := &sdkproto.ConnectionConfig{
+		Connection: "conn1",
+		Config:     "new",
+	}
+
+	merged := pm.buildMergedConfigMap(newCfg)
+
+	assert.Len(t, merged, 1)
+	assert.Equal(t, "new", merged["conn1"].Config)
+
+	// Original map should still have old value
+	assert.Equal(t, "old", pm.connectionConfigMap["conn1"].Config)
+}
+
+// Test 9: Validate function edge cases
+func TestValidateSetConnectionConfigRequest(t *testing.T) {
+	// All fields present — should pass
+	err := validateSetConnectionConfigRequest(&SetConnectionConfigRequest{
+		Connection:      "c",
+		PluginShortName: "aws",
+		Config:          "x",
+		PluginInstance:  "aws",
+	})
+	assert.NoError(t, err)
+}
+
+// Test 10: startConfigAPIServer does nothing when env var is not set
+func TestConfigAPIServer_StartDisabledByDefault(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	// Ensure the env var is not set
+	t.Setenv("STEAMPIPE_CONFIG_API_PORT", "")
+
+	// Should not panic or start any server
+	pm.startConfigAPIServer()
+}
+
+func TestConfigAPIServer_StartDisabledWithZero(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	t.Setenv("STEAMPIPE_CONFIG_API_PORT", "0")
+
+	// Should not panic or start any server
+	pm.startConfigAPIServer()
+}
+
+// Test 13: Concurrent requests for the SAME connection serialize correctly.
+// This is the thundering-herd scenario: 20 goroutines all request the same
+// connection simultaneously. The per-connection lock ensures they see a
+// consistent isNewConnection value (only the first sees true).
+func TestConfigAPIServer_SetConnectionConfig_ConcurrentSameConnection(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	var wg sync.WaitGroup
+	numGoroutines := 20
+	results := make([]int, numGoroutines) // status codes
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func(idx int) {
+			defer wg.Done()
+			body := makeConfigRequest(t, "same_conn", "hub.steampipe.io/plugins/turbot/aws@latest", "aws",
+				`connection "same_conn" { regions = ["us-east-1"] }`, "aws")
+
+			req := httptest.NewRequest(http.MethodPost, "/v1/connection/config", body)
+			w := httptest.NewRecorder()
+
+			pm.handleSetConnectionConfig(w, req)
+			results[idx] = w.Result().StatusCode
+		}(i)
+	}
+
+	wg.Wait()
+
+	// All requests should succeed
+	for i, code := range results {
+		assert.Equal(t, http.StatusOK, code, "goroutine %d failed", i)
+	}
+
+	// Only one connection should exist in the map
+	pm.mut.RLock()
+	defer pm.mut.RUnlock()
+	assert.Equal(t, 1, len(pm.connectionConfigMap))
+	assert.NotNil(t, pm.connectionConfigMap["same_conn"])
+}
+
+// Test 14: getConnLock returns the same mutex for the same connection name
+func TestConfigAPIServer_GetConnLock_SameConnection(t *testing.T) {
+	pm := newTestPluginManager(t)
+
+	lock1 := pm.getConnLock("conn_a")
+	lock2 := pm.getConnLock("conn_a")
+	lock3 := pm.getConnLock("conn_b")
+
+	assert.Same(t, lock1, lock2, "same connection should return same mutex")
+	assert.NotSame(t, lock1, lock3, "different connections should return different mutexes")
+}

--- a/pkg/pluginmanager_service/plugin_manager.go
+++ b/pkg/pluginmanager_service/plugin_manager.go
@@ -98,6 +98,13 @@ type PluginManager struct {
 	plugins connection.PluginMap
 
 	pool *pgxpool.Pool
+
+	// Per-connection mutexes for the Config API.
+	// Serializes handleSetConnectionConfig for the same connection name so that
+	// ensureConnectionSchema completes before a concurrent request for the same
+	// connection can return success.
+	connLocks   map[string]*sync.Mutex
+	connLocksMu sync.Mutex
 }
 
 func NewPluginManager(ctx context.Context, connectionConfig map[string]*sdkproto.ConnectionConfig, pluginConfigs connection.PluginMap, logger hclog.Logger) (*PluginManager, error) {
@@ -108,6 +115,7 @@ func NewPluginManager(ctx context.Context, connectionConfig map[string]*sdkproto
 		connectionConfigMap: connectionConfig,
 		userLimiters:        pluginConfigs.ToPluginLimiterMap(),
 		plugins:             pluginConfigs,
+		connLocks:           make(map[string]*sync.Mutex),
 	}
 
 	pluginManager.messageServer = &PluginMessageServer{pluginManager: pluginManager}
@@ -139,6 +147,9 @@ func NewPluginManager(ctx context.Context, connectionConfig map[string]*sdkproto
 // plugin interface functions
 
 func (m *PluginManager) Serve() {
+	// Start HTTP config API server (if enabled via env var)
+	m.startConfigAPIServer()
+
 	// create a plugin map, using ourselves as the implementation
 	pluginMap := map[string]goplugin.Plugin{
 		pluginshared.PluginName: &pluginshared.PluginManagerPlugin{Impl: m},

--- a/pkg/pluginmanager_service/plugin_manager_test.go
+++ b/pkg/pluginmanager_service/plugin_manager_test.go
@@ -33,6 +33,7 @@ func newTestPluginManager(t *testing.T) *PluginManager {
 		plugins:                   make(connection.PluginMap),
 		userLimiters:              make(connection.PluginLimiterMap),
 		pluginLimiters:            make(connection.PluginLimiterMap),
+		connLocks:                 make(map[string]*sync.Mutex),
 	}
 
 	pm.messageServer = &PluginMessageServer{pluginManager: pm}


### PR DESCRIPTION
### API reference

`POST /v1/connection/config`

Request body:

```json
{
  "connection": "aws_tenant_123",
  "plugin": "hub.steampipe.io/plugins/turbot/aws@latest",
  "plugin_short_name": "aws",
  "config": "regions = [\"us-east-1\"]\naccess_key = \"...\"\nsecret_key = \"...\"\nsession_token = \"...\"",
  "plugin_instance": "aws"
}
```

Notes:

- `config` is plugin attributes only (no outer `connection {}` block).
- handler resolves/normalizes plugin fields against existing connection metadata where available.

Success response:

```json
{"success": true}
```

Error response:

```json
{"success": false, "error": "..."}
```

Status codes:

- `200`: config updated (and schema created for new connection)
- `400`: invalid JSON / missing required field
- `405`: non-POST method
- `500`: update or schema-creation failure
