### PR TITLE
Bump FdwVersion to 2.2.4 (statement_timeout fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v2.4.4 [2026-05-25]
+_Bug fixes_
+- Update embedded `steampipe-postgres-fdw` to `v2.2.4` — fixes `statement_timeout`, `pg_cancel_backend`, and `pg_terminate_backend` having no effect when a plugin's gRPC stream stalls. Affected sessions previously held `AccessShareLock` indefinitely, blocking partition swaps and other DDL until restart. ([steampipe-postgres-fdw#671](https://github.com/turbot/steampipe-postgres-fdw/issues/671))
+
 ## v2.4.3 [2026-05-19]
 _Dependencies_
 - Bump `jackc/pgx/v5` from v5.7.6 to v5.9.2 to remediate CVE-2026-41889. ([#4990](https://github.com/turbot/steampipe/pull/4990))

--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -28,7 +28,7 @@ const (
 // constants for installing db and fdw images
 const (
 	DatabaseVersion = "14.19.0"
-	FdwVersion      = "2.2.3"
+	FdwVersion      = "2.2.4"
 
 	// PostgresImageRef is the OCI Image ref for the database binaries
 	PostgresImageRef    = "ghcr.io/turbot/steampipe/db:14.19.0"


### PR DESCRIPTION
Release v2.4.4 — bumps embedded FDW to v2.2.4, which fixes `statement_timeout` / `pg_cancel_backend` / `pg_terminate_backend` having no effect when a plugin's gRPC stream stalls.

## Background
A customer's Powerpipe dashboard had recurring queries against an AWS GuardDuty table that hung indefinitely. The hung sessions held `AccessShareLock` on the foreign table, which blocked the customer's datatank partition swap from running. Partition data hadn't been updated since April 10, accumulating 10,019 orphaned `part_*` tables.

Root cause was in the FDW: when a plugin's gRPC `Recv()` stalls, the Postgres backend is stuck inside a cgo `IterateForeignScan` call. Postgres sets `QueryCancelPending` (from `statement_timeout` / `pg_cancel_backend` / `pg_terminate_backend`), but `CHECK_FOR_INTERRUPTS` never runs because control never returns from cgo. The session stays `active` forever and only a Postgres restart frees it.

FDW v2.2.4 ([steampipe-postgres-fdw#672](https://github.com/turbot/steampipe-postgres-fdw/pull/672)) adds a per-scan polling goroutine that reads `QueryCancelPending`/`ProcDiePending` every 250ms from a different OS thread and cancels the iterator's Go context. That unblocks the cgo call so Postgres can finally process the interrupt.

## Changes
- `pkg/constants/db.go`: `FdwVersion = "2.2.4"`
- `CHANGELOG.md`: v2.4.4 entry

## Verification
Reproduced the bug on stock FDW v2.2.3 and verified the fix locally end-to-end (see [FDW #673](https://github.com/turbot/steampipe-postgres-fdw/pull/673) for the repro evidence).
