### PR TITLE
Do not let one bad connection stop all connections from syncing

### DIFF
--- a/pkg/connection/connection_watcher.go
+++ b/pkg/connection/connection_watcher.go
@@ -75,8 +75,17 @@ func (w *ConnectionWatcher) handleFileWatcherEvent([]fsnotify.Event) {
 	if !errorsAndWarnings.Empty() {
 		w.pluginManager.SendPostgresErrorsAndWarningsNotification(ctx, errorsAndWarnings)
 		// if there was an error return
+		//
+		// NOTE: this aborts the refresh for EVERY connection, not just the one
+		// the config error relates to, and it will keep doing so on every
+		// subsequent file event for as long as the config folder fails to
+		// parse - so connections silently stop being created and credential
+		// updates stop being applied while the watcher itself keeps running.
+		// Log at ERROR level so this is visible at default log levels: it
+		// names the file to fix, and it is the only signal that syncing has
+		// stopped.
 		if errorsAndWarnings.GetError() != nil {
-			log.Printf("[WARN] error loading updated connection config: %v", errorsAndWarnings.GetError())
+			log.Printf("[ERROR] error loading updated connection config - NO connections will be refreshed until this is resolved: %v", errorsAndWarnings.GetError())
 			return
 		}
 	}

--- a/pkg/steampipeconfig/load_config.go
+++ b/pkg/steampipeconfig/load_config.go
@@ -288,12 +288,29 @@ func loadConfig(ctx context.Context, configFolder string, steampipeConfig *Steam
 			if moreDiags.HasErrors() {
 				continue
 			}
+			// NOTE: a problem with a SINGLE connection must not fail the whole
+			// config load. LoadConnectionConfig re-parses the entire config
+			// folder, and the connection watcher aborts the refresh when it
+			// returns an error - so failing here for one bad connection stops
+			// ALL connections from being synced (no schemas created, no
+			// credential updates applied) for as long as the offending block
+			// exists, while the file watcher itself keeps running. Skip the
+			// offending connection with a warning and keep the rest usable.
 			if existingConnection, alreadyThere := steampipeConfig.Connections[connection.Name]; alreadyThere {
-				err := getDuplicateConnectionError(existingConnection, connection)
-				return perror_helpers.NewErrorsAndWarning(err)
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  getDuplicateConnectionError(existingConnection, connection).Error(),
+					Subject:  hclhelpers.BlockRangePointer(block),
+				})
+				continue
 			}
 			if ok, errorMessage := db_common.IsSchemaNameValid(connection.Name); !ok {
-				return perror_helpers.NewErrorsAndWarning(sperr.New("invalid connection name: '%s' in '%s'. %s ", connection.Name, block.TypeRange.Filename, errorMessage))
+				diags = append(diags, &hcl.Diagnostic{
+					Severity: hcl.DiagWarning,
+					Summary:  fmt.Sprintf("invalid connection name: '%s' in '%s'. %s ", connection.Name, block.TypeRange.Filename, errorMessage),
+					Subject:  hclhelpers.BlockRangePointer(block),
+				})
+				continue
 			}
 			steampipeConfig.Connections[connection.Name] = connection
 

