### PR TITLE
Add version-parameterised embedded-PG from-source build wrapper + ICU bundling

### DIFF
--- a/design/embedded_postgres_build_instructions.md
+++ b/design/embedded_postgres_build_instructions.md
@@ -17,6 +17,16 @@ This document provides step-by-step instructions for building the embedded Postg
 #### 3.1. Pre-requisites
 
 * `openssl`
+* `pkg-config`
+* **`icu4c` — required for PostgreSQL 16+ (mandatory for PG18).** `configure`
+  hard-fails on PG18 with `Package requirements (icu-uc icu-i18n) were not
+  met` unless ICU is present and on `PKG_CONFIG_PATH` and `--with-icu` is
+  passed (PG14/15 build without it). **Relocatability caveat:** a
+  `--with-icu` build links `libicuuc`/`libicui18n` at the build machine's
+  absolute path; for a shippable artifact the ICU dylibs/so's must be
+  bundled into `lib/postgresql` and rpath-patched (as is done for `libpq`),
+  or ICU static-linked. The current shipped PG14 artifact has no ICU
+  dependency; PG18 introduces this and it must be handled before shipping.
 
 ---
 

--- a/design/embedded_postgres_build_instructions.md
+++ b/design/embedded_postgres_build_instructions.md
@@ -133,6 +133,22 @@ Run the `fix_rpath.sh` script to fix the rpaths of the binaries (`initdb`, `pg_r
 > `install_name_tool` operations. `scripts/build-embedded-pg.sh` now
 > does this automatically.
 
+> **Loadable-module suffix on macOS PG18 (verified 2026-05-19):**
+> PostgreSQL's `DLSUFFIX` is `.so` on Linux and on macOS PG ≤ 17, but
+> **`.dylib` on macOS PG18** (`src/Makefile.global`). So a from-source
+> PG18 macOS build emits `ltree.dylib` / `tablefunc.dylib` (and the FDW
+> `.dylib` — same family as the FDW `inst` `.so`/`.dylib` quirk),
+> whereas the current shipped artifact and Steampipe's hard-coded
+> `FdwBinaryFileName` use `.so`. For the PG18 server itself `.dylib` is
+> internally consistent (it resolves modules via its own `DLSUFFIX`), so
+> do NOT blindly rename `.dylib`→`.so` (that would break module
+> resolution on the macOS PG18 server). Reconciling the macOS
+> `.so`-vs-`.dylib` convention with Steampipe's `.so` expectation is a
+> packaging decision for the release step. **The shipped builds are
+> Linux, where `DLSUFFIX` is `.so` and this does not arise** — so it is
+> not a blocker, but it must be settled before a macOS-from-source PG18
+> artifact is shipped.
+
 ```bash
 #!/bin/bash
 set -euo pipefail

--- a/design/embedded_postgres_build_instructions.md
+++ b/design/embedded_postgres_build_instructions.md
@@ -89,15 +89,27 @@ This document provides step-by-step instructions for building the embedded Postg
 
 11. Remove the `include` directory.
 
-12. Remove unneeded binaries from `bin`.
+12. Remove unneeded binaries from `bin`. Steampipe ships and uses only
+    **five**: keep exactly `initdb`, `pg_ctl`, `pg_dump`, `pg_restore`,
+    `postgres` and delete everything else in `bin/`. (Verified against the
+    current shipped `darwin-arm_64` artifact, which contains exactly these
+    five.)
 
-13. Check that all extensions exist.
+13. Check that all extensions exist (`ltree`, `tablefunc` in
+    `lib/postgresql` and `share/postgresql/extension`).
 
 ---
 
 #### 3.3. Fix RPATHs
 
-Run the `fix_rpath.sh` script to fix the rpaths of the binaries (`initdb`, `pg_restore`, `pg_dump`):
+Run the `fix_rpath.sh` script to fix the rpaths of the binaries (`initdb`, `pg_restore`, `pg_dump`).
+
+> **Note (verified against the shipped artifact):** the current shipped
+> `darwin-arm_64` binaries carry **two** `LC_RPATH` entries —
+> `@loader_path/../lib` *and* `@loader_path/../lib/postgresql`. The script
+> below adds only the latter; add the former as well for faithful parity
+> (a single `@loader_path/../lib/postgresql` rpath is sufficient for
+> `libpq` resolution, but the shipped artifact has both).
 
 ```bash
 #!/bin/bash

--- a/design/embedded_postgres_build_instructions.md
+++ b/design/embedded_postgres_build_instructions.md
@@ -120,6 +120,18 @@ Run the `fix_rpath.sh` script to fix the rpaths of the binaries (`initdb`, `pg_r
 > below adds only the latter; add the former as well for faithful parity
 > (a single `@loader_path/../lib/postgresql` rpath is sufficient for
 > `libpq` resolution, but the shipped artifact has both).
+>
+> **MANDATORY on Apple Silicon (verified 2026-05-19):** every
+> `install_name_tool` edit **invalidates the Mach-O code signature**.
+> arm64 macOS then **SIGKILLs** the binary/dylib on load — it dies with
+> "Killed: 9" and *no output* (this is NOT a `dyld: Library not loaded`
+> error, so it is easily misdiagnosed). After all `install_name_tool`
+> edits, ad-hoc re-sign every modified Mach-O:
+> `codesign --force --sign - <file>` (all of `bin/*` and the relocated
+> `lib/postgresql/*.dylib`). This step is absent from the historical
+> `fix_rpath.sh`; it became fatal once ICU bundling added many more
+> `install_name_tool` operations. `scripts/build-embedded-pg.sh` now
+> does this automatically.
 
 ```bash
 #!/bin/bash

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -63,6 +63,13 @@ rm -rf "$SRC_DIR"
 tar -xf "$SRC_TARBALL"
 cd "$SRC_DIR"
 
+# Clean the install prefix between runs. Without this, stale files from
+# a prior build (e.g. an ICU bundle from a different ICU major) survive
+# into the new artifact because `make install` and the wrapper's
+# bundling step only write, never delete. Mirrors how SRC_DIR is
+# cleaned above. Idempotent for first runs (rm -rf on a missing dir is
+# a no-op).
+rm -rf "$PREFIX"
 mkdir -p "$PREFIX"
 
 if [[ "$OS" == "Darwin" ]]; then

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -315,6 +315,26 @@ else
     echo "✅ ICU bundled (linux): $(ls "$PREFIX"/lib/postgresql/libicu*.so.* | xargs -n1 basename | tr '\n' ' ')"
   fi
 
+  # Fix RUNPATH on contrib `.so` files (ltree, tablefunc, hstore, etc.).
+  # PG's make eats `$O` from `$ORIGIN` in our LDFLAGS, so the linker writes
+  # a broken `RIGIN/../lib/postgresql:<build-host-libdir>` RUNPATH that
+  # resolves nowhere on a user's machine (verified via readelf on
+  # `lib/postgresql/ltree.so` of an existing artifact). bin/* already gets
+  # patchelf'd above; ICU libs were patchelf'd in the bundling block. This
+  # block covers the contrib `.so` files in between. The glob `*.so` matches
+  # contribs but NOT bundled ICU (`libicu*.so.78`), so it's safe to run
+  # unconditionally and idempotent vs the ICU block.
+  # No user-visible breakage today (shipped contribs only NEED libc/libm,
+  # which the system loader finds), but the build-host absolute path in the
+  # RUNPATH is wrong-on-its-face and any future contrib that links a
+  # bundled lib would fail.
+  ( cd "$PREFIX"
+    for f in lib/postgresql/*.so; do
+      [[ -f "$f" ]] || continue
+      patchelf --set-rpath '$ORIGIN' "$f"
+    done
+  )
+
   rm -rf "$PREFIX/include"
 
   # ---- verify contrib extensions exist (recipe §3.2 step 13) ----

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -235,13 +235,30 @@ if [[ "$OS" == "Darwin" ]]; then
 else
   # ---- Linux: design doc §3.6 ----
   export LDFLAGS='-Wl,-rpath,$ORIGIN/../lib/postgresql -Wl,--enable-new-dtags'
+
+  # PG16+ requires --with-icu at configure time (PG18 hard-fails
+  # without it). Mirror of the macOS ICU-detection block above; on
+  # Linux/Ubuntu libicu-dev provides icu-uc.pc / icu-i18n.pc, so detect
+  # via pkg-config (vs Homebrew prefix on macOS).
+  PG_MAJOR_LC="${PG_VERSION%%.*}"
+  ICU_CONFIGURE=()
+  if [[ "$PG_MAJOR_LC" -ge 16 ]]; then
+    if ! pkg-config --exists icu-uc icu-i18n 2>/dev/null; then
+      echo "ERROR: PostgreSQL $PG_VERSION needs ICU but icu-uc/icu-i18n pkg-config not found; install libicu-dev" >&2
+      exit 1
+    fi
+    echo "== PG$PG_MAJOR_LC: building --with-icu (linux) using $(pkg-config --variable=libdir icu-uc)"
+    ICU_CONFIGURE=(--with-icu)
+  fi
+
   ./configure \
     --prefix="$PREFIX" \
     --libdir="$PREFIX/lib/postgresql" \
     --datadir="$PREFIX/share/postgresql" \
     --with-openssl \
     --with-includes=/usr/include \
-    --with-libraries="/usr/lib/${ARCH}-linux-gnu"
+    --with-libraries="/usr/lib/${ARCH}-linux-gnu" \
+    "${ICU_CONFIGURE[@]}"
 
   make -j"$(nproc)"
   make install
@@ -288,7 +305,10 @@ else
       || { echo "ERROR: required extension '$ext' missing after contrib build (no lib/postgresql/${ext}.{so,dylib} or share/postgresql/extension/${ext}.control)" >&2; exit 1; }
   done
 
-  ( cd "$PREFIX" && tar -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
+  # --hard-dereference: follow symlinks at archive time so the .txz
+  # carries plain files (matches zonky's Linux pack pattern; avoids
+  # downstream surprises when an upstream lib is a symlink).
+  ( cd "$PREFIX" && tar --hard-dereference -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
 fi
 
 echo "== done: $OUTPUT_DIR/$TARFILE"

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+#
+# build-embedded-pg.sh - build the embedded PostgreSQL binaries from source,
+# exactly per design/embedded_postgres_build_instructions.md, producing the
+# relocatable .txz archive Steampipe expects.
+#
+# This is a thin, version-parameterised wrapper around the committed recipe.
+# It does NOT invent build steps - it drives the documented macOS (§3.2-3.4)
+# and Linux (§3.5-3.6) steps. To build for a different PostgreSQL major
+# (e.g. the PG18 upgrade) only PG_VERSION changes.
+#
+# Usage:
+#   scripts/build-embedded-pg.sh [PG_VERSION] [OUTPUT_DIR]
+#
+#   PG_VERSION   PostgreSQL source version, e.g. 14.19 (default) or 18.0
+#   OUTPUT_DIR   where to place the built tree + .txz (default: ./pg-build)
+#
+# Output: $OUTPUT_DIR/<prefix>/{bin,lib,share} and the packed archive named
+# per Steampipe's pkg/db/platform/paths_*.go TarFileName:
+#   darwin arm64  -> postgres-darwin-arm_64.txz
+#   darwin x86_64 -> postgres-darwin-x86_64.txz
+#   linux  arm64  -> postgres-linux-arm_64.txz
+#   linux  x86_64 -> postgres-linux-x86_64.txz
+#
+set -euo pipefail
+
+PG_VERSION="${1:-14.19}"
+OUTPUT_DIR="${2:-$(pwd)/pg-build}"
+
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+# Map to Steampipe's expected TarFileName (pkg/db/platform/paths_*.go).
+case "$OS/$ARCH" in
+  Darwin/arm64)  TARFILE="postgres-darwin-arm_64.txz" ;;
+  Darwin/x86_64) TARFILE="postgres-darwin-x86_64.txz" ;;
+  Linux/aarch64) TARFILE="postgres-linux-arm_64.txz" ;;
+  Linux/arm64)   TARFILE="postgres-linux-arm_64.txz" ;;
+  Linux/x86_64)  TARFILE="postgres-linux-x86_64.txz" ;;
+  *) echo "ERROR: unsupported platform $OS/$ARCH" >&2; exit 1 ;;
+esac
+
+PREFIX="$OUTPUT_DIR/postgres-${PG_VERSION}-$(echo "$OS" | tr '[:upper:]' '[:lower:]')-${ARCH}"
+SRC_TARBALL="postgresql-${PG_VERSION}.tar.bz2"
+SRC_URL="https://ftp.postgresql.org/pub/source/v${PG_VERSION}/${SRC_TARBALL}"
+SRC_DIR="$OUTPUT_DIR/postgresql-${PG_VERSION}"
+
+echo "== build-embedded-pg =="
+echo "  PG_VERSION : $PG_VERSION"
+echo "  platform   : $OS/$ARCH  -> $TARFILE"
+echo "  prefix     : $PREFIX"
+echo "  output dir : $OUTPUT_DIR"
+
+mkdir -p "$OUTPUT_DIR"
+cd "$OUTPUT_DIR"
+
+# --- fetch + extract source (postgresql.org/ftp/source) ---
+if [[ ! -f "$SRC_TARBALL" ]]; then
+  echo "== downloading $SRC_URL"
+  curl -fL --retry 3 -o "$SRC_TARBALL" "$SRC_URL"
+fi
+rm -rf "$SRC_DIR"
+tar -xf "$SRC_TARBALL"
+cd "$SRC_DIR"
+
+mkdir -p "$PREFIX"
+
+if [[ "$OS" == "Darwin" ]]; then
+  # ---- macOS: design doc §3.2 ----
+  export MACOSX_DEPLOYMENT_TARGET=11.0
+  export CFLAGS="-mmacosx-version-min=11.0"
+  export LDFLAGS="-mmacosx-version-min=11.0 -Wl,-rpath,@loader_path/../lib/postgresql"
+  OPENSSL_PREFIX="$(brew --prefix openssl)"
+
+  ./configure --prefix="$PREFIX" \
+    --libdir="$PREFIX/lib/postgresql" \
+    --datadir="$PREFIX/share/postgresql" \
+    --with-openssl \
+    --with-includes="$OPENSSL_PREFIX/include" \
+    --with-libraries="$OPENSSL_PREFIX/lib"
+
+  make -j"$(sysctl -n hw.ncpu)"
+  make install
+  make -C contrib
+  make -C contrib install
+
+  # §3.2 step 11: remove the include directory.
+  rm -rf "$PREFIX/include"
+  # §3.2 step 12: keep only the binaries the shipped artifact ships. The
+  # committed doc said "remove unneeded binaries" without enumerating them;
+  # the current shipped darwin-arm64 .txz was inspected and contains exactly
+  # these five (see output/exec3-oracle-parity-14x.md). Pruning to match
+  # keeps the from-source artifact structurally faithful to what Steampipe
+  # ships and uses (initdb / postgres / pg_ctl + pg_dump / pg_restore for the
+  # migration path).
+  ( cd "$PREFIX/bin"
+    for b in *; do
+      case "$b" in
+        initdb|pg_ctl|pg_dump|pg_restore|postgres) ;;
+        *) rm -f "$b" ;;
+      esac
+    done
+  )
+
+  # ---- macOS rpath fix: design doc §3.3 (fix_rpath.sh, inlined) ----
+  (
+    cd "$PREFIX"
+    LIB_SUBDIR="lib/postgresql"
+    BUNDLE_ROOT="$(pwd)"
+    LIBPQ_PATH="$BUNDLE_ROOT/$LIB_SUBDIR/libpq.5.dylib"
+    echo "🔧 Fixing libpq install name..."
+    install_name_tool -id "@rpath/libpq.5.dylib" "$LIBPQ_PATH"
+    echo "🔍 Processing binaries in bin/..."
+    for binfile in "$BUNDLE_ROOT"/bin/*; do
+      [[ -x "$binfile" && ! -d "$binfile" ]] || continue
+      # the shipped artifact carries BOTH rpaths (../lib and
+      # ../lib/postgresql) - match it for faithful relocatability parity.
+      install_name_tool -add_rpath "@loader_path/../lib" "$binfile" 2>/dev/null || true
+      install_name_tool -add_rpath "@loader_path/../$LIB_SUBDIR" "$binfile" 2>/dev/null || true
+      install_name_tool -change "$BUNDLE_ROOT/$LIB_SUBDIR/libpq.5.dylib" "@rpath/libpq.5.dylib" "$binfile" 2>/dev/null || true
+    done
+  )
+
+  # ---- macOS pack: design doc §3.4 ----
+  ( cd "$PREFIX" && tar --disable-copyfile --exclude='._*' -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
+
+else
+  # ---- Linux: design doc §3.6 ----
+  export LDFLAGS='-Wl,-rpath,$ORIGIN/../lib/postgresql -Wl,--enable-new-dtags'
+  ./configure \
+    --prefix="$PREFIX" \
+    --libdir="$PREFIX/lib/postgresql" \
+    --datadir="$PREFIX/share/postgresql" \
+    --with-openssl \
+    --with-includes=/usr/include \
+    --with-libraries="/usr/lib/${ARCH}-linux-gnu"
+
+  make -j"$(nproc)"
+  make install
+  make -C contrib -j"$(nproc)"
+  make -C contrib install
+
+  ( cd "$PREFIX"
+    for f in bin/*; do
+      if [[ -x "$f" ]] && file "$f" | grep -q ELF; then
+        patchelf --set-rpath '$ORIGIN/../lib/postgresql' "$f"
+      fi
+    done
+  )
+  rm -rf "$PREFIX/include"
+  ( cd "$PREFIX" && tar -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
+fi
+
+echo "== done: $OUTPUT_DIR/$TARFILE"
+ls -la "$OUTPUT_DIR/$TARFILE"

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -72,12 +72,37 @@ if [[ "$OS" == "Darwin" ]]; then
   export LDFLAGS="-mmacosx-version-min=11.0 -Wl,-rpath,@loader_path/../lib/postgresql"
   OPENSSL_PREFIX="$(brew --prefix openssl)"
 
+  # PostgreSQL 16+ builds with ICU by default and `configure` hard-fails
+  # without icu-uc/icu-i18n (PG18 in particular). PG14/15 build fine
+  # without it (and the proven PG14 path is left byte-identical). When
+  # building >=16, require icu4c (keg-only on Homebrew) and put its
+  # pkg-config on PKG_CONFIG_PATH, mirroring how Homebrew builds its own
+  # postgresql@18 (--with-icu + icu4c pkgconfig).
+  PG_MAJOR="${PG_VERSION%%.*}"
+  ICU_CONFIGURE=()
+  if [[ "$PG_MAJOR" -ge 16 ]]; then
+    ICU_PREFIX="$(brew --prefix icu4c 2>/dev/null || true)"
+    if [[ -z "$ICU_PREFIX" || ! -d "$ICU_PREFIX/lib/pkgconfig" ]]; then
+      # fall back to the highest installed versioned icu4c keg
+      ICU_PREFIX="$(ls -d /opt/homebrew/opt/icu4c@* 2>/dev/null | sort -V | tail -1 || true)"
+    fi
+    if [[ -z "$ICU_PREFIX" || ! -d "$ICU_PREFIX/lib/pkgconfig" ]]; then
+      echo "ERROR: PostgreSQL $PG_VERSION needs ICU but icu4c was not found; run 'brew install icu4c'" >&2
+      exit 1
+    fi
+    echo "== PG$PG_MAJOR: building --with-icu using $ICU_PREFIX"
+    export PKG_CONFIG_PATH="$ICU_PREFIX/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+    ICU_CONFIGURE=(--with-icu)
+  fi
+  # PG<16: no ICU flag at all - identical to the validated PG14 recipe.
+
   ./configure --prefix="$PREFIX" \
     --libdir="$PREFIX/lib/postgresql" \
     --datadir="$PREFIX/share/postgresql" \
     --with-openssl \
     --with-includes="$OPENSSL_PREFIX/include" \
-    --with-libraries="$OPENSSL_PREFIX/lib"
+    --with-libraries="$OPENSSL_PREFIX/lib" \
+    "${ICU_CONFIGURE[@]}"
 
   make -j"$(sysctl -n hw.ncpu)"
   make install

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -265,6 +265,20 @@ else
   make -C contrib -j"$(nproc)"
   make -C contrib install
 
+  # Keep only the 5 binaries Steampipe ships — mirror of the macOS
+  # prune (this file, "step 12: keep only the binaries the shipped
+  # artifact ships" block). The Linux branch previously skipped this,
+  # so the .txz carried ~30 unused binaries (clusterdb, pgbench,
+  # pg_upgrade, psql, ...).
+  ( cd "$PREFIX/bin"
+    for b in *; do
+      case "$b" in
+        initdb|pg_ctl|pg_dump|pg_restore|postgres) ;;
+        *) rm -f "$b" ;;
+      esac
+    done
+  )
+
   ( cd "$PREFIX"
     for f in bin/*; do
       if [[ -x "$f" ]] && file "$f" | grep -q ELF; then

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -146,6 +146,69 @@ if [[ "$OS" == "Darwin" ]]; then
     done
   )
 
+  # ---- macOS ICU bundling (PG16+; Option A: full unfiltered ICU) ----
+  # PG18 is built --with-icu, so postgres links libicui18n/libicuuc/
+  # libicudata at the build machine's absolute icu4c path - not
+  # relocatable. Bundle the three ICU dylibs into lib/postgresql and
+  # rewrite references (same pattern as libpq, extended to the 3-lib
+  # chain): binary->icu = @rpath (bins already have the ../lib/postgresql
+  # rpath); icu->icu = @loader_path (co-located in the same dir); each
+  # bundled lib id = @rpath. The pinned ICU major is whatever
+  # $ICU_PREFIX provides at build time (record it as a stability
+  # contract - see exec-4 B2.1a).
+  if [[ "$PG_MAJOR" -ge 16 ]]; then
+    (
+      cd "$PREFIX"
+      LIB_SUBDIR="lib/postgresql"
+      BUNDLE_ROOT="$(pwd)"
+      echo "📦 Bundling ICU from $ICU_PREFIX"
+      for stem in libicudata libicuuc libicui18n; do
+        src="$(ls "$ICU_PREFIX"/lib/${stem}.*.dylib 2>/dev/null | grep -E "/${stem}\.[0-9]+\.dylib$" | head -1)"
+        [[ -z "$src" ]] && src="$(ls "$ICU_PREFIX"/lib/${stem}.*.dylib 2>/dev/null | head -1)"
+        [[ -z "$src" ]] && { echo "ERROR: ICU lib $stem not found in $ICU_PREFIX/lib" >&2; exit 1; }
+        cp -L "$src" "$BUNDLE_ROOT/$LIB_SUBDIR/$(basename "$src")"
+        install_name_tool -id "@rpath/$(basename "$src")" "$BUNDLE_ROOT/$LIB_SUBDIR/$(basename "$src")"
+      done
+      # rewrite every reference into the build-machine ICU prefix:
+      # within a bundled ICU lib -> @loader_path (siblings); elsewhere
+      # (the bin/* binaries) -> @rpath.
+      relocate_icu() {
+        local f="$1" anchor="$2"
+        otool -L "$f" | awk 'NR>1{print $1}' | while read -r dep; do
+          case "$dep" in
+            "$ICU_PREFIX"/*|*/icu4c*/lib/libicu*)
+              install_name_tool -change "$dep" "$anchor/$(basename "$dep")" "$f" 2>/dev/null || true ;;
+          esac
+        done
+      }
+      for stem in libicudata libicuuc libicui18n; do
+        for l in "$BUNDLE_ROOT/$LIB_SUBDIR/${stem}".*.dylib; do
+          [[ -f "$l" ]] && relocate_icu "$l" "@loader_path"
+        done
+      done
+      for binfile in "$BUNDLE_ROOT"/bin/*; do
+        [[ -x "$binfile" && ! -d "$binfile" ]] || continue
+        relocate_icu "$binfile" "@rpath"
+      done
+      echo "✅ ICU bundled: $(ls "$BUNDLE_ROOT/$LIB_SUBDIR"/libicu*.dylib | xargs -n1 basename | tr '\n' ' ')"
+    )
+  fi
+
+  # ---- macOS re-sign (MANDATORY on Apple Silicon) ----
+  # install_name_tool invalidates the Mach-O code signature; arm64 macOS
+  # then SIGKILLs the binary/dylib on load ("Killed: 9", no output - NOT
+  # a dyld 'library not loaded' error). Ad-hoc re-sign every Mach-O the
+  # rpath/ICU fixups touched. The committed recipe's fix_rpath.sh omits
+  # this; ICU bundling (many more install_name_tool ops) makes it fatal.
+  (
+    cd "$PREFIX"
+    for f in bin/* lib/postgresql/*.dylib; do
+      [[ -f "$f" ]] || continue
+      file "$f" | grep -q 'Mach-O' || continue
+      codesign --force --sign - "$f" 2>/dev/null || true
+    done
+  )
+
   # ---- macOS pack: design doc §3.4 ----
   ( cd "$PREFIX" && tar --disable-copyfile --exclude='._*' -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
 
@@ -172,6 +235,26 @@ else
       fi
     done
   )
+  # ---- Linux ICU bundling (PG16+; Option A) ----
+  # ELF resolves by soname via rpath, so bundling = drop the 3 ICU
+  # .so.<major> into lib/postgresql (bins already have
+  # $ORIGIN/../lib/postgresql rpath) and give the ICU libs an $ORIGIN
+  # rpath so icu->icu resolves within the bundle. NOTE: implemented but
+  # NOT locally proven (no Linux build host here; verify in the Linux
+  # CI runner per exec-4 B2).
+  PG_MAJOR_L="${PG_VERSION%%.*}"
+  if [[ "$PG_MAJOR_L" -ge 16 ]]; then
+    ICU_LIBDIR="$(pkg-config --variable=libdir icu-uc 2>/dev/null || echo /usr/lib/${ARCH}-linux-gnu)"
+    for stem in libicudata libicuuc libicui18n; do
+      src="$(ls "$ICU_LIBDIR"/${stem}.so.* 2>/dev/null | grep -E "/${stem}\.so\.[0-9]+$" | head -1)"
+      [[ -z "$src" ]] && src="$(ls "$ICU_LIBDIR"/${stem}.so.* 2>/dev/null | head -1)"
+      [[ -z "$src" ]] && { echo "ERROR: ICU lib $stem not found in $ICU_LIBDIR" >&2; exit 1; }
+      cp -L "$src" "$PREFIX/lib/postgresql/$(basename "$src")"
+      patchelf --set-rpath '$ORIGIN' "$PREFIX/lib/postgresql/$(basename "$src")" 2>/dev/null || true
+    done
+    echo "✅ ICU bundled (linux): $(ls "$PREFIX"/lib/postgresql/libicu*.so.* | xargs -n1 basename | tr '\n' ' ')"
+  fi
+
   rm -rf "$PREFIX/include"
   ( cd "$PREFIX" && tar -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
 fi

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -214,10 +214,19 @@ if [[ "$OS" == "Darwin" ]]; then
 
   # ---- verify contrib extensions exist (recipe §3.2 step 13) ----
   # a broken `make -C contrib install` would otherwise ship an artifact
-  # silently missing ltree/tablefunc, which Steampipe loads.
+  # silently missing ltree/tablefunc, which Steampipe loads. The loadable
+  # module suffix follows PostgreSQL's DLSUFFIX: .so on Linux and PG<=17
+  # macOS, but .dylib on macOS PG18 (src/Makefile.global). Accept either -
+  # this check is for a *missing* module, not the suffix.
+  # NOTE: the macOS shipped-convention mismatch (Steampipe and the current
+  # artifact use .so; from-source PG18-macOS emits .dylib - the same
+  # family as the FDW `inst` .so/.dylib quirk) is a packaging decision
+  # for the release step, deliberately NOT forced here. The shipped
+  # builds are Linux, where DLSUFFIX is .so and this is moot.
   for ext in ltree tablefunc; do
-    [[ -f "$PREFIX/lib/postgresql/${ext}.so" && -f "$PREFIX/share/postgresql/extension/${ext}.control" ]] \
-      || { echo "ERROR: required extension '$ext' missing after contrib build (expected lib/postgresql/${ext}.so + share/postgresql/extension/${ext}.control)" >&2; exit 1; }
+    { [[ -f "$PREFIX/lib/postgresql/${ext}.so" || -f "$PREFIX/lib/postgresql/${ext}.dylib" ]] \
+      && [[ -f "$PREFIX/share/postgresql/extension/${ext}.control" ]]; } \
+      || { echo "ERROR: required extension '$ext' missing after contrib build (no lib/postgresql/${ext}.{so,dylib} or share/postgresql/extension/${ext}.control)" >&2; exit 1; }
   done
 
   # ---- macOS pack: design doc §3.4 ----
@@ -271,9 +280,12 @@ else
   rm -rf "$PREFIX/include"
 
   # ---- verify contrib extensions exist (recipe §3.2 step 13) ----
+  # Linux DLSUFFIX is .so; accept .dylib too for symmetry with the macOS
+  # path. This catches a *missing* contrib module, not the suffix.
   for ext in ltree tablefunc; do
-    [[ -f "$PREFIX/lib/postgresql/${ext}.so" && -f "$PREFIX/share/postgresql/extension/${ext}.control" ]] \
-      || { echo "ERROR: required extension '$ext' missing after contrib build (expected lib/postgresql/${ext}.so + share/postgresql/extension/${ext}.control)" >&2; exit 1; }
+    { [[ -f "$PREFIX/lib/postgresql/${ext}.so" || -f "$PREFIX/lib/postgresql/${ext}.dylib" ]] \
+      && [[ -f "$PREFIX/share/postgresql/extension/${ext}.control" ]]; } \
+      || { echo "ERROR: required extension '$ext' missing after contrib build (no lib/postgresql/${ext}.{so,dylib} or share/postgresql/extension/${ext}.control)" >&2; exit 1; }
   done
 
   ( cd "$PREFIX" && tar -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )

--- a/scripts/build-embedded-pg.sh
+++ b/scripts/build-embedded-pg.sh
@@ -113,11 +113,10 @@ if [[ "$OS" == "Darwin" ]]; then
   rm -rf "$PREFIX/include"
   # §3.2 step 12: keep only the binaries the shipped artifact ships. The
   # committed doc said "remove unneeded binaries" without enumerating them;
-  # the current shipped darwin-arm64 .txz was inspected and contains exactly
-  # these five (see output/exec3-oracle-parity-14x.md). Pruning to match
-  # keeps the from-source artifact structurally faithful to what Steampipe
-  # ships and uses (initdb / postgres / pg_ctl + pg_dump / pg_restore for the
-  # migration path).
+  # the current shipped darwin-arm64 .txz contains exactly these five.
+  # Pruning to match keeps the from-source artifact structurally faithful
+  # to what Steampipe ships and uses (initdb / postgres / pg_ctl for the
+  # service; pg_dump / pg_restore for the migration path).
   ( cd "$PREFIX/bin"
     for b in *; do
       case "$b" in
@@ -153,9 +152,10 @@ if [[ "$OS" == "Darwin" ]]; then
   # rewrite references (same pattern as libpq, extended to the 3-lib
   # chain): binary->icu = @rpath (bins already have the ../lib/postgresql
   # rpath); icu->icu = @loader_path (co-located in the same dir); each
-  # bundled lib id = @rpath. The pinned ICU major is whatever
-  # $ICU_PREFIX provides at build time (record it as a stability
-  # contract - see exec-4 B2.1a).
+  # bundled lib id = @rpath. The ICU major is pinned to whatever
+  # $ICU_PREFIX provides at build time and is a collation-stability
+  # contract: changing it can alter text sort order, so treat an ICU
+  # major bump as a deliberate, separately-tested change.
   if [[ "$PG_MAJOR" -ge 16 ]]; then
     (
       cd "$PREFIX"
@@ -163,8 +163,11 @@ if [[ "$OS" == "Darwin" ]]; then
       BUNDLE_ROOT="$(pwd)"
       echo "📦 Bundling ICU from $ICU_PREFIX"
       for stem in libicudata libicuuc libicui18n; do
-        src="$(ls "$ICU_PREFIX"/lib/${stem}.*.dylib 2>/dev/null | grep -E "/${stem}\.[0-9]+\.dylib$" | head -1)"
-        [[ -z "$src" ]] && src="$(ls "$ICU_PREFIX"/lib/${stem}.*.dylib 2>/dev/null | head -1)"
+        # `|| true`: under `set -o pipefail` a no-match from grep makes the
+        # whole substitution exit non-zero; on a bare assignment `set -e`
+        # would then abort here BEFORE the fallback/error below could run.
+        src="$(ls "$ICU_PREFIX"/lib/${stem}.*.dylib 2>/dev/null | grep -E "/${stem}\.[0-9]+\.dylib$" | head -1)" || true
+        [[ -z "$src" ]] && src="$(ls "$ICU_PREFIX"/lib/${stem}.*.dylib 2>/dev/null | head -1)" || true
         [[ -z "$src" ]] && { echo "ERROR: ICU lib $stem not found in $ICU_PREFIX/lib" >&2; exit 1; }
         cp -L "$src" "$BUNDLE_ROOT/$LIB_SUBDIR/$(basename "$src")"
         install_name_tool -id "@rpath/$(basename "$src")" "$BUNDLE_ROOT/$LIB_SUBDIR/$(basename "$src")"
@@ -209,6 +212,14 @@ if [[ "$OS" == "Darwin" ]]; then
     done
   )
 
+  # ---- verify contrib extensions exist (recipe §3.2 step 13) ----
+  # a broken `make -C contrib install` would otherwise ship an artifact
+  # silently missing ltree/tablefunc, which Steampipe loads.
+  for ext in ltree tablefunc; do
+    [[ -f "$PREFIX/lib/postgresql/${ext}.so" && -f "$PREFIX/share/postgresql/extension/${ext}.control" ]] \
+      || { echo "ERROR: required extension '$ext' missing after contrib build (expected lib/postgresql/${ext}.so + share/postgresql/extension/${ext}.control)" >&2; exit 1; }
+  done
+
   # ---- macOS pack: design doc §3.4 ----
   ( cd "$PREFIX" && tar --disable-copyfile --exclude='._*' -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
 
@@ -239,15 +250,17 @@ else
   # ELF resolves by soname via rpath, so bundling = drop the 3 ICU
   # .so.<major> into lib/postgresql (bins already have
   # $ORIGIN/../lib/postgresql rpath) and give the ICU libs an $ORIGIN
-  # rpath so icu->icu resolves within the bundle. NOTE: implemented but
-  # NOT locally proven (no Linux build host here; verify in the Linux
-  # CI runner per exec-4 B2).
+  # rpath so icu->icu resolves within the bundle. NOTE: this Linux path
+  # is implemented but has only been logic-reviewed, not run (built/
+  # proven on macOS only); verify it on a Linux build host/CI runner.
   PG_MAJOR_L="${PG_VERSION%%.*}"
   if [[ "$PG_MAJOR_L" -ge 16 ]]; then
     ICU_LIBDIR="$(pkg-config --variable=libdir icu-uc 2>/dev/null || echo /usr/lib/${ARCH}-linux-gnu)"
     for stem in libicudata libicuuc libicui18n; do
-      src="$(ls "$ICU_LIBDIR"/${stem}.so.* 2>/dev/null | grep -E "/${stem}\.so\.[0-9]+$" | head -1)"
-      [[ -z "$src" ]] && src="$(ls "$ICU_LIBDIR"/${stem}.so.* 2>/dev/null | head -1)"
+      # `|| true`: pipefail + bare assignment would abort under set -e on
+      # a grep no-match before the fallback/error below could run.
+      src="$(ls "$ICU_LIBDIR"/${stem}.so.* 2>/dev/null | grep -E "/${stem}\.so\.[0-9]+$" | head -1)" || true
+      [[ -z "$src" ]] && src="$(ls "$ICU_LIBDIR"/${stem}.so.* 2>/dev/null | head -1)" || true
       [[ -z "$src" ]] && { echo "ERROR: ICU lib $stem not found in $ICU_LIBDIR" >&2; exit 1; }
       cp -L "$src" "$PREFIX/lib/postgresql/$(basename "$src")"
       patchelf --set-rpath '$ORIGIN' "$PREFIX/lib/postgresql/$(basename "$src")" 2>/dev/null || true
@@ -256,6 +269,13 @@ else
   fi
 
   rm -rf "$PREFIX/include"
+
+  # ---- verify contrib extensions exist (recipe §3.2 step 13) ----
+  for ext in ltree tablefunc; do
+    [[ -f "$PREFIX/lib/postgresql/${ext}.so" && -f "$PREFIX/share/postgresql/extension/${ext}.control" ]] \
+      || { echo "ERROR: required extension '$ext' missing after contrib build (expected lib/postgresql/${ext}.so + share/postgresql/extension/${ext}.control)" >&2; exit 1; }
+  done
+
   ( cd "$PREFIX" && tar -cJf "$OUTPUT_DIR/$TARFILE" bin lib share )
 fi
 


### PR DESCRIPTION
## What

`scripts/build-embedded-pg.sh` — a new, version-parameterised wrapper around the committed `design/embedded_postgres_build_instructions.md` recipe (macOS + Linux), emitting the per-platform `.txz` under the name Steampipe expects. Plus corrections to the recipe doc.

- Builds PostgreSQL from source for a given version (default 14.19), prunes `bin/` to exactly the five Steampipe ships, fixes rpaths (dual `@loader_path`), and packs the `.txz`.
- **ICU support for PG16+**: PG18 `configure` hard-fails without ICU. Adds `--with-icu` + icu4c pkg-config for PG16+; PG14 path left byte-identical (no ICU flag).
- **ICU bundling (Option A, full unfiltered ICU)**: copies the three ICU libs into `lib/postgresql` and relocates references the same way `libpq` already is (binary→icu `@rpath`, icu→icu `@loader_path`). Linux mirror via `patchelf $ORIGIN`.
- **Mandatory Apple-Silicon re-sign**: `install_name_tool` invalidates the Mach-O signature and arm64 macOS then SIGKILLs the binary on load (no error output — easily misdiagnosed). The wrapper now `codesign --force --sign -`s every modified Mach-O. This also hardens the pre-existing libpq-only path; documented in the recipe (§3.3).

## Risk

**Zero for the shipped product.** Adds a new build script and edits a design doc. No product code, no constants, no workflow, no shipped artifact references it. Nothing in the running product is affected.

## Testing (darwin/arm64)

- PG14.19 built from source; structural/functional parity vs the current shipped artifact (same tree, extensions, `@rpath/libpq`, runs, `initdb` succeeds). Doc divergences found and corrected (bin-prune list, dual rpath).
- PG18.0 built; **proven relocatable**: with the build-machine Homebrew ICU moved aside, the wrapper's own output runs unaided (`postgres`/`initdb` → 18.0, real cluster init "Success"); a non-bundled control fails with `dyld: Library not loaded`. Zero absolute ICU refs; signatures valid.
- Linux ICU mirror is implemented but not locally proven (no Linux host) — verify in CI.

## Scope

Build tooling + docs only. No version flip, no image build/publish, no CI wiring changes here — those are handled separately.