### PR TITLE
Fix release workflow homebrew PR title check

### DIFF
--- a/.github/workflows/01-steampipe-release.yaml
+++ b/.github/workflows/01-steampipe-release.yaml
@@ -253,7 +253,7 @@ jobs:
       - name: Fail if PR title does not match with version
         if: steps.semver_parser.outputs.prerelease == ''
         run: |
-          if [[ "${{ steps.pr_title.outputs.PR_TITLE }}" == "Steampipe ${{ env.VERSION }}" ]]; then
+          if [[ "${{ steps.pr_title.outputs.PR_TITLE }}" == "Steampipe ${{ github.event.inputs.version }}" ]]; then
             echo "Correct version"
           else
             echo "Incorrect version"


### PR DESCRIPTION
## Summary

Fix a bug in `01 - Steampipe: Release` that causes `update_homebrew_tap` to always fail (and `trigger_smoke_tests` to be skipped) on final releases.

## Root cause

The homebrew PR is created in `create_pr_in_homebrew` with title:
```
Steampipe <version>
```
using `env.Version` (raw input, e.g. `2.4.1`, no `v` prefix).

The later check in `update_homebrew_tap` compared the PR title against:
```
Steampipe <VERSION>
```
using `env.VERSION` (calculated as `v<input>`, with `v` prefix, e.g. `v2.4.1`).

These never match. Result: the auto-merge of the brew formula PR always fails, and the post-release smoke tests are skipped.

## Evidence

- Historical homebrew-tap PRs from this workflow use the no-`v` convention: #219 "Steampipe 2.3.5", #221 "Steampipe 2.3.6", #223 "Steampipe 2.4.0", #225 "Steampipe 2.4.1", #228 "Steampipe 2.4.2".
- Each corresponding release workflow run failed `update_homebrew_tap` at this check, exactly at `Incorrect version` → `exit 1`.
- Someone has been manually merging the homebrew PRs after each release to compensate.

## Fix

Change the comparison RHS from `${{ env.VERSION }}` (with `v`) to `${{ github.event.inputs.version }}` (without `v`) to match the PR title convention the workflow itself produces.

## Backport

Should cherry-pick to `v2.4.x` (and other live release branches) so future patch releases don't hit the same bug.

## Test plan

- [x] Diff inspected — single-line change
- [ ] Will validate on the next real release (can't easily unit-test a workflow change)

## Related

- Previous release run that hit this: https://github.com/turbot/steampipe/actions/runs/24097092738 (v2.4.1)
