### PR TITLE
Bump FDW version to v2.2.2

### DIFF
--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -28,7 +28,7 @@ const (
 // constants for installing db and fdw images
 const (
 	DatabaseVersion = "14.19.0"
-	FdwVersion      = "2.2.0"
+	FdwVersion      = "2.2.2"
 
 	// PostgresImageRef is the OCI Image ref for the database binaries
 	PostgresImageRef    = "ghcr.io/turbot/steampipe/db:14.19.0"


### PR DESCRIPTION
## Summary

- Bump FDW version `2.2.0` → `2.2.2` in `pkg/constants/db.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)