### PR TITLE
Add CHANGELOG.md entry for v2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v2.4.2 [2026-04-22]
+_Bug fixes_
+- Fix `steampipe plugin install` failing with an opaque `403 Forbidden` when stale GHCR credentials are present in `~/.docker/config.json` (e.g. from a prior `docker login`). Now retries the OCI pull anonymously when stored credentials are rejected. ([pipe-fittings#792](https://github.com/turbot/pipe-fittings/pull/792))
+
+_Dependencies_
+- Bump `pipe-fittings/v2` from v2.9.0 to v2.9.1.
+
 ## v2.4.0 [2026-02-27]
 _Whats new_
 - Compiled with Go 1.26.


### PR DESCRIPTION
## Summary

Adds the missing `v2.4.2` entry to `CHANGELOG.md`.

Entry content matches the v2.4.2 release notes on GitHub and the upcoming steampipe.io changelog PR.
