### PR TITLE
Bump Go 1.26.1 → 1.26.4 to clear go-runtime CVEs

### DIFF
--- a/.github/workflows/01-steampipe-release.yaml
+++ b/.github/workflows/01-steampipe-release.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -32,7 +32,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.1'
+          go-version: '1.26.4'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: golangci-lint

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.1
+          go-version: 1.26.4
 
       - name: Prepare for downloads
         id: prepare-for-downloads

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe/v2
 
-go 1.26.1
+go 1.26.4
 
 replace (
 	github.com/c-bata/go-prompt => github.com/turbot/go-prompt v0.2.6-steampipe.0.0.20221028122246-eb118ec58d50


### PR DESCRIPTION
## Problem

The Steampipe binary and the bundled `steampipe_postgres_fdw.so` are compiled with **Go 1.26.1**. Turbot Pipes installs the Steampipe CLI into its `workspace` container image, where GCP Artifact Registry scanning flags the Go 1.26.1 runtime for standard-library CVEs, including:

- **CVE-2026-27143** (CRITICAL) — fixed in Go 1.26.2
- **CVE-2026-42504** — fixed in **Go 1.26.4**
- plus CVE-2026-33810/33811/33814/39820/39836/42499/42501

## Change

- `go.mod`: `go 1.26.1 → 1.26.4`
- CI `setup-go` pins → `1.26.4`: `01-steampipe-release.yaml` (release build), `11-test-acceptance.yaml` (×2), `10-test-lint.yaml`

The CI pin is what stamps the runtime into the released binaries, so both the directive and the pins are bumped (mirrors turbot/pipes#6738).

## Related

- steampipe-postgres-fdw#685 — same Go 1.26.4 bump for the FDW `.so`
- steampipe-postgres-fdw#684 + this repo's #5009 — Dependabot `containerd` 1.7.29 → 1.7.33 (clears the paired containerd CVEs)

## Downstream

Turbot Pipes' `workspace` image installs a released Steampipe CLI, so a release cut from this change (with the updated FDW) is required for the fix to reach the scanned image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)