--- a/pkg/steampipeconfig/load_config_resilience_test.go
+++ b/pkg/steampipeconfig/load_config_resilience_test.go
@@ -1,0 +1,91 @@
+package steampipeconfig
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/turbot/pipe-fittings/v2/app_specific"
+)
+
+// setInstallDir points the app at a scratch install dir; several filepath
+// helpers panic if it is unset.
+func setInstallDir(t *testing.T) {
+	t.Helper()
+	prev := app_specific.InstallDir
+	app_specific.InstallDir = t.TempDir()
+	t.Cleanup(func() { app_specific.InstallDir = prev })
+}
+
+// writeConfigFile writes a .spc file into dir.
+func writeConfigFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0600); err != nil {
+		t.Fatalf("failed to write %s: %v", name, err)
+	}
+}
+
+func connectionConfig(name string) string {
+	return `
+connection "` + name + `" {
+  plugin = "chaos"
+}
+`
+}
+
+// TestLoadConfig_DuplicateConnectionDoesNotFailWholeLoad asserts that a single
+// duplicate connection name is reported as a warning and skipped, while every
+// other connection still loads.
+//
+// This matters because loadConfig re-parses the WHOLE config folder and the
+// connection watcher aborts the refresh when it returns an error: failing the
+// entire load for one bad block stops all connections from being synced (no
+// schemas created, no connection config updates applied) for as long as the
+// offending block exists, while the file watcher keeps running.
+func TestLoadConfig_DuplicateConnectionDoesNotFailWholeLoad(t *testing.T) {
+	setInstallDir(t)
+	dir := t.TempDir()
+	writeConfigFile(t, dir, "a.spc", connectionConfig("conn_a"))
+	writeConfigFile(t, dir, "b.spc", connectionConfig("conn_b"))
+	// duplicates conn_a, declared in a second file
+	writeConfigFile(t, dir, "c.spc", connectionConfig("conn_a"))
+
+	config := NewSteampipeConfig("")
+	res := loadConfig(context.TODO(), dir, config, &loadConfigOptions{include: []string{"*.spc"}})
+
+	if err := res.GetError(); err != nil {
+		t.Fatalf("a duplicate connection must not fail the whole config load, got error: %v", err)
+	}
+	if len(res.Warnings) == 0 {
+		t.Error("expected a warning describing the duplicate connection")
+	}
+	for _, name := range []string{"conn_a", "conn_b"} {
+		if _, ok := config.Connections[name]; !ok {
+			t.Errorf("connection %q should still have loaded despite the duplicate", name)
+		}
+	}
+}
+
+// TestLoadConfig_InvalidConnectionNameDoesNotFailWholeLoad asserts the same
+// contract for a connection whose name is not a valid schema name.
+func TestLoadConfig_InvalidConnectionNameDoesNotFailWholeLoad(t *testing.T) {
+	setInstallDir(t)
+	dir := t.TempDir()
+	writeConfigFile(t, dir, "good.spc", connectionConfig("conn_good"))
+	// "pg_catalog" is reserved, so this connection name is invalid
+	writeConfigFile(t, dir, "bad.spc", connectionConfig("pg_catalog"))
+
+	config := NewSteampipeConfig("")
+	res := loadConfig(context.TODO(), dir, config, &loadConfigOptions{include: []string{"*.spc"}})
+
+	if err := res.GetError(); err != nil {
+		t.Fatalf("an invalid connection name must not fail the whole config load, got error: %v", err)
+	}
+	if _, ok := config.Connections["conn_good"]; !ok {
+		t.Error("the valid connection should still have loaded")
+	}
+	if _, ok := config.Connections["pg_catalog"]; ok {
+		t.Error("the invalid connection must be skipped")
+	}
+}


### PR DESCRIPTION
Closes #5020

## Problem

`loadConfig` fails the entire config load when a single connection block has a duplicate name or an invalid schema name. Since `LoadConnectionConfig` re-parses the whole config folder and `ConnectionWatcher.handleFileWatcherEvent` returns early on a load error, one bad block stops `RefreshConnections` from running **at all** — for every connection, on every subsequent file event, for as long as that block exists.

The result is a silent, permanent halt to connection syncing while the file watcher keeps running: connections written afterwards never get a schema or a `steampipe_connection_state` row, and updated credentials in rewritten config files are never applied. Existing connections keep serving queries so the service looks healthy, and the only log line is a `[WARN]` that is invisible at default log levels. Full detail in #5020.

## Changes

- **`pkg/steampipeconfig/load_config.go`** — a duplicate connection name or an invalid connection name now appends a warning diagnostic and skips that connection, instead of returning an error for the whole load. The remaining connections load and continue to sync.
- **`pkg/connection/connection_watcher.go`** — log a config-load failure at `ERROR` rather than `WARN`, and state the consequence in the message. This line names the file to fix and is the only signal that syncing has stopped, so it should be visible at default log levels.
- **`pkg/steampipeconfig/load_config_resilience_test.go`** — regression tests for both cases: the whole load must succeed, the good connections must be present, the bad one must be skipped, and a warning must be reported. Both tests fail without the fix and pass with it.

## Notes

- Behaviour for other config errors (malformed HCL, bad plugin blocks) is unchanged; this narrowly targets per-connection problems that today take down the entire config.
- The duplicate case keeps the **first** declaration and skips the later one, which matches the existing error message's framing of "existing" vs "new".
- `go build ./...` and `go vet ./pkg/steampipeconfig/` pass.