### PR TITLE
Cherry-pick: Fix release workflow homebrew PR title check (#4983)

### DIFF
--- a/.github/workflows/01-steampipe-release.yaml
+++ b/.github/workflows/01-steampipe-release.yaml
@@ -253,7 +253,7 @@ jobs:
       - name: Fail if PR title does not match with version
         if: steps.semver_parser.outputs.prerelease == ''
         run: |
-          if [[ "${{ steps.pr_title.outputs.PR_TITLE }}" == "Steampipe ${{ env.VERSION }}" ]]; then
+          if [[ "${{ steps.pr_title.outputs.PR_TITLE }}" == "Steampipe ${{ github.event.inputs.version }}" ]]; then
             echo "Correct version"
           else
             echo "Incorrect version"


### PR DESCRIPTION
Cherry-picks #4983 onto v2.4.x — the fix was only on develop, so v2.4.4's release hit the same homebrew PR title check failure as v2.4.3. This brings the fix forward to the release branch so future v2.4.x releases don't trip on it.