### PR TITLE
Bump Go toolchain to 1.26.7 to remediate CVE-2026-39821 (GO-2026-5026)

### DIFF
--- a/.github/workflows/01-steampipe-release.yaml
+++ b/.github/workflows/01-steampipe-release.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -32,7 +32,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: golangci-lint

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -132,7 +132,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Prepare for downloads
         id: prepare-for-downloads

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe/v2
 
-go 1.26.5
+go 1.26.7
 
 replace (
 	github.com/c-bata/go-prompt => github.com/turbot/go-prompt v0.2.6-steampipe.0.0.20221028122246-eb118ec58d50


### PR DESCRIPTION
## What

Bump the Go toolchain from **1.26.5 to 1.26.7** — the `go` directive in `go.mod` plus all four `go-version:` pins in `.github/workflows/`. Nothing else changes: no dependency bumps, no code changes, no other workflow inputs.

```
go.mod                                        go 1.26.5  -> go 1.26.7
.github/workflows/01-steampipe-release.yaml   go-version: 1.26.5   -> 1.26.7   (line 117)
.github/workflows/10-test-lint.yaml           go-version: '1.26.5' -> '1.26.7' (line 35)
.github/workflows/11-test-acceptance.yaml     go-version: 1.26.5   -> 1.26.7   (lines 35, 135)
```

I grepped the whole `.github/` tree to confirm those four are the only Go version pins — a missed CI pin is exactly how this kind of fix silently fails to take effect. Each file's existing quoting style is preserved.

## Why: CVE-2026-39821 / GO-2026-5026 (CVSS 9.6)

`golang.org/x/net/idna`'s `ToASCII`/`ToUnicode` wrongly accept Punycode-encoded labels that decode to an ASCII-only label — `ToUnicode("xn--example-.com")` returns `"example.com"` instead of an error. A caller that allowlists on the ASCII hostname can therefore be bypassed by submitting the encoded spelling.

**Why a toolchain bump is the fix, and the only fix.** There are two copies of this code. Our direct `golang.org/x/net` dependency is already `v0.56.0`, well past the fixed `v0.55.0` — that copy is fine and this PR deliberately does not touch it. The copy that actually matters is the one **vendored into the Go standard library** and reachable through `net/http`. It carries the stdlib's version, not the module's, so no amount of dependency bumping reaches it. Upstream fixed it in Go 1.26.6, 1.25.13, and 1.27.0-rc.3.

Targeting **1.26.7** (latest 1.26.x: the 1.26.6 security content plus subsequent `net/http` bugfixes). Deliberately *not* 1.27.x — that is a language-version change, not a patch.

## Verification

Installed Go on the build machine is `go1.26.1`. Inside the module `go version` reports `go1.26.7 darwin/arm64` because `GOTOOLCHAIN` defaults to `auto` and re-execs a newer toolchain to satisfy the bumped `go` directive — so the binaries below genuinely were compiled by 1.26.7, but via toolchain resolution rather than a natively installed 1.26.7.

**Confirmed passing:**
- `go build ./...` — exit 0, clean.
- Release binary builds; `go version -m` stamps `go1.26.7` and `golang.org/x/net v0.56.0`.
- `govulncheck -mode=binary` on binaries built both ways:

| | go1.26.5 (before) | go1.26.7 (after) |
|---|---|---|
| GO-2026-5026 | **CALLED** — 16 reachable symbols via `http.Client.Do` / `.Get` / `.Post` | **absent** |
| Total called vulns | 11 | 4 |
| Stdlib called vulns | 7 | **0** |

govulncheck on the 1.26.5 build reports it precisely as described above:

```
Vulnerability #11: GO-2026-5026
    Invoking failure to reject ASCII-only Punycode-encoded labels in golang.org/x/net/idna
  Standard library
    Found in: net/http@go1.26.5
    Fixed in: net/http@go1.26.6
```

The bump clears 7 stdlib findings in total — GO-2026-5026 plus GO-2026-5942, -5972, -6088, -6090, -6091, -6218 — and introduces **no** new findings. The 4 that remain are all module-level (`containerd` x3, `otel`) and are out of scope for a toolchain change.

**Not verified — stated plainly so nobody assumes otherwise:**
- `go vet ./...` reports 3 findings (context leak in `pkg/db/db_client/db_client_execute.go:175`, lock copy in `pkg/db/db_local/local_db_client.go:85`, non-deferred `time.Since` in `pkg/connection/refresh_connections.go:31`). I confirmed these are **pre-existing** by stashing my change and re-running vet on unmodified `develop` — byte-identical output. Not introduced here, and not fixed here.
- I did not run the acceptance suite locally; CI covers it.

## Downstream impact: Turbot Pipes workspace image

Turbot Pipes bundles Steampipe, Powerpipe, and `steampipe-postgres-fdw` into its `workspace` container image, where they are currently the **only remaining CRITICAL findings**. Verified 2026-08-31 by extracting the binaries from the built image `workspace@sha256:7f5ab7a3f39a` (v1.22.46-rc.1) and running `go version -m`:

```
.../postgres/lib/postgresql/steampipe_postgres_fdw.so   go1.26.5   x/net v0.54.0   <- 2 hits
/usr/local/bin/steampipe   (Steampipe v2.4.5)           go1.26.5   x/net v0.54.0   <- 2 hits   <- this repo
/usr/local/bin/powerpipe   (Powerpipe v1.5.3)           go1.26.5                   <- 1 hit
/opt/steampipe/steampipe-server (Pipes' own binary)     go1.26.7   x/net v0.56.0   <- CLEAN
```

Pipes already fixed its own binary the same way (turbot/pipes#6801, 1.26.5 -> 1.26.7) and `govulncheck -mode=binary` confirmed GO-2026-5026 went from CALLED to absent there. Pipes cannot fix the other three itself — the CLIs are installed from their release install scripts at image-build time.

Worth stating clearly: the released artifacts (steampipe v2.4.5, powerpipe v1.5.3, fdw v2.2.5, all 2026-08-10) were built with go1.26.5 and shipped **three days before go1.26.6 existed**. This is a timing gap, not neglect.

## Sequencing — this PR alone does not clear the workspace image

Three things have to land, and merging this is only the first:

1. **This PR** — merge, then cut a Steampipe release built on 1.26.7.
2. **`steampipe-postgres-fdw`** — needs the same bump and its own release. Tracked in turbot/steampipe-postgres-fdw#695 (open since 2026-08-20, no replies); a companion PR is going up.
3. **`powerpipe`** — same bump and release; companion PR going up.

Note the FDW coupling: the bundled FDW version is chosen by *this* repo's compiled-in constant, `FdwVersion` in `pkg/constants/db.go`, **currently `"2.2.5"`** -> `ghcr.io/turbot/steampipe/fdw:2.2.5`. I have deliberately **not** touched it here. Bumping it is a separate follow-up that can only happen after the fdw repo cuts a release built on 1.26.7 — pointing the constant at a tag that does not exist yet would break the build. So the ordering is: fdw releases first, then a small follow-up PR here moves `FdwVersion`, then Pipes rebuilds the workspace image.

I also did not add a CHANGELOG entry — this repo's convention is to write those at release time (see the `v2.4.5` block, which documents the previous Go bump), and the release that carries this bump doesn't exist yet.

Do not merge without a maintainer's review of the release sequencing above.

