### PR TITLE
Backport: Bump Go toolchain to 1.26.7 to remediate CVE-2026-39821 (GO-2026-5026)

### DIFF
--- a/.github/workflows/01-steampipe-release.yaml
+++ b/.github/workflows/01-steampipe-release.yaml
@@ -114,7 +114,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Install GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0

--- a/.github/workflows/10-test-lint.yaml
+++ b/.github/workflows/10-test-lint.yaml
@@ -32,7 +32,7 @@ jobs:
       # this is required, check golangci-lint-action docs
       - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5.4.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.7'
           cache: false # setup-go v4 caches by default, do not change this parameter, check golangci-lint-action doc: https://github.com/golangci/golangci-lint-action/pull/704
 
       - name: golangci-lint

--- a/.github/workflows/11-test-acceptance.yaml
+++ b/.github/workflows/11-test-acceptance.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Fetching Go Cache Paths
         id: go-cache-paths
@@ -130,7 +130,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00 # v6.0.0
         with:
-          go-version: 1.26.5
+          go-version: 1.26.7
 
       - name: Prepare for downloads
         id: prepare-for-downloads

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/turbot/steampipe/v2
 
-go 1.26.5
+go 1.26.7
 
 replace (
 	github.com/c-bata/go-prompt => github.com/turbot/go-prompt v0.2.6-steampipe.0.0.20221028122246-eb118ec58d50


### PR DESCRIPTION
Cherry-pick of 6bb2469 (#5031, merged to develop) onto v2.4.x so the fix ships in the next Steampipe patch release. Clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
