### PR TITLE
Cherry-pick #4965: workflow permissions for v2.4.1 release

### DIFF
--- a/.github/workflows/01-steampipe-release.yaml
+++ b/.github/workflows/01-steampipe-release.yaml
@@ -21,6 +21,9 @@ on:
         required: true
         type: boolean
 
+permissions:
+  contents: write
+
 env:
   # Version number from user input, used throughout the workflow for tagging, branching, and release operations
   VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/02-steampipe-db-image-build.yaml
+++ b/.github/workflows/02-steampipe-db-image-build.yaml
@@ -16,6 +16,10 @@ on:
         required: true
         default: 14.19.0
 
+permissions:
+  contents: read
+  packages: write
+
 env:
   PROJECT_ID: steampipe
   IMAGE_NAME: db

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -9,6 +9,9 @@ on:
   workflow_dispatch:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: Test Linting

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -2,6 +2,9 @@ name: "11 - Test: Acceptance"
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   STEAMPIPE_UPDATE_CHECK: false
   SPIPETOOLS_PG_CONN_STRING: ${{ secrets.SPIPETOOLS_PG_CONN_STRING }}

--- a/.github/workflows/12-test-post-release-linux-distros.yaml
+++ b/.github/workflows/12-test-post-release-linux-distros.yaml
@@ -8,6 +8,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   # Version from input, used to download the correct release artifacts
   VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/30-stale.yaml
+++ b/.github/workflows/30-stale.yaml
@@ -10,6 +10,11 @@ on:
         default: "false"
         type: string
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/31-add-issues-to-pipeling-issue-tracker.yaml
+++ b/.github/workflows/31-add-issues-to-pipeling-issue-tracker.yaml
@@ -4,6 +4,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   add-to-project:
     uses: turbot/steampipe-workflows/.github/workflows/assign-issue-to-pipeling-issue-tracker.yml@main


### PR DESCRIPTION
Cherry-picks the workflow hardening from develop onto v2.4.x so the release workflow can push the v2.4.1 tag. Org-wide default GITHUB_TOKEN was changed to read; this adds explicit permissions: contents: write to the workflows. Required for today's CVE remediation release.