### PR TITLE
Bump FDW version to v2.2.6

### DIFF
--- a/pkg/constants/db.go
+++ b/pkg/constants/db.go
@@ -28,7 +28,7 @@ const (
 // constants for installing db and fdw images
 const (
 	DatabaseVersion = "14.19.0"
-	FdwVersion      = "2.2.5"
+	FdwVersion      = "2.2.6"
 
 	// PostgresImageRef is the OCI Image ref for the database binaries
 	PostgresImageRef    = "ghcr.io/turbot/steampipe/db:14.19.0"


### PR DESCRIPTION
FDW v2.2.6 (Go 1.26.7, CVE-2026-39821) is published. Point v2.4.x at it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
