### PR TITLE
Bump github.com/jackc/pgx/v5 to v5.9.2 (CVE-2026-41889)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/hashicorp/go-plugin v1.7.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
-	github.com/jackc/pgx/v5 v5.7.6
+	github.com/jackc/pgx/v5 v5.9.2
 	github.com/jedib0t/go-pretty/v6 v6.6.9
 	github.com/karrick/gows v0.3.0
 	github.com/mattn/go-isatty v0.0.20

--- a/go.sum
+++ b/go.sum
@@ -1036,8 +1036,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.7.6 h1:rWQc5FwZSPX58r1OQmkuaNicxdmExaEz5A2DO2hUuTk=
-github.com/jackc/pgx/v5 v5.7.6/go.mod h1:aruU7o91Tc2q2cFp5h4uP3f6ztExVpyVv88Xl/8Vl8M=
+github.com/jackc/pgx/v5 v5.9.2 h1:3ZhOzMWnR4yJ+RW1XImIPsD1aNSz4T4fyP7zlQb56hw=
+github.com/jackc/pgx/v5 v5.9.2/go.mod h1:mal1tBGAFfLHvZzaYh77YS/eC6IX9OWbRV1QIIM0Jn4=
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=


### PR DESCRIPTION
## Summary

Raise the direct dependency `github.com/jackc/pgx/v5` from **v5.7.6** to **v5.9.2** to remediate **CVE-2026-41889**, plus `go mod tidy`.

This is a **dependency-only** change:
- No Go toolchain bump — `go.mod` already declares `go 1.26.1` and all CI Go pins are already 1.26.x.
- No behavioral code changes — the v5.7.6 → v5.9.2 pgx behavioral-change analysis found **0 affected sites** in steampipe (no custom `sql.Scanner`, the single `errors.Is(err, pgx.ErrNoRows)` site is additive-safe, all conn-string builders supply an explicit non-empty user, and `golang.org/x/crypto` is `// indirect` only).

## Verification

- `go build ./...` — clean
- `go test ./...` — pass (21 packages with tests pass, 0 fail, 21 with no test files)
- Lint (`golangci-lint run --timeout=10m`) is `continue-on-error: true` / advisory in the workflow; not run locally because the locally-installed golangci-lint (built with go1.24) cannot load a go1.26.1 module. The change adds no new code, so lint risk is nil.

Refs #4989