### PR TITLE
Bump FdwVersion to 2.2.3 (FDW v2.2.3 security release)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ _Dependencies_
 - Bump `jackc/pgx/v5` from v5.7.6 to v5.9.2 to remediate CVE-2026-41889. ([#4990](https://github.com/turbot/steampipe/pull/4990))
 - Bump `go-jose/go-jose/v4` from v4.1.3 to v4.1.4 to remediate CVE-2026-34986.
 - Bump `go.opentelemetry.io/otel/sdk` from v1.40.0 to v1.43.0 to remediate CVE-2026-24051 and CVE-2026-39883.
+- Update embedded `steampipe-postgres-fdw` to `v2.2.3` (carries the pgx v5.9.2 / CVE-2026-41889 fix).
 
 ## v2.4.2 [2026-04-22]
 _Bug fixes_

--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -28,7 +28,7 @@ const (
 // constants for installing db and fdw images
 const (
 	DatabaseVersion = "14.19.0"
-	FdwVersion      = "2.2.2"
+	FdwVersion      = "2.2.3"
 
 	// PostgresImageRef is the OCI Image ref for the database binaries
 	PostgresImageRef    = "ghcr.io/turbot/steampipe/db:14.19.0"


### PR DESCRIPTION
## Summary

Points the embedded Steampipe FDW at the newly published **`steampipe-postgres-fdw` v2.2.3** security release. FDW v2.2.3 is now fully published — GitHub release plus the OCI image `ghcr.io/turbot/steampipe/fdw:2.2.3` is live — so Steampipe must consume the patched image.

This is a one-line constant change in `pkg/constants/db.go` (`FdwVersion` `2.2.2` → `2.2.3`). `FdwImageRef` is derived from `FdwVersion`, so the embedded FDW image ref automatically resolves to `ghcr.io/turbot/steampipe/fdw:2.2.3`.

## Why

FDW v2.2.3 carries the `jackc/pgx/v5` v5.9.2 fix for **CVE-2026-41889**. Steampipe's own `pgx` / `go-jose` / `otel` remediations for v2.4.3 already merged via #4995 (which also added the `## v2.4.3 [2026-05-19]` CHANGELOG entry). Pointing at the patched FDW image is the **last remaining prerequisite** before cutting the Steampipe v2.4.3 release.

## Changes

- `pkg/constants/db.go`: `FdwVersion = "2.2.2"` → `FdwVersion = "2.2.3"` (only this constant; `FdwImageRef` untouched, derives automatically).
- `CHANGELOG.md`: appended one bullet to the existing `## v2.4.3 [2026-05-19]` _Dependencies_ section (no new entry created).

## Verification

- `GOTOOLCHAIN=auto go build ./...` — clean (exit 0).

PR only. No merge, no tag, no release.